### PR TITLE
reset session id when launching to runtime

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/invoke.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/invoke.py
@@ -9,7 +9,7 @@ from bedrock_agentcore.services.identity import IdentityClient
 
 from ...services.runtime import BedrockAgentCoreClient, generate_session_id
 from ...utils.runtime.config import load_config, save_config
-from ...utils.runtime.schema import BedrockAgentCoreConfigSchema
+from ...utils.runtime.schema import BedrockAgentCoreAgentSchema, BedrockAgentCoreConfigSchema
 from .models import InvokeResult
 
 log = logging.getLogger(__name__)
@@ -37,15 +37,7 @@ def invoke_bedrock_agentcore(
         raise ValueError("Region not configured.")
 
     agent_arn = agent_config.bedrock_agentcore.agent_arn
-
-    # Handle session ID
-    if not session_id:
-        session_id = agent_config.bedrock_agentcore.agent_session_id
-        if not session_id:
-            session_id = generate_session_id()
-
-    # Save session ID for reuse
-    agent_config.bedrock_agentcore.agent_session_id = session_id
+    session_id = _handle_session_id(agent_config, local_mode, session_id)
 
     # Update project config and save
     project_config.agents[agent_config.name] = agent_config
@@ -127,3 +119,23 @@ def _get_workload_name(
     save_config(project_config, project_config_path)
 
     return workload_name
+
+
+def _handle_session_id(
+    agent_config: BedrockAgentCoreAgentSchema, local: Optional[bool], session_id: Optional[str]
+) -> str:
+    if not session_id:
+        if local:
+            session_id = agent_config.bedrock_agentcore.local_session_id
+        else:
+            session_id = agent_config.bedrock_agentcore.agent_session_id
+
+        if not session_id:
+            session_id = generate_session_id()
+
+    if local:
+        agent_config.bedrock_agentcore.local_session_id = session_id
+    else:
+        agent_config.bedrock_agentcore.agent_session_id = session_id
+
+    return session_id

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -149,18 +149,17 @@ def launch_bedrock_agentcore(
     if not local:
         existing_session_id = None
         if agent_config.bedrock_agentcore.agent_session_id:
-            # existing session ID exists in runtime
+            # session ID exists in runtime
             existing_session_id = agent_config.bedrock_agentcore.agent_session_id
             agent_config.bedrock_agentcore.agent_session_id = None
         if existing_session_id:
-            if agent_config.bedrock_agentcore.agent_arn:
-                log.info("------------------------------------------------------------")
-                log.info(
-                    "Session ID will be reset to connect to the updated agent. "
-                    "The previous agent remains accessible via the original session ID: %s",
-                    existing_session_id,
-                )
-                log.info("------------------------------------------------------------")
+            log.info("------------------------------------------------------------")
+            log.info(
+                "Session ID will be reset to connect to the updated agent. "
+                "The previous agent remains accessible via the original session ID: %s",
+                existing_session_id,
+            )
+            log.info("------------------------------------------------------------")
 
     save_config(project_config, config_path)
 

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -144,6 +144,24 @@ def launch_bedrock_agentcore(
 
     # Update the project config and save
     project_config.agents[agent_config.name] = agent_config
+
+    # reset session id when deploying to cloud
+    if not local:
+        existing_session_id = None
+        if agent_config.bedrock_agentcore.agent_session_id:
+            # existing session ID exists in runtime
+            existing_session_id = agent_config.bedrock_agentcore.agent_session_id
+            agent_config.bedrock_agentcore.agent_session_id = None
+        if existing_session_id:
+            if agent_config.bedrock_agentcore.agent_arn:
+                log.info("------------------------------------------------------------")
+                log.info(
+                    "Session ID will be reset to connect to the updated agent. "
+                    "The previous agent remains accessible via the original session ID: %s",
+                    existing_session_id,
+                )
+                log.info("------------------------------------------------------------")
+
     save_config(project_config, config_path)
 
     log.info("Agent created/updated: %s", agent_arn)

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
@@ -58,7 +58,8 @@ class BedrockAgentCoreDeploymentInfo(BaseModel):
 
     agent_id: Optional[str] = Field(default=None, description="BedrockAgentCore agent ID")
     agent_arn: Optional[str] = Field(default=None, description="BedrockAgentCore agent ARN")
-    agent_session_id: Optional[str] = Field(default=None, description="Session ID for invocations")
+    agent_session_id: Optional[str] = Field(default=None, description="Session ID for invocations in runtime")
+    local_session_id: Optional[str] = Field(default=None, description="Session ID for invocations in local mode")
 
 
 class BedrockAgentCoreAgentSchema(BaseModel):

--- a/tests/operations/runtime/test_invoke.py
+++ b/tests/operations/runtime/test_invoke.py
@@ -419,8 +419,98 @@ class TestInvokeBedrockAgentCore:
             updated_agent = updated_config.get_agent_config("test-agent")
             assert updated_agent.oauth_configuration == {"workload_name": "auto-created-workload-123"}
 
-            # Verify result
-            assert result.response == {"response": "workload creation test"}
+        # Verify result
+        assert result.response == {"response": "workload creation test"}
+
+
+class TestHandleSessionId:
+    """Test _handle_session_id functionality."""
+
+    def test_handle_session_id_with_provided_session_id(self):
+        """Test _handle_session_id when session_id is provided."""
+        from bedrock_agentcore_starter_toolkit.operations.runtime.invoke import _handle_session_id
+
+        # Create agent config
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test.py",
+            aws=AWSConfig(
+                region="us-west-2", network_configuration=NetworkConfiguration(), observability=ObservabilityConfig()
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+
+        provided_session_id = "custom-session-123"
+
+        # Test with local=False
+        result = _handle_session_id(agent_config, local=False, session_id=provided_session_id)
+
+        assert result == provided_session_id
+        assert agent_config.bedrock_agentcore.agent_session_id == provided_session_id
+
+        # Test with local=True
+        result = _handle_session_id(agent_config, local=True, session_id=provided_session_id)
+
+        assert result == provided_session_id
+        assert agent_config.bedrock_agentcore.local_session_id == provided_session_id
+
+    def test_handle_session_id_without_provided_session_id(self):
+        """Test _handle_session_id when session_id is None."""
+        from bedrock_agentcore_starter_toolkit.operations.runtime.invoke import _handle_session_id
+
+        # Create agent config with existing local_session_id
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test.py",
+            aws=AWSConfig(
+                region="us-west-2", network_configuration=NetworkConfiguration(), observability=ObservabilityConfig()
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(
+                agent_session_id="existing-agent-session", local_session_id="existing-local-session"
+            ),
+        )
+
+        result = _handle_session_id(agent_config, local=True, session_id=None)
+        assert result == "existing-local-session"
+        assert agent_config.bedrock_agentcore.local_session_id == "existing-local-session"
+
+        result = _handle_session_id(agent_config, local=False, session_id=None)
+        assert result == "existing-agent-session"
+        assert agent_config.bedrock_agentcore.agent_session_id == "existing-agent-session"
+
+    def test_handle_session_id_overwrite(self):
+        """Test _handle_session_id overwrites existing session_id when new one is provided."""
+        from bedrock_agentcore_starter_toolkit.operations.runtime.invoke import _handle_session_id
+
+        # Create agent config with existing session IDs
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test.py",
+            aws=AWSConfig(
+                region="us-west-2", network_configuration=NetworkConfiguration(), observability=ObservabilityConfig()
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(
+                agent_session_id="old-agent-session", local_session_id="old-local-session"
+            ),
+        )
+
+        new_session_id = "new-session-override"
+
+        # Test overwriting agent session ID
+        result = _handle_session_id(agent_config, local=False, session_id=new_session_id)
+
+        assert result == new_session_id
+        assert agent_config.bedrock_agentcore.agent_session_id == new_session_id
+        # Local session should remain unchanged
+        assert agent_config.bedrock_agentcore.local_session_id == "old-local-session"
+
+        # Test overwriting local session ID
+        result = _handle_session_id(agent_config, local=True, session_id=new_session_id)
+
+        assert result == new_session_id
+        assert agent_config.bedrock_agentcore.local_session_id == new_session_id
+        # Agent session should remain the new value from previous test
+        assert agent_config.bedrock_agentcore.agent_session_id == new_session_id
 
 
 class TestGetWorkloadName:

--- a/tests/operations/runtime/test_launch.py
+++ b/tests/operations/runtime/test_launch.py
@@ -273,3 +273,109 @@ class TestLaunchBedrockAgentCore:
         ):
             with pytest.raises(ValueError, match="ECR repository not configured"):
                 launch_bedrock_agentcore(config_path, local=False)
+
+    def test_launch_cloud_with_existing_session_id(self, mock_boto3_clients, mock_container_runtime, tmp_path, caplog):
+        """Test cloud deployment with existing session ID - should reset session ID and log message."""
+        import logging
+
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+
+        # Create config file with existing session ID
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        existing_session_id = "existing-session-12345"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role="arn:aws:iam::123456789012:role/TestRole",
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(
+                agent_id="existing-agent-id",
+                agent_session_id=existing_session_id,  # Set existing session ID
+            ),
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Mock the build to return success
+        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+                return_value=mock_container_runtime,
+            ),
+            caplog.at_level(logging.INFO),
+        ):
+            launch_bedrock_agentcore(config_path, local=False)
+
+            # Verify that the log message about session ID reset was generated
+            session_reset_logs = [record for record in caplog.records if existing_session_id in record.message]
+            assert len(session_reset_logs) == 1
+            assert "Session ID will be reset to connect to the updated agent." in session_reset_logs[0].message
+
+            # Verify that the session ID was reset to None in the saved config
+            updated_config = load_config(config_path)
+            updated_agent_config = updated_config.get_agent_config("test-agent")
+            assert updated_agent_config.bedrock_agentcore.agent_session_id is None
+
+    def test_launch_local_with_existing_session_id(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test local deployment with existing session ID - should not reset session ID."""
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+
+        # Create config file with existing session ID
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        existing_runtime_session_id = "existing-runtime-session-12345"
+        existing_local_session_id = "existing-local-session-67890"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role="arn:aws:iam::123456789012:role/TestRole",
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(
+                agent_id="existing-agent-id",
+                agent_session_id=existing_runtime_session_id,
+                local_session_id=existing_local_session_id,
+            ),
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Mock the build to return success
+        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+                return_value=mock_container_runtime,
+            ),
+        ):
+            launch_bedrock_agentcore(config_path, local=True)
+
+            # Verify that the session ID was not reset to None in the saved config
+            agent_config = load_config(config_path).get_agent_config("test-agent")
+            assert agent_config.bedrock_agentcore.agent_session_id == existing_runtime_session_id
+            assert agent_config.bedrock_agentcore.local_session_id == existing_local_session_id


### PR DESCRIPTION
## Description

https://github.com/aws/bedrock-agentcore-starter-toolkit/issues/38

Brief description of changes
- split session id into local and cloud
- reset cloud session id when deploying to runtime
- log message to user when resetting

## Testing
- tested locally