### PR TITLE
feat(runtime): Add auto-creation of execution role with detailed logging

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -1,22 +1,15 @@
 """BedrockAgentCore CLI main module."""
 
-import logging
-
 import typer
-from rich.logging import RichHandler
 
 from ..cli.gateway.commands import create_mcp_gateway, create_mcp_gateway_target, gateway_app
-from .common import console
+from ..utils.logging_config import setup_toolkit_logging
 from .runtime.commands import configure_app, invoke, launch, status
 
 app = typer.Typer(name="agentcore", help="BedrockAgentCore CLI", add_completion=False)
 
-FORMAT = "%(message)s"
-logging.basicConfig(
-    level="INFO",
-    format=FORMAT,
-    handlers=[RichHandler(show_time=False, show_path=False, show_level=False, console=console)],
-)
+# Setup centralized logging for CLI
+setup_toolkit_logging(mode="cli")
 
 # runtime
 app.command("invoke")(invoke)

--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -265,6 +265,9 @@ def launch(
     local: bool = typer.Option(False, "--local", "-l", help="Run locally"),
     push_ecr: bool = typer.Option(False, "--push-ecr", "-p", help="Build and push to ECR only (no deployment)"),
     codebuild: bool = typer.Option(False, "--codebuild", "-cb", help="Use CodeBuild for ARM64 builds"),
+    auto_update_on_conflict: bool = typer.Option(
+        False, "--auto-update-on-conflict", help="Enable automatic update when agent already exists"
+    ),
     envs: List[str] = typer.Option(  # noqa: B008
         None, "--env", "-env", help="Environment variables for agent (format: KEY=VALUE)"
     ),
@@ -309,6 +312,7 @@ def launch(
                 push_ecr_only=push_ecr,
                 use_codebuild=codebuild,
                 env_vars=env_vars,
+                auto_update_on_conflict=auto_update_on_conflict,
             )
 
         # Handle result based on mode
@@ -531,8 +535,6 @@ def status(
     try:
         if not verbose:
             if "config" in status_json:
-                print(f"Getting Status for {status_json['config']['name']}")
-
                 if status_json["agent"] is None:
                     console.print(
                         Panel(

--- a/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
+++ b/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
@@ -12,15 +12,12 @@ from ...operations.runtime import (
     validate_agent_name,
 )
 from ...operations.runtime.models import ConfigureResult, LaunchResult, StatusResult
+
+# Setup centralized logging for SDK usage (notebooks, scripts, imports)
+from ...utils.logging_config import setup_toolkit_logging
 from ...utils.runtime.entrypoint import parse_entrypoint
 
-# Configure logger for ALL toolkit modules (ensures all operation logs appear)
-toolkit_logger = logging.getLogger("bedrock_agentcore_starter_toolkit")
-if not toolkit_logger.handlers:
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    toolkit_logger.addHandler(handler)
-    toolkit_logger.setLevel(logging.INFO)
+setup_toolkit_logging(mode="sdk")
 
 # Configure logger for this module
 log = logging.getLogger(__name__)

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/create_role.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/create_role.py
@@ -1,5 +1,6 @@
 """Creates an execution role to use in the Bedrock AgentCore Runtime module."""
 
+import hashlib
 import json
 import logging
 from typing import Optional
@@ -15,7 +16,25 @@ from ...utils.runtime.policy_template import (
 )
 
 
-def create_runtime_execution_role(
+def _generate_deterministic_suffix(agent_name: str, length: int = 10) -> str:
+    """Generate a deterministic suffix for role names based on agent name.
+
+    Args:
+        agent_name: Name of the agent
+        length: Length of the suffix (default: 10)
+
+    Returns:
+        Deterministic alphanumeric string in lowercase
+    """
+    # Create deterministic hash from agent name
+    hash_object = hashlib.sha256(agent_name.encode())
+    hex_hash = hash_object.hexdigest()
+
+    # Take first N characters for AWS resource names
+    return hex_hash[:length].lower()
+
+
+def get_or_create_runtime_execution_role(
     session: Session,
     logger: logging.Logger,
     region: str,
@@ -23,7 +42,7 @@ def create_runtime_execution_role(
     agent_name: str,
     role_name: Optional[str] = None,
 ) -> str:
-    """Create the Runtime execution role.
+    """Get existing execution role or create a new one (idempotent).
 
     Args:
         session: Boto3 session
@@ -40,58 +59,155 @@ def create_runtime_execution_role(
         RuntimeError: If role creation fails
     """
     if not role_name:
-        role_name = f"BedrockAgentCoreRuntimeExecutionRole-{agent_name}"
+        # Generate deterministic role name based on agent name
+        # This ensures the same agent always gets the same role name
+        deterministic_suffix = _generate_deterministic_suffix(agent_name)
+        role_name = f"AmazonBedrockAgentCoreSDKRuntime-{region}-{deterministic_suffix}"
 
-    logger.info("Starting execution role creation process for agent: %s", agent_name)
+    logger.info("Getting or creating execution role for agent: %s", agent_name)
     logger.info("Using AWS region: %s, account ID: %s", region, account_id)
-    logger.info("Role name will be: %s", role_name)
+    logger.info("Role name: %s", role_name)
 
     iam = session.client("iam")
 
     try:
-        # Render the trust policy template
-        logger.debug("Rendering trust policy template...")
-        trust_policy_json = render_trust_policy_template(region, account_id)
-        trust_policy = validate_rendered_policy(trust_policy_json)
-        logger.debug("Trust policy validated successfully")
+        # Step 1: Check if role already exists
+        logger.debug("Checking if role exists: %s", role_name)
+        role = iam.get_role(RoleName=role_name)
+        existing_role_arn = role["Role"]["Arn"]
 
-        # Render the execution policy template
-        logger.debug("Rendering execution policy template...")
-        execution_policy_json = render_execution_policy_template(region, account_id, agent_name)
-        execution_policy = validate_rendered_policy(execution_policy_json)
-        logger.debug("Execution policy validated successfully")
+        logger.info("✅ Reusing existing execution role: %s", existing_role_arn)
+        logger.debug("Role creation date: %s", role["Role"].get("CreateDate", "Unknown"))
 
+        # TODO: In future, we could add validation here to ensure the role has correct policies
+        # For now, we trust that if the role exists with our naming pattern, it's compatible
+
+        return existing_role_arn
+
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchEntity":
+            # Step 2: Role doesn't exist, create it
+            logger.info("Role doesn't exist, creating new execution role: %s", role_name)
+
+            # Inline role creation logic (previously in create_runtime_execution_role)
+            logger.info("Starting execution role creation process for agent: %s", agent_name)
+            logger.info("✓ Role creating: %s", role_name)
+
+            try:
+                # Render the trust policy template
+                trust_policy_json = render_trust_policy_template(region, account_id)
+                trust_policy = validate_rendered_policy(trust_policy_json)
+
+                # Render the execution policy template
+                execution_policy_json = render_execution_policy_template(region, account_id, agent_name)
+                execution_policy = validate_rendered_policy(execution_policy_json)
+
+                logger.info("Creating IAM role: %s", role_name)
+
+                # Create the role with the trust policy
+                role = iam.create_role(
+                    RoleName=role_name,
+                    AssumeRolePolicyDocument=json.dumps(trust_policy),
+                    Description=f"Execution role for BedrockAgentCore Runtime - {agent_name}",
+                )
+
+                role_arn = role["Role"]["Arn"]
+                logger.info("✓ Role created: %s", role_arn)
+
+                # Create and attach the inline execution policy
+                policy_name = f"BedrockAgentCoreRuntimeExecutionPolicy-{agent_name}"
+
+                _attach_inline_policy(
+                    iam_client=iam,
+                    role_name=role_name,
+                    policy_name=policy_name,
+                    policy_document=json.dumps(execution_policy),
+                    logger=logger,
+                )
+
+                logger.info("✓ Execution policy attached: %s", policy_name)
+                logger.info("Role creation complete and ready for use with Bedrock AgentCore")
+
+                return role_arn
+
+            except ClientError as create_error:
+                if create_error.response["Error"]["Code"] == "EntityAlreadyExists":
+                    try:
+                        logger.info("Role %s already exists, retrieving existing role...", role_name)
+                        role = iam.get_role(RoleName=role_name)
+                        logger.info("✓ Role already exists: %s", role["Role"]["Arn"])
+                        return role["Role"]["Arn"]
+                    except ClientError as get_error:
+                        logger.error("Error getting existing role: %s", get_error)
+                        raise RuntimeError(f"Failed to get existing role: {get_error}") from get_error
+                else:
+                    logger.error("Error creating role: %s", create_error)
+                    if create_error.response["Error"]["Code"] == "AccessDenied":
+                        logger.error(
+                            "Access denied. Ensure your AWS credentials have sufficient IAM permissions "
+                            "to create roles and policies."
+                        )
+                    elif create_error.response["Error"]["Code"] == "LimitExceeded":
+                        logger.error(
+                            "AWS limit exceeded. You may have reached the maximum number of IAM roles "
+                            "allowed in your account."
+                        )
+                    raise RuntimeError(f"Failed to create role: {create_error}") from create_error
+        else:
+            logger.error("Error checking role existence: %s", e)
+            raise RuntimeError(f"Failed to check role existence: {e}") from e
+
+
+def _create_iam_role_with_policies(
+    session: Session,
+    logger: logging.Logger,
+    role_name: str,
+    trust_policy: dict,
+    inline_policies: dict,  # {policy_name: policy_document}
+    description: str,
+) -> str:
+    """Generic IAM role creation with inline policies.
+
+    Args:
+        session: Boto3 session
+        logger: Logger instance
+        role_name: Name for the IAM role
+        trust_policy: Trust policy document (dict)
+        inline_policies: Dictionary of {policy_name: policy_document}
+        description: Role description
+
+    Returns:
+        Role ARN
+
+    Raises:
+        RuntimeError: If role creation fails
+    """
+    iam = session.client("iam")
+
+    try:
         logger.info("Creating IAM role: %s", role_name)
-        logger.debug("Role will trust bedrock-agentcore.amazonaws.com service")
 
-        # Create the role with the trust policy
+        # Create the role with trust policy
         role = iam.create_role(
             RoleName=role_name,
             AssumeRolePolicyDocument=json.dumps(trust_policy),
-            Description=f"Execution role for BedrockAgentCore Runtime - {agent_name}",
+            Description=description,
         )
 
         role_arn = role["Role"]["Arn"]
         logger.info("✓ Role created: %s", role_arn)
-        logger.debug("Role ID: %s", role["Role"].get("RoleId", "Unknown"))
-        logger.debug("Role Path: %s", role["Role"].get("Path", "/"))
-        logger.debug("Creation Date: %s", role["Role"].get("CreateDate", "Unknown"))
 
-        # Create and attach the inline execution policy
-        policy_name = f"BedrockAgentCoreRuntimeExecutionPolicy-{agent_name}"
-        logger.info("Attaching inline policy: %s to role: %s", policy_name, role_name)
-        logger.debug("Policy grants permissions for ECR, CloudWatch Logs, X-Ray, and Bedrock")
-
-        _attach_inline_policy(
-            iam_client=iam,
-            role_name=role_name,
-            policy_name=policy_name,
-            policy_document=json.dumps(execution_policy),
-            logger=logger,
-        )
-
-        logger.info("✓ Execution policy attached: %s", policy_name)
-        logger.info("Role creation complete and ready for use with Bedrock AgentCore")
+        # Attach inline policies
+        for policy_name, policy_document in inline_policies.items():
+            logger.info("Attaching inline policy: %s to role: %s", policy_name, role_name)
+            _attach_inline_policy(
+                iam_client=iam,
+                role_name=role_name,
+                policy_name=policy_name,
+                policy_document=json.dumps(policy_document) if isinstance(policy_document, dict) else policy_document,
+                logger=logger,
+            )
+            logger.info("✓ Policy attached: %s", policy_name)
 
         return role_arn
 
@@ -101,7 +217,20 @@ def create_runtime_execution_role(
                 logger.info("Role %s already exists, retrieving existing role...", role_name)
                 role = iam.get_role(RoleName=role_name)
                 logger.info("✓ Role already exists: %s", role["Role"]["Arn"])
-                logger.debug("Creation Date: %s", role["Role"].get("CreateDate", "Unknown"))
+
+                # Update existing policies
+                for policy_name, policy_document in inline_policies.items():
+                    logger.info("Updating inline policy: %s on existing role: %s", policy_name, role_name)
+                    _attach_inline_policy(
+                        iam_client=iam,
+                        role_name=role_name,
+                        policy_name=policy_name,
+                        policy_document=json.dumps(policy_document)
+                        if isinstance(policy_document, dict)
+                        else policy_document,
+                        logger=logger,
+                    )
+
                 return role["Role"]["Arn"]
             except ClientError as get_error:
                 logger.error("Error getting existing role: %s", get_error)
@@ -157,3 +286,119 @@ def _attach_inline_policy(
         elif e.response["Error"]["Code"] == "LimitExceeded":
             logger.error("Policy size limit exceeded or too many policies attached to the role.")
         raise RuntimeError(f"Failed to attach policy {policy_name}: {e}") from e
+
+
+def get_or_create_codebuild_execution_role(
+    session: Session,
+    logger: logging.Logger,
+    region: str,
+    account_id: str,
+    agent_name: str,
+    ecr_repository_arn: str,
+    source_bucket_name: str,
+) -> str:
+    """Get existing CodeBuild execution role or create a new one (idempotent).
+
+    Args:
+        session: Boto3 session
+        logger: Logger instance
+        region: AWS region
+        account_id: AWS account ID
+        agent_name: Agent name for resource scoping
+        ecr_repository_arn: ECR repository ARN for permissions
+        source_bucket_name: S3 source bucket name for permissions
+
+    Returns:
+        Role ARN
+
+    Raises:
+        RuntimeError: If role creation fails
+    """
+    # Generate deterministic role name based on agent name
+    deterministic_suffix = _generate_deterministic_suffix(agent_name)
+    role_name = f"AmazonBedrockAgentCoreSDKCodeBuild-{region}-{deterministic_suffix}"
+
+    logger.info("Getting or creating CodeBuild execution role for agent: %s", agent_name)
+    logger.info("Role name: %s", role_name)
+
+    iam = session.client("iam")
+
+    try:
+        # Step 1: Check if role already exists
+        logger.debug("Checking if CodeBuild role exists: %s", role_name)
+        role = iam.get_role(RoleName=role_name)
+        existing_role_arn = role["Role"]["Arn"]
+
+        logger.info("Reusing existing CodeBuild execution role: %s", existing_role_arn)
+        return existing_role_arn
+
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchEntity":
+            # Step 2: Role doesn't exist, create it
+            logger.info("CodeBuild role doesn't exist, creating new role: %s", role_name)
+
+            # Define trust policy for CodeBuild service
+            trust_policy = {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "codebuild.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                        "Condition": {"StringEquals": {"aws:SourceAccount": account_id}},
+                    }
+                ],
+            }
+
+            # Define permissions policy for CodeBuild operations
+            permissions_policy = {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {"Effect": "Allow", "Action": ["ecr:GetAuthorizationToken"], "Resource": "*"},
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "ecr:BatchCheckLayerAvailability",
+                            "ecr:BatchGetImage",
+                            "ecr:GetDownloadUrlForLayer",
+                            "ecr:PutImage",
+                            "ecr:InitiateLayerUpload",
+                            "ecr:UploadLayerPart",
+                            "ecr:CompleteLayerUpload",
+                        ],
+                        "Resource": ecr_repository_arn,
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+                        "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:/aws/codebuild/bedrock-agentcore-*",
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": ["s3:GetObject"],
+                        "Resource": f"arn:aws:s3:::{source_bucket_name}/*",
+                    },
+                ],
+            }
+
+            # Create role using shared logic
+            role_arn = _create_iam_role_with_policies(
+                session=session,
+                logger=logger,
+                role_name=role_name,
+                trust_policy=trust_policy,
+                inline_policies={"CodeBuildExecutionPolicy": permissions_policy},
+                description="CodeBuild execution role for Bedrock AgentCore ARM64 builds",
+            )
+
+            # Wait for IAM propagation to prevent CodeBuild authorization errors
+            logger.info("Waiting for IAM role propagation...")
+            import time
+
+            time.sleep(15)
+
+            logger.info("CodeBuild execution role creation complete: %s", role_arn)
+            return role_arn
+        else:
+            logger.error("Error checking CodeBuild role existence: %s", e)
+            raise RuntimeError(f"Failed to check CodeBuild role existence: {e}") from e

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/create_role.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/create_role.py
@@ -1,0 +1,159 @@
+"""Creates an execution role to use in the Bedrock AgentCore Runtime module."""
+
+import json
+import logging
+from typing import Optional
+
+from boto3 import Session
+from botocore.client import BaseClient
+from botocore.exceptions import ClientError
+
+from ...utils.runtime.policy_template import (
+    render_execution_policy_template,
+    render_trust_policy_template,
+    validate_rendered_policy,
+)
+
+
+def create_runtime_execution_role(
+    session: Session,
+    logger: logging.Logger,
+    region: str,
+    account_id: str,
+    agent_name: str,
+    role_name: Optional[str] = None,
+) -> str:
+    """Create the Runtime execution role.
+
+    Args:
+        session: Boto3 session
+        logger: Logger instance
+        region: AWS region
+        account_id: AWS account ID
+        agent_name: Agent name for resource scoping
+        role_name: Optional custom role name
+
+    Returns:
+        Role ARN
+
+    Raises:
+        RuntimeError: If role creation fails
+    """
+    if not role_name:
+        role_name = f"BedrockAgentCoreRuntimeExecutionRole-{agent_name}"
+
+    logger.info("Starting execution role creation process for agent: %s", agent_name)
+    logger.info("Using AWS region: %s, account ID: %s", region, account_id)
+    logger.info("Role name will be: %s", role_name)
+
+    iam = session.client("iam")
+
+    try:
+        # Render the trust policy template
+        logger.debug("Rendering trust policy template...")
+        trust_policy_json = render_trust_policy_template(region, account_id)
+        trust_policy = validate_rendered_policy(trust_policy_json)
+        logger.debug("Trust policy validated successfully")
+
+        # Render the execution policy template
+        logger.debug("Rendering execution policy template...")
+        execution_policy_json = render_execution_policy_template(region, account_id, agent_name)
+        execution_policy = validate_rendered_policy(execution_policy_json)
+        logger.debug("Execution policy validated successfully")
+
+        logger.info("Creating IAM role: %s", role_name)
+        logger.debug("Role will trust bedrock-agentcore.amazonaws.com service")
+
+        # Create the role with the trust policy
+        role = iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(trust_policy),
+            Description=f"Execution role for BedrockAgentCore Runtime - {agent_name}",
+        )
+
+        role_arn = role["Role"]["Arn"]
+        logger.info("✓ Role created: %s", role_arn)
+        logger.debug("Role ID: %s", role["Role"].get("RoleId", "Unknown"))
+        logger.debug("Role Path: %s", role["Role"].get("Path", "/"))
+        logger.debug("Creation Date: %s", role["Role"].get("CreateDate", "Unknown"))
+
+        # Create and attach the inline execution policy
+        policy_name = f"BedrockAgentCoreRuntimeExecutionPolicy-{agent_name}"
+        logger.info("Attaching inline policy: %s to role: %s", policy_name, role_name)
+        logger.debug("Policy grants permissions for ECR, CloudWatch Logs, X-Ray, and Bedrock")
+
+        _attach_inline_policy(
+            iam_client=iam,
+            role_name=role_name,
+            policy_name=policy_name,
+            policy_document=json.dumps(execution_policy),
+            logger=logger,
+        )
+
+        logger.info("✓ Execution policy attached: %s", policy_name)
+        logger.info("Role creation complete and ready for use with Bedrock AgentCore")
+
+        return role_arn
+
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "EntityAlreadyExists":
+            try:
+                logger.info("Role %s already exists, retrieving existing role...", role_name)
+                role = iam.get_role(RoleName=role_name)
+                logger.info("✓ Role already exists: %s", role["Role"]["Arn"])
+                logger.debug("Creation Date: %s", role["Role"].get("CreateDate", "Unknown"))
+                return role["Role"]["Arn"]
+            except ClientError as get_error:
+                logger.error("Error getting existing role: %s", get_error)
+                raise RuntimeError(f"Failed to get existing role: {get_error}") from get_error
+        else:
+            logger.error("Error creating role: %s", e)
+            if e.response["Error"]["Code"] == "AccessDenied":
+                logger.error(
+                    "Access denied. Ensure your AWS credentials have sufficient IAM permissions "
+                    "to create roles and policies."
+                )
+            elif e.response["Error"]["Code"] == "LimitExceeded":
+                logger.error(
+                    "AWS limit exceeded. You may have reached the maximum number of IAM roles allowed in your account."
+                )
+            raise RuntimeError(f"Failed to create role: {e}") from e
+
+
+def _attach_inline_policy(
+    iam_client: BaseClient,
+    role_name: str,
+    policy_name: str,
+    policy_document: str,
+    logger: logging.Logger,
+) -> None:
+    """Attach an inline policy to an IAM role.
+
+    Args:
+        iam_client: IAM client instance
+        role_name: Name of the role
+        policy_name: Name of the policy
+        policy_document: Policy document JSON string
+        logger: Logger instance
+
+    Raises:
+        RuntimeError: If policy attachment fails
+    """
+    try:
+        logger.debug("Attaching inline policy %s to role %s", policy_name, role_name)
+        logger.debug("Policy document size: %d bytes", len(policy_document))
+
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName=policy_name,
+            PolicyDocument=policy_document,
+        )
+
+        logger.debug("Successfully attached policy %s to role %s", policy_name, role_name)
+    except ClientError as e:
+        logger.error("Error attaching policy %s to role %s: %s", policy_name, role_name, e)
+        if e.response["Error"]["Code"] == "MalformedPolicyDocument":
+            logger.error("Policy document is malformed. Check the JSON syntax.")
+        elif e.response["Error"]["Code"] == "LimitExceeded":
+            logger.error("Policy size limit exceeded or too many policies attached to the role.")
+        raise RuntimeError(f"Failed to attach policy {policy_name}: {e}") from e

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -1,27 +1,40 @@
 """Launch operation - deploys Bedrock AgentCore locally or to cloud."""
 
+import json
 import logging
+import time
+import urllib.parse
 from pathlib import Path
 from typing import Optional
 
 import boto3
+from botocore.exceptions import ClientError
 
 from ...services.codebuild import CodeBuildService
-from ...services.ecr import create_ecr_repository, deploy_to_ecr
+from ...services.ecr import deploy_to_ecr, get_or_create_ecr_repository
 from ...services.runtime import BedrockAgentCoreClient
 from ...utils.runtime.config import load_config, save_config
 from ...utils.runtime.container import ContainerRuntime
+from .create_role import get_or_create_runtime_execution_role
 from .models import LaunchResult
 
 log = logging.getLogger(__name__)
 
 
 def _ensure_ecr_repository(agent_config, project_config, config_path, agent_name, region):
-    """Ensure ECR repository exists, creating if needed and updating config."""
+    """Ensure ECR repository exists (idempotent)."""
     ecr_uri = agent_config.aws.ecr_repository
-    if not ecr_uri and agent_config.aws.ecr_auto_create:
-        repo_name = f"bedrock_agentcore-{agent_name}"
-        ecr_uri = create_ecr_repository(repo_name, region)
+
+    # Step 1: Check if we already have a repository in config
+    if ecr_uri:
+        log.info("Using ECR repository from config: %s", ecr_uri)
+        return ecr_uri
+
+    # Step 2: Create repository if needed (idempotent)
+    if agent_config.aws.ecr_auto_create:
+        log.info("Getting or creating ECR repository for agent: %s", agent_name)
+
+        ecr_uri = get_or_create_ecr_repository(agent_name, region)
 
         # Update the config
         agent_config.aws.ecr_repository = ecr_uri
@@ -31,14 +44,104 @@ def _ensure_ecr_repository(agent_config, project_config, config_path, agent_name
         project_config.agents[agent_config.name] = agent_config
         save_config(project_config, config_path)
 
-    if not ecr_uri:
-        raise ValueError("ECR repository not configured and auto-create not enabled")
+        log.info("✅ ECR repository available: %s", ecr_uri)
+        return ecr_uri
 
-    return ecr_uri
+    # Step 3: No repository and auto-create disabled
+    raise ValueError("ECR repository not configured and auto-create not enabled")
 
 
-def _deploy_to_bedrock_agentcore(agent_config, project_config, config_path, agent_name, ecr_uri, region, env_vars=None):
-    """Deploy agent to Bedrock AgentCore and wait for readiness."""
+def _validate_execution_role(role_arn: str, session: boto3.Session) -> bool:
+    """Validate that execution role exists and has correct trust policy for Bedrock AgentCore."""
+    iam = session.client("iam")
+    role_name = role_arn.split("/")[-1]
+
+    try:
+        response = iam.get_role(RoleName=role_name)
+        trust_policy = response["Role"]["AssumeRolePolicyDocument"]
+
+        # Parse trust policy (it might be URL-encoded)
+        if isinstance(trust_policy, str):
+            trust_policy = json.loads(urllib.parse.unquote(trust_policy))
+
+        # Check if bedrock-agentcore service can assume this role
+        for statement in trust_policy.get("Statement", []):
+            if statement.get("Effect") == "Allow":
+                principals = statement.get("Principal", {})
+
+                if isinstance(principals, dict):
+                    services = principals.get("Service", [])
+                    if isinstance(services, str):
+                        services = [services]
+
+                    if "bedrock-agentcore.amazonaws.com" in services:
+                        return True
+
+        return False
+
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchEntity":
+            return False
+        raise
+
+
+def _ensure_execution_role(agent_config, project_config, config_path, agent_name, region, account_id):
+    """Ensure execution role exists without waiting.
+
+    This function handles:
+    1. Reusing existing role from config if available
+    2. Creating role if needed (auto_create_execution_role=True) - now idempotent
+    3. Basic validation that existing roles have correct trust policy
+    4. Returning role ARN (readiness will be checked during actual deployment)
+    """
+    execution_role_arn = agent_config.aws.execution_role
+    session = boto3.Session(region_name=region)
+
+    # Step 1: Check if we already have a role in config
+    if execution_role_arn:
+        log.info("Using execution role from config: %s", execution_role_arn)
+
+        # Step 2: Basic validation for existing roles
+        if not _validate_execution_role(execution_role_arn, session):
+            raise ValueError(
+                f"Execution role {execution_role_arn} has invalid trust policy. "
+                "Ensure it allows bedrock-agentcore.amazonaws.com service to assume the role."
+            )
+
+        log.info("✅ Execution role validation passed: %s", execution_role_arn)
+        return execution_role_arn
+
+    # Step 3: Create role if needed (idempotent)
+    if agent_config.aws.execution_role_auto_create:
+        log.info("Getting or creating execution role for agent: %s", agent_name)
+
+        execution_role_arn = get_or_create_runtime_execution_role(
+            session=session,
+            logger=log,
+            region=region,
+            account_id=account_id,
+            agent_name=agent_name,
+        )
+
+        # Update the config
+        agent_config.aws.execution_role = execution_role_arn
+        agent_config.aws.execution_role_auto_create = False
+
+        # Update the project config and save
+        project_config.agents[agent_config.name] = agent_config
+        save_config(project_config, config_path)
+
+        log.info("✅ Execution role available: %s", execution_role_arn)
+        return execution_role_arn
+
+    # Step 4: No role and auto-create disabled
+    raise ValueError("Execution role not configured and auto-create not enabled")
+
+
+def _deploy_to_bedrock_agentcore(
+    agent_config, project_config, config_path, agent_name, ecr_uri, region, env_vars=None, auto_update_on_conflict=False
+):
+    """Deploy agent to Bedrock AgentCore with retry logic for role validation."""
     log.info("Deploying to Bedrock AgentCore...")
 
     bedrock_agentcore_client = BedrockAgentCoreClient(region)
@@ -47,23 +150,64 @@ def _deploy_to_bedrock_agentcore(agent_config, project_config, config_path, agen
     network_config = agent_config.aws.network_configuration.to_aws_dict()
     protocol_config = agent_config.aws.protocol_configuration.to_aws_dict()
 
-    # Execution role should already be configured during configure step
+    # Execution role should be available by now (either provided or auto-created)
     if not agent_config.aws.execution_role:
         raise ValueError(
-            "Execution role not configured. Please run configure with --auto-create-execution-role "
-            "or provide --execution-role"
+            "Execution role not available. This should have been handled by _ensure_execution_role. "
+            "Please check configuration or enable auto-creation."
         )
 
-    agent_info = bedrock_agentcore_client.create_or_update_agent(
-        agent_id=agent_config.bedrock_agentcore.agent_id,
-        agent_name=agent_name,
-        image_uri=f"{ecr_uri}:latest",
-        execution_role_arn=agent_config.aws.execution_role,
-        network_config=network_config,
-        authorizer_config=agent_config.get_authorizer_configuration(),
-        protocol_config=protocol_config,
-        env_vars=env_vars,
-    )
+    # Retry logic for role validation eventual consistency
+    max_retries = 3
+    base_delay = 5  # Start with 2 seconds
+    max_delay = 15  # Max 32 seconds between retries
+
+    for attempt in range(max_retries + 1):
+        try:
+            agent_info = bedrock_agentcore_client.create_or_update_agent(
+                agent_id=agent_config.bedrock_agentcore.agent_id,
+                agent_name=agent_name,
+                image_uri=f"{ecr_uri}:latest",
+                execution_role_arn=agent_config.aws.execution_role,
+                network_config=network_config,
+                authorizer_config=agent_config.get_authorizer_configuration(),
+                protocol_config=protocol_config,
+                env_vars=env_vars,
+                auto_update_on_conflict=auto_update_on_conflict,
+            )
+            break  # Success! Exit retry loop
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_message = e.response.get("Error", {}).get("Message", "")
+
+            # Check if this is a role validation error
+            is_role_validation_error = (
+                error_code == "ValidationException"
+                and "Role validation failed" in error_message
+                and agent_config.aws.execution_role in error_message
+            )
+
+            if not is_role_validation_error or attempt == max_retries:
+                # Not a role validation error, or we've exhausted retries
+                if is_role_validation_error:
+                    log.error(
+                        "Role validation failed after %d attempts. The execution role may not be ready. Role: %s",
+                        max_retries + 1,
+                        agent_config.aws.execution_role,
+                    )
+                raise e
+
+            # Calculate delay with exponential backoff
+            delay = min(base_delay * (2**attempt), max_delay)
+            log.info(
+                "⏳ Role validation failed (attempt %d/%d), retrying in %ds... Role: %s",
+                attempt + 1,
+                max_retries + 1,
+                delay,
+                agent_config.aws.execution_role,
+            )
+            time.sleep(delay)
 
     # Save deployment info
     agent_id = agent_info["id"]
@@ -77,7 +221,7 @@ def _deploy_to_bedrock_agentcore(agent_config, project_config, config_path, agen
     project_config.agents[agent_config.name] = agent_config
     save_config(project_config, config_path)
 
-    log.info("Agent created/updated: %s", agent_arn)
+    log.info("✅ Agent created/updated: %s", agent_arn)
 
     # Wait for agent to be ready
     log.info("Polling for endpoint to be ready...")
@@ -94,6 +238,7 @@ def launch_bedrock_agentcore(
     push_ecr_only: bool = False,
     use_codebuild: bool = False,
     env_vars: Optional[dict] = None,
+    auto_update_on_conflict: bool = False,
 ) -> LaunchResult:
     """Launch Bedrock AgentCore locally or to cloud.
 
@@ -104,6 +249,7 @@ def launch_bedrock_agentcore(
         push_ecr_only: Whether to only build and push to ECR without deploying
         use_codebuild: Whether to use CodeBuild for ARM64 builds
         env_vars: Environment variables to pass to local container (dict of key-value pairs)
+        auto_update_on_conflict: Whether to automatically update when agent already exists (default: False)
 
     Returns:
         LaunchResult model with launch details
@@ -119,6 +265,7 @@ def launch_bedrock_agentcore(
             agent_name=agent_config.name,
             agent_config=agent_config,
             project_config=project_config,
+            auto_update_on_conflict=auto_update_on_conflict,
         )
 
     # Log which agent is being launched
@@ -157,12 +304,17 @@ def launch_bedrock_agentcore(
             env_vars=env_vars,
         )
 
-    # Step 2: Push to ECR
-    log.info("Uploading to ECR...")
-
     region = agent_config.aws.region
     if not region:
         raise ValueError("Region not found in configuration")
+
+    account_id = agent_config.aws.account
+
+    # Step 2: Ensure execution role exists (moved before ECR push)
+    _ensure_execution_role(agent_config, project_config, config_path, bedrock_agentcore_name, region, account_id)
+
+    # Step 3: Push to ECR
+    log.info("Uploading to ECR...")
 
     # Handle ECR repository
     ecr_uri = _ensure_ecr_repository(agent_config, project_config, config_path, bedrock_agentcore_name, region)
@@ -182,9 +334,16 @@ def launch_bedrock_agentcore(
             build_output=output,
         )
 
-    # Step 3: Deploy agent
+    # Step 4: Deploy agent (with retry logic for role readiness)
     agent_id, agent_arn = _deploy_to_bedrock_agentcore(
-        agent_config, project_config, config_path, bedrock_agentcore_name, ecr_uri, region, env_vars
+        agent_config,
+        project_config,
+        config_path,
+        bedrock_agentcore_name,
+        ecr_uri,
+        region,
+        env_vars,
+        auto_update_on_conflict,
     )
 
     return LaunchResult(
@@ -202,9 +361,15 @@ def _launch_with_codebuild(
     agent_name: str,
     agent_config,
     project_config,
+    auto_update_on_conflict: bool = False,
 ) -> LaunchResult:
     """Launch using CodeBuild for ARM64 builds."""
-    log.info("Starting CodeBuild ARM64 deployment for agent '%s'", agent_name)
+    log.info(
+        "Starting CodeBuild ARM64 deployment for agent '%s' to account %s (%s)",
+        agent_name,
+        agent_config.aws.account,
+        agent_config.aws.region,
+    )
 
     # Validate configuration
     errors = agent_config.validate(for_local=False)
@@ -218,27 +383,22 @@ def _launch_with_codebuild(
     session = boto3.Session(region_name=region)
     account_id = agent_config.aws.account  # Use existing account from config
 
-    # Step 1: Ensure ECR repository exists
-    log.info("Ensuring ECR repository exists...")
+    # Step 1: Setup AWS resources
+    log.info("Setting up AWS resources (ECR repository, execution roles)...")
     ecr_uri = _ensure_ecr_repository(agent_config, project_config, config_path, agent_name, region)
-
     ecr_repository_arn = f"arn:aws:ecr:{region}:{account_id}:repository/{ecr_uri.split('/')[-1]}"
+    _ensure_execution_role(agent_config, project_config, config_path, agent_name, region, account_id)
 
-    # Step 2: Initialize CodeBuild service
+    # Step 2: Prepare CodeBuild
+    log.info("Preparing CodeBuild project and uploading source...")
     codebuild_service = CodeBuildService(session)
 
-    # Step 3: Create CodeBuild execution role (auto-create)
-    log.info("Creating CodeBuild execution role...")
     codebuild_execution_role = codebuild_service.create_codebuild_execution_role(
         account_id=account_id, ecr_repository_arn=ecr_repository_arn, agent_name=agent_name
     )
 
-    # Step 4: Upload source with agent name and timestamp
-    log.info("Uploading source code to S3...")
     source_location = codebuild_service.upload_source(agent_name=agent_name)
 
-    # Step 5: Create/update CodeBuild project
-    log.info("Creating/updating CodeBuild project...")
     project_name = codebuild_service.create_or_update_project(
         agent_name=agent_name,
         ecr_repository_uri=ecr_uri,
@@ -246,25 +406,30 @@ def _launch_with_codebuild(
         source_location=source_location,
     )
 
-    # Step 6: Trigger CodeBuild
-    log.info("Starting CodeBuild...")
+    # Step 3: Execute CodeBuild
+    log.info("Starting CodeBuild build (this may take several minutes)...")
     build_id = codebuild_service.start_build(project_name, source_location)
-    log.info("Started CodeBuild: %s", build_id)
-
-    # Step 7: Wait for completion
-    log.info("Waiting for CodeBuild to complete...")
     codebuild_service.wait_for_completion(build_id)
     log.info("CodeBuild completed successfully")
 
-    # Step 7.1: Update CodeBuild config
+    # Update CodeBuild config
     agent_config.codebuild.project_name = project_name
     agent_config.codebuild.execution_role = codebuild_execution_role
     agent_config.codebuild.source_bucket = codebuild_service.source_bucket
 
-    # Step 8: Deploy to Bedrock AgentCore
+    # Deploy to Bedrock AgentCore
     agent_id, agent_arn = _deploy_to_bedrock_agentcore(
-        agent_config, project_config, config_path, agent_name, ecr_uri, region, env_vars=None
+        agent_config,
+        project_config,
+        config_path,
+        agent_name,
+        ecr_uri,
+        region,
+        env_vars=None,
+        auto_update_on_conflict=auto_update_on_conflict,
     )
+
+    log.info("Deployment completed successfully - Agent: %s", agent_arn)
 
     return LaunchResult(
         mode="codebuild",

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -47,8 +47,12 @@ def _deploy_to_bedrock_agentcore(agent_config, project_config, config_path, agen
     network_config = agent_config.aws.network_configuration.to_aws_dict()
     protocol_config = agent_config.aws.protocol_configuration.to_aws_dict()
 
+    # Execution role should already be configured during configure step
     if not agent_config.aws.execution_role:
-        raise ValueError("Execution role not configured")
+        raise ValueError(
+            "Execution role not configured. Please run configure with --auto-create-execution-role "
+            "or provide --execution-role"
+        )
 
     agent_info = bedrock_agentcore_client.create_or_update_agent(
         agent_id=agent_config.bedrock_agentcore.agent_id,

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -113,8 +113,6 @@ def _ensure_execution_role(agent_config, project_config, config_path, agent_name
 
     # Step 3: Create role if needed (idempotent)
     if agent_config.aws.execution_role_auto_create:
-        log.info("Getting or creating execution role for agent: %s", agent_name)
-
         execution_role_arn = get_or_create_runtime_execution_role(
             session=session,
             logger=log,

--- a/src/bedrock_agentcore_starter_toolkit/utils/logging_config.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/logging_config.py
@@ -1,0 +1,72 @@
+"""Centralized logging configuration for bedrock-agentcore-starter-toolkit."""
+
+import logging
+
+_LOGGING_CONFIGURED = False
+
+
+def setup_toolkit_logging(mode: str = "sdk") -> None:
+    """Setup logging for bedrock-agentcore-starter-toolkit.
+
+    Args:
+        mode: "cli" or "sdk" (defaults to "sdk")
+    """
+    global _LOGGING_CONFIGURED
+    if _LOGGING_CONFIGURED:
+        return  # Already configured, prevent duplicates
+
+    if mode == "cli":
+        _setup_cli_logging()
+    elif mode == "sdk":
+        _setup_sdk_logging()
+    else:
+        raise ValueError(f"Invalid logging mode: {mode}. Must be 'cli' or 'sdk'")
+
+    _LOGGING_CONFIGURED = True
+
+
+def _setup_cli_logging() -> None:
+    """Setup logging for CLI usage with RichHandler."""
+    try:
+        from rich.logging import RichHandler
+
+        from ..cli.common import console
+
+        FORMAT = "%(message)s"
+        logging.basicConfig(
+            level="INFO",
+            format=FORMAT,
+            handlers=[RichHandler(show_time=False, show_path=False, show_level=False, console=console)],
+            force=True,  # Override any existing configuration
+        )
+    except ImportError:
+        # Fallback if rich is not available
+        _setup_basic_logging()
+
+
+def _setup_sdk_logging() -> None:
+    """Setup logging for SDK usage (notebooks, scripts, imports) with StreamHandler."""
+    # Configure logger for ALL toolkit modules (ensures all operation logs appear)
+    toolkit_logger = logging.getLogger("bedrock_agentcore_starter_toolkit")
+
+    if not toolkit_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        toolkit_logger.addHandler(handler)
+        toolkit_logger.setLevel(logging.INFO)
+
+
+def _setup_basic_logging() -> None:
+    """Setup basic logging as fallback."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s", force=True)
+
+
+def is_logging_configured() -> bool:
+    """Check if toolkit logging has been configured."""
+    return _LOGGING_CONFIGURED
+
+
+def reset_logging_config() -> None:
+    """Reset logging configuration state (for testing)."""
+    global _LOGGING_CONFIGURED
+    _LOGGING_CONFIGURED = False

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/entrypoint.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/entrypoint.py
@@ -181,11 +181,11 @@ def validate_requirements_file(build_dir: Path, requirements_file: str) -> Depen
             f"Please specify a requirements file (requirements.txt, pyproject.toml, etc.)"
         )
 
-    # Validate that it's a recognized dependency file type (strict validation)
-    if file_path.name not in ["requirements.txt", "pyproject.toml"]:
+    # Validate that it's a recognized dependency file type (flexible validation)
+    if not (file_path.suffix in [".txt", ".in"] or file_path.name == "pyproject.toml"):
         raise ValueError(
             f"'{file_path.name}' is not a supported dependency file. "
-            f"Only 'requirements.txt' and 'pyproject.toml' are supported."
+            f"Supported formats: *.txt, *.in (pip requirements), or pyproject.toml"
         )
 
     # Use the existing detect_dependencies function to process the file

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/policy_template.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/policy_template.py
@@ -1,0 +1,74 @@
+"""Policy template utilities for runtime execution roles."""
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def _get_template_dir() -> Path:
+    """Get the templates directory path."""
+    return Path(__file__).parent / "templates"
+
+
+def _render_template(template_name: str, variables: Dict[str, str]) -> str:
+    """Render a Jinja2 template with the provided variables."""
+    template_dir = _get_template_dir()
+    env = Environment(loader=FileSystemLoader(template_dir), autoescape=True)
+    template = env.get_template(template_name)
+    return template.render(**variables)
+
+
+def render_trust_policy_template(region: str, account_id: str) -> str:
+    """Render the trust policy template with provided values.
+
+    Args:
+        region: AWS region
+        account_id: AWS account ID
+
+    Returns:
+        Rendered trust policy as JSON string
+    """
+    variables = {
+        "region": region,
+        "account_id": account_id,
+    }
+    return _render_template("execution_role_trust_policy.json.j2", variables)
+
+
+def render_execution_policy_template(region: str, account_id: str, agent_name: str) -> str:
+    """Render the execution policy template with provided values.
+
+    Args:
+        region: AWS region
+        account_id: AWS account ID
+        agent_name: Agent name for resource scoping
+
+    Returns:
+        Rendered execution policy as JSON string
+    """
+    variables = {
+        "region": region,
+        "account_id": account_id,
+        "agent_name": agent_name,
+    }
+    return _render_template("execution_role_policy.json.j2", variables)
+
+
+def validate_rendered_policy(policy_json: str) -> Dict:
+    """Validate that the rendered policy is valid JSON.
+
+    Args:
+        policy_json: JSON policy string
+
+    Returns:
+        Parsed policy dictionary
+
+    Raises:
+        ValueError: If policy JSON is invalid
+    """
+    try:
+        return json.loads(policy_json)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid policy JSON: {e}") from e

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
@@ -35,6 +35,7 @@ class AWSConfig(BaseModel):
     """AWS-specific configuration."""
 
     execution_role: Optional[str] = Field(default=None, description="AWS IAM execution role ARN")
+    execution_role_auto_create: bool = Field(default=False, description="Whether to auto-create execution role")
     account: Optional[str] = Field(default=None, description="AWS account ID")
     region: Optional[str] = Field(default=None, description="AWS region")
     ecr_repository: Optional[str] = Field(default=None, description="ECR repository URI")
@@ -105,8 +106,8 @@ class BedrockAgentCoreAgentSchema(BaseModel):
 
         # AWS fields required for cloud deployment
         if not for_local:
-            if not self.aws.execution_role:
-                errors.append("Missing 'aws.execution_role' for cloud deployment")
+            if not self.aws.execution_role and not self.aws.execution_role_auto_create:
+                errors.append("Missing 'aws.execution_role' for cloud deployment (or enable auto-creation)")
             if not self.aws.region:
                 errors.append("Missing 'aws.region' for cloud deployment")
             if not self.aws.account:

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
@@ -1,0 +1,98 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECRImageAccess",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ],
+      "Resource": [
+        "arn:aws:ecr:{{ region }}:{{ account_id }}:repository/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogStreams",
+        "logs:CreateLogGroup"
+      ],
+      "Resource": [
+        "arn:aws:logs:{{ region }}:{{ account_id }}:log-group:/aws/bedrock-agentcore/runtimes/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": [
+        "arn:aws:logs:{{ region }}:{{ account_id }}:log-group:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:{{ region }}:{{ account_id }}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*"
+      ]
+    },
+    {
+      "Sid": "ECRTokenAccess",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "xray:PutTraceSegments",
+        "xray:PutTelemetryRecords",
+        "xray:GetSamplingRules",
+        "xray:GetSamplingTargets"
+      ],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": "cloudwatch:PutMetricData",
+      "Condition": {
+        "StringEquals": {
+          "cloudwatch:namespace": "bedrock-agentcore"
+        }
+      }
+    },
+    {
+      "Sid": "GetAgentAccessToken",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:GetWorkloadAccessToken",
+        "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+        "bedrock-agentcore:GetWorkloadAccessTokenForUserId"
+      ],
+      "Resource": [
+        "arn:aws:bedrock-agentcore:{{ region }}:{{ account_id }}:workload-identity-directory/default",
+        "arn:aws:bedrock-agentcore:{{ region }}:{{ account_id }}:workload-identity-directory/default/workload-identity/{{ agent_name }}-*"
+      ]
+    },
+    {
+      "Sid": "BedrockModelInvocation",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:{{ region }}:{{ account_id }}:*"
+      ]
+    }
+  ]
+}

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_trust_policy.json.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_trust_policy.json.j2
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AssumeRolePolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "bedrock-agentcore.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "{{ account_id }}"
+        },
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:bedrock-agentcore:{{ region }}:{{ account_id }}:*"
+        }
+      }
+    }
+  ]
+}

--- a/tests/cli/runtime/test_commands.py
+++ b/tests/cli/runtime/test_commands.py
@@ -191,6 +191,7 @@ agents:
                     push_ecr_only=False,
                     use_codebuild=False,
                     env_vars=None,
+                    auto_update_on_conflict=False,
                 )
             finally:
                 os.chdir(original_cwd)
@@ -463,6 +464,7 @@ agents:
                     push_ecr_only=False,
                     use_codebuild=False,
                     env_vars=None,
+                    auto_update_on_conflict=False,
                 )
             finally:
                 os.chdir(original_cwd)
@@ -1667,6 +1669,7 @@ agents:
                     push_ecr_only=True,
                     use_codebuild=False,
                     env_vars=None,
+                    auto_update_on_conflict=False,
                 )
             finally:
                 os.chdir(original_cwd)
@@ -1772,6 +1775,7 @@ agents:
                     push_ecr_only=False,
                     use_codebuild=False,
                     env_vars=None,
+                    auto_update_on_conflict=False,
                 )
             finally:
                 os.chdir(original_cwd)

--- a/tests/cli/runtime/test_configuration_manager.py
+++ b/tests/cli/runtime/test_configuration_manager.py
@@ -26,9 +26,9 @@ class TestConfigurationManager:
             result = config_manager.prompt_execution_role()
 
             assert result == "arn:aws:iam::123456789012:role/TestExecutionRole"
-            mock_prompt.assert_called_once_with("Enter execution role ARN or name", "")
+            mock_prompt.assert_called_once_with("Execution role ARN/name (or press Enter to auto-create)", "")
             mock_success.assert_called_once_with(
-                "Using execution role: [dim]arn:aws:iam::123456789012:role/TestExecutionRole[/dim]"
+                "Using existing execution role: [dim]arn:aws:iam::123456789012:role/TestExecutionRole[/dim]"
             )
 
     def test_prompt_execution_role_with_existing_config(self, tmp_path):
@@ -58,12 +58,10 @@ class TestConfigurationManager:
             result = config_manager.prompt_execution_role()
 
             assert result == "arn:aws:iam::123456789012:role/ExistingRole"
-            # Should use existing role as default
-            mock_prompt.assert_called_once_with(
-                "Enter execution role ARN or name", "arn:aws:iam::123456789012:role/ExistingRole"
-            )
+            # Should use empty default since we're showing the existing config separately
+            mock_prompt.assert_called_once_with("Execution role ARN/name (or press Enter to auto-create)", "")
             mock_success.assert_called_once_with(
-                "Using execution role: [dim]arn:aws:iam::123456789012:role/ExistingRole[/dim]"
+                "Using existing execution role: [dim]arn:aws:iam::123456789012:role/ExistingRole[/dim]"
             )
 
     def test_prompt_execution_role_existing_config_overridden(self, tmp_path):
@@ -93,10 +91,8 @@ class TestConfigurationManager:
             result = config_manager.prompt_execution_role()
 
             assert result == "arn:aws:iam::123456789012:role/NewRole"
-            # Should use existing role as default but return new role
-            mock_prompt.assert_called_once_with(
-                "Enter execution role ARN or name", "arn:aws:iam::123456789012:role/OldRole"
-            )
+            # Should use empty default since we're showing the existing config separately
+            mock_prompt.assert_called_once_with("Execution role ARN/name (or press Enter to auto-create)", "")
             mock_success.assert_called_once_with(
-                "Using execution role: [dim]arn:aws:iam::123456789012:role/NewRole[/dim]"
+                "Using existing execution role: [dim]arn:aws:iam::123456789012:role/NewRole[/dim]"
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def mock_boto3_clients(monkeypatch):
     )
 
     monkeypatch.setattr("boto3.client", mock_client)
-    monkeypatch.setattr("boto3.Session", lambda: mock_session)
+    monkeypatch.setattr("boto3.Session", lambda *args, **kwargs: mock_session)
 
     return {"sts": mock_sts, "ecr": mock_ecr, "bedrock_agentcore": mock_bedrock_agentcore, "session": mock_session}
 

--- a/tests/operations/runtime/test_create_role.py
+++ b/tests/operations/runtime/test_create_role.py
@@ -1,0 +1,255 @@
+"""Tests for create_role module."""
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from bedrock_agentcore_starter_toolkit.operations.runtime.create_role import (
+    _attach_inline_policy,
+    create_runtime_execution_role,
+)
+
+
+class TestCreateRole:
+    """Test create_role functionality."""
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock boto3 session."""
+        session = MagicMock(spec=boto3.Session)
+        mock_iam = MagicMock()
+        session.client.return_value = mock_iam
+        return session, mock_iam
+
+    @pytest.fixture
+    def mock_logger(self):
+        """Create a mock logger."""
+        return MagicMock(spec=logging.Logger)
+
+    def test_create_runtime_execution_role_success(self, mock_session, mock_logger):
+        """Test successful role creation."""
+        session, mock_iam = mock_session
+        mock_iam.create_role.return_value = {"Role": {"Arn": "arn:aws:iam::123456789012:role/TestRole"}}
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_trust_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_execution_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.validate_rendered_policy",
+                return_value={"Version": "2012-10-17", "Statement": []},
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role._attach_inline_policy"
+            ) as mock_attach,
+        ):
+            result = create_runtime_execution_role(
+                session=session,
+                logger=mock_logger,
+                region="us-east-1",
+                account_id="123456789012",
+                agent_name="test-agent",
+            )
+
+            assert result == "arn:aws:iam::123456789012:role/TestRole"
+            mock_iam.create_role.assert_called_once()
+            mock_attach.assert_called_once()
+            mock_logger.info.assert_called()
+
+    def test_create_runtime_execution_role_with_custom_name(self, mock_session, mock_logger):
+        """Test role creation with custom name."""
+        session, mock_iam = mock_session
+        mock_iam.create_role.return_value = {"Role": {"Arn": "arn:aws:iam::123456789012:role/CustomRoleName"}}
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_trust_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_execution_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.validate_rendered_policy",
+                return_value={"Version": "2012-10-17", "Statement": []},
+            ),
+            patch("bedrock_agentcore_starter_toolkit.operations.runtime.create_role._attach_inline_policy"),
+        ):
+            result = create_runtime_execution_role(
+                session=session,
+                logger=mock_logger,
+                region="us-east-1",
+                account_id="123456789012",
+                agent_name="test-agent",
+                role_name="CustomRoleName",
+            )
+
+            assert result == "arn:aws:iam::123456789012:role/CustomRoleName"
+            mock_iam.create_role.assert_called_once_with(
+                RoleName="CustomRoleName",
+                AssumeRolePolicyDocument=json.dumps({"Version": "2012-10-17", "Statement": []}),
+                Description="Execution role for BedrockAgentCore Runtime - test-agent",
+            )
+
+    def test_create_runtime_execution_role_already_exists(self, mock_session, mock_logger):
+        """Test role creation when role already exists."""
+        session, mock_iam = mock_session
+
+        # Mock the create_role to raise EntityAlreadyExists error
+        error_response = {"Error": {"Code": "EntityAlreadyExists"}}
+        mock_iam.create_role.side_effect = ClientError(error_response, "CreateRole")
+
+        # Mock the get_role response
+        mock_iam.get_role.return_value = {"Role": {"Arn": "arn:aws:iam::123456789012:role/ExistingRole"}}
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_trust_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_execution_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.validate_rendered_policy",
+                return_value={"Version": "2012-10-17", "Statement": []},
+            ),
+        ):
+            result = create_runtime_execution_role(
+                session=session,
+                logger=mock_logger,
+                region="us-east-1",
+                account_id="123456789012",
+                agent_name="test-agent",
+                role_name="ExistingRole",
+            )
+
+            assert result == "arn:aws:iam::123456789012:role/ExistingRole"
+            mock_iam.create_role.assert_called_once()
+            mock_iam.get_role.assert_called_once_with(RoleName="ExistingRole")
+            mock_logger.info.assert_called_with(
+                "✓ Role already exists: %s", "arn:aws:iam::123456789012:role/ExistingRole"
+            )
+
+    def test_create_runtime_execution_role_error_getting_existing(self, mock_session, mock_logger):
+        """Test error when getting existing role."""
+        session, mock_iam = mock_session
+
+        # Mock the create_role to raise EntityAlreadyExists error
+        error_response = {"Error": {"Code": "EntityAlreadyExists"}}
+        mock_iam.create_role.side_effect = ClientError(error_response, "CreateRole")
+
+        # Mock the get_role to raise an error
+        error_response_get = {"Error": {"Code": "NoSuchEntity"}}
+        mock_iam.get_role.side_effect = ClientError(error_response_get, "GetRole")
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_trust_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_execution_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.validate_rendered_policy",
+                return_value={"Version": "2012-10-17", "Statement": []},
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to get existing role"):
+                create_runtime_execution_role(
+                    session=session,
+                    logger=mock_logger,
+                    region="us-east-1",
+                    account_id="123456789012",
+                    agent_name="test-agent",
+                    role_name="ExistingRole",
+                )
+
+            mock_iam.create_role.assert_called_once()
+            mock_iam.get_role.assert_called_once()
+            mock_logger.error.assert_called()
+
+    def test_create_runtime_execution_role_other_error(self, mock_session, mock_logger):
+        """Test other errors during role creation."""
+        session, mock_iam = mock_session
+
+        # Mock the create_role to raise a different error
+        error_response = {"Error": {"Code": "AccessDenied"}}
+        mock_iam.create_role.side_effect = ClientError(error_response, "CreateRole")
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_trust_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_execution_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.validate_rendered_policy",
+                return_value={"Version": "2012-10-17", "Statement": []},
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to create role"):
+                create_runtime_execution_role(
+                    session=session,
+                    logger=mock_logger,
+                    region="us-east-1",
+                    account_id="123456789012",
+                    agent_name="test-agent",
+                )
+
+            mock_iam.create_role.assert_called_once()
+            mock_logger.error.assert_called()
+
+    def test_attach_inline_policy_success(self, mock_session, mock_logger):
+        """Test successful policy attachment."""
+        _, mock_iam = mock_session
+
+        _attach_inline_policy(
+            iam_client=mock_iam,
+            role_name="TestRole",
+            policy_name="TestPolicy",
+            policy_document='{"Version": "2012-10-17", "Statement": []}',
+            logger=mock_logger,
+        )
+
+        mock_iam.put_role_policy.assert_called_once_with(
+            RoleName="TestRole",
+            PolicyName="TestPolicy",
+            PolicyDocument='{"Version": "2012-10-17", "Statement": []}',
+        )
+
+    def test_attach_inline_policy_error(self, mock_session, mock_logger):
+        """Test error during policy attachment."""
+        _, mock_iam = mock_session
+
+        # Mock the put_role_policy to raise an error
+        error_response = {"Error": {"Code": "MalformedPolicyDocument"}}
+        mock_iam.put_role_policy.side_effect = ClientError(error_response, "PutRolePolicy")
+
+        with pytest.raises(RuntimeError, match="Failed to attach policy"):
+            _attach_inline_policy(
+                iam_client=mock_iam,
+                role_name="TestRole",
+                policy_name="TestPolicy",
+                policy_document='{"Version": "2012-10-17", "Statement": []}',
+                logger=mock_logger,
+            )
+
+        mock_iam.put_role_policy.assert_called_once()
+        mock_logger.error.assert_called()

--- a/tests/operations/runtime/test_launch.py
+++ b/tests/operations/runtime/test_launch.py
@@ -1,10 +1,13 @@
 """Tests for Bedrock AgentCore launch operation."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from bedrock_agentcore_starter_toolkit.operations.runtime.launch import launch_bedrock_agentcore
+from bedrock_agentcore_starter_toolkit.operations.runtime.launch import (
+    _ensure_execution_role,
+    launch_bedrock_agentcore,
+)
 from bedrock_agentcore_starter_toolkit.utils.runtime.config import save_config
 from bedrock_agentcore_starter_toolkit.utils.runtime.schema import (
     AWSConfig,
@@ -84,6 +87,17 @@ class TestLaunchBedrockAgentCore:
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
 
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
         with (
             patch("bedrock_agentcore_starter_toolkit.services.ecr.create_ecr_repository") as mock_create_ecr,
             patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr") as mock_deploy_ecr,
@@ -135,6 +149,17 @@ class TestLaunchBedrockAgentCore:
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+        mock_boto3_clients["session"].client.return_value = mock_iam_client
 
         with (
             patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
@@ -224,6 +249,17 @@ class TestLaunchBedrockAgentCore:
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
 
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
         with (
             patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
             patch(
@@ -267,9 +303,560 @@ class TestLaunchBedrockAgentCore:
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
 
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
         with patch(
             "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
             return_value=mock_container_runtime,
         ):
             with pytest.raises(ValueError, match="ECR repository not configured"):
                 launch_bedrock_agentcore(config_path, local=False)
+
+    def test_launch_cloud_with_execution_role_auto_create(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test cloud deployment with execution role auto-creation."""
+        # Create config file with execution role auto-create enabled
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role_auto_create=True,  # Enable auto-creation
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Mock the build to return success
+        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        # Role name will use random suffix, so we can't predict the exact name
+        created_role_arn = "arn:aws:iam::123456789012:role/AmazonBedrockAgentCoreSDKRuntime-us-west-2-abc123xyz9"
+
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.get_or_create_runtime_execution_role"
+            ) as mock_get_or_create_role,
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+                return_value=mock_container_runtime,
+            ),
+        ):
+            mock_get_or_create_role.return_value = created_role_arn
+
+            result = launch_bedrock_agentcore(config_path, local=False)
+
+            # Verify execution role creation was called
+            mock_get_or_create_role.assert_called_once()
+
+            # Verify role creation parameters
+            call_args = mock_get_or_create_role.call_args
+            assert call_args.kwargs["region"] == "us-west-2"
+            assert call_args.kwargs["account_id"] == "123456789012"
+            assert call_args.kwargs["agent_name"] == "test-agent"
+
+            # Verify cloud deployment succeeded
+            assert result.mode == "cloud"
+            assert hasattr(result, "agent_arn")
+            assert hasattr(result, "agent_id")
+
+        # Verify the config was updated with the created role
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+
+        updated_config = load_config(config_path)
+        updated_agent = updated_config.agents["test-agent"]
+        assert updated_agent.aws.execution_role == created_role_arn
+        assert updated_agent.aws.execution_role_auto_create is False  # Should be disabled after creation
+
+    def test_launch_cloud_with_existing_execution_role(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test cloud deployment with existing execution role (no auto-creation)."""
+        existing_role_arn = "arn:aws:iam::123456789012:role/existing-test-role"
+
+        # Create config file with existing execution role
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role=existing_role_arn,
+                execution_role_auto_create=True,  # Should be ignored since role exists
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Mock the build to return success
+        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.get_or_create_runtime_execution_role"
+            ) as mock_create_role,
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+                return_value=mock_container_runtime,
+            ),
+        ):
+            result = launch_bedrock_agentcore(config_path, local=False)
+
+            # Verify execution role creation was NOT called (role already exists)
+            mock_create_role.assert_not_called()
+
+            # Verify cloud deployment succeeded
+            assert result.mode == "cloud"
+            assert hasattr(result, "agent_arn")
+            assert hasattr(result, "agent_id")
+
+        # Verify the config was not modified (role already existed)
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+
+        updated_config = load_config(config_path)
+        updated_agent = updated_config.agents["test-agent"]
+        assert updated_agent.aws.execution_role == existing_role_arn
+
+    def test_launch_missing_execution_role_no_auto_create(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test error when execution role not configured and auto-create disabled."""
+        # Create config file without execution role and auto-create disabled
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role_auto_create=False,  # No auto-create and no execution role
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Mock the build to return success
+        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+                return_value=mock_container_runtime,
+            ),
+        ):
+            with pytest.raises(ValueError, match="Missing 'aws.execution_role' for cloud deployment"):
+                launch_bedrock_agentcore(config_path, local=False)
+
+    def test_launch_cloud_conflict_exception_graceful_handling(
+        self, mock_boto3_clients, mock_container_runtime, tmp_path
+    ):
+        """Test graceful handling of ConflictException when agent already exists."""
+        # Create config file without agent_id (simulating first deployment after agent already exists)
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role="arn:aws:iam::123456789012:role/TestRole",
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),  # No agent_id set
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Mock the build to return success
+        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        # Mock ConflictException on create, then successful list and update
+        from botocore.exceptions import ClientError
+
+        conflict_error = ClientError(
+            error_response={"Error": {"Code": "ConflictException", "Message": "Agent already exists"}},
+            operation_name="CreateAgentRuntime",
+        )
+
+        # Mock the bedrock client to throw ConflictException on create_agent_runtime
+        mock_boto3_clients["bedrock_agentcore"].create_agent_runtime.side_effect = conflict_error
+
+        # Mock successful list_agent_runtimes to find existing agent
+        mock_boto3_clients["bedrock_agentcore"].list_agent_runtimes.return_value = {
+            "agentRuntimes": [
+                {
+                    "agentRuntimeId": "existing-agent-123",
+                    "agentRuntimeArn": (
+                        "arn:aws:bedrock-agentcore:us-west-2:123456789012:agent-runtime/existing-agent-123"
+                    ),
+                    "agentRuntimeName": "test-agent",
+                }
+            ]
+        }
+
+        # Mock successful update_agent_runtime
+        mock_boto3_clients["bedrock_agentcore"].update_agent_runtime.return_value = {
+            "agentRuntimeArn": "arn:aws:bedrock-agentcore:us-west-2:123456789012:agent-runtime/existing-agent-123"
+        }
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+                return_value=mock_container_runtime,
+            ),
+        ):
+            result = launch_bedrock_agentcore(config_path, local=False, auto_update_on_conflict=True)
+
+            # Verify that create was attempted first
+            mock_boto3_clients["bedrock_agentcore"].create_agent_runtime.assert_called_once()
+
+            # Verify that list was called to find existing agent
+            mock_boto3_clients["bedrock_agentcore"].list_agent_runtimes.assert_called()
+
+            # Verify that update was called instead of failing
+            mock_boto3_clients["bedrock_agentcore"].update_agent_runtime.assert_called_once()
+
+            # Verify successful deployment
+            assert result.mode == "cloud"
+            assert hasattr(result, "agent_arn")
+            assert hasattr(result, "agent_id")
+
+        # Verify the config was updated with the discovered agent ID
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+
+        updated_config = load_config(config_path)
+        updated_agent = updated_config.agents["test-agent"]
+        assert updated_agent.bedrock_agentcore.agent_id == "existing-agent-123"
+        assert (
+            updated_agent.bedrock_agentcore.agent_arn
+            == "arn:aws:bedrock-agentcore:us-west-2:123456789012:agent-runtime/existing-agent-123"
+        )
+
+    def test_launch_cloud_conflict_exception_disabled_auto_update(
+        self, mock_boto3_clients, mock_container_runtime, tmp_path
+    ):
+        """Test ConflictException when auto_update_on_conflict is disabled."""
+        # Create config file
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role="arn:aws:iam::123456789012:role/TestRole",
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Mock the build to return success
+        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        # Mock ConflictException on create
+        from botocore.exceptions import ClientError
+
+        conflict_error = ClientError(
+            error_response={"Error": {"Code": "ConflictException", "Message": "Agent already exists"}},
+            operation_name="CreateAgentRuntime",
+        )
+        mock_boto3_clients["bedrock_agentcore"].create_agent_runtime.side_effect = conflict_error
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+                return_value=mock_container_runtime,
+            ),
+        ):
+            # Should raise ConflictException when auto_update_on_conflict=False
+            with pytest.raises(ClientError, match="ConflictException"):
+                launch_bedrock_agentcore(config_path, local=False, auto_update_on_conflict=False)
+
+            # Verify that create was attempted but list/update were not called
+            mock_boto3_clients["bedrock_agentcore"].create_agent_runtime.assert_called_once()
+            mock_boto3_clients["bedrock_agentcore"].list_agent_runtimes.assert_not_called()
+            mock_boto3_clients["bedrock_agentcore"].update_agent_runtime.assert_not_called()
+
+
+class TestEnsureExecutionRole:
+    """Test _ensure_execution_role functionality."""
+
+    def test_ensure_execution_role_auto_create_success(self, mock_boto3_clients, tmp_path):
+        """Test successful execution role auto-creation."""
+        # Create agent config with auto-create enabled
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role_auto_create=True,
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+
+        # Create project config
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        save_config(project_config, config_path)
+
+        # Role name will use random suffix, so we can't predict the exact name
+        created_role_arn = "arn:aws:iam::123456789012:role/AmazonBedrockAgentCoreRuntimeSDKServiceRole-abc123xyz9"
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.get_or_create_runtime_execution_role"
+            ) as mock_get_or_create_role,
+            patch("bedrock_agentcore_starter_toolkit.operations.runtime.launch.save_config") as mock_save_config,
+        ):
+            mock_get_or_create_role.return_value = created_role_arn
+
+            result = _ensure_execution_role(
+                agent_config=agent_config,
+                project_config=project_config,
+                config_path=config_path,
+                agent_name="test-agent",
+                region="us-west-2",
+                account_id="123456789012",
+            )
+
+            # Verify role creation was called with correct parameters
+            call_args = mock_get_or_create_role.call_args
+            assert call_args.kwargs["region"] == "us-west-2"
+            assert call_args.kwargs["account_id"] == "123456789012"
+            assert call_args.kwargs["agent_name"] == "test-agent"
+            assert "logger" in call_args.kwargs
+
+            # Verify config was updated
+            assert agent_config.aws.execution_role == created_role_arn
+            assert agent_config.aws.execution_role_auto_create is False
+
+            # Verify config was saved
+            mock_save_config.assert_called_once_with(project_config, config_path)
+
+            # Verify return value
+            assert result == created_role_arn
+
+    def test_ensure_execution_role_existing_role_no_create(self, tmp_path):
+        """Test when execution role already exists (no auto-creation needed)."""
+        existing_role_arn = "arn:aws:iam::123456789012:role/existing-role"
+
+        # Create agent config with existing role
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role=existing_role_arn,
+                execution_role_auto_create=True,  # Should be ignored
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+
+        # Mock IAM client response for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.get_or_create_runtime_execution_role"
+            ) as mock_create_role,
+            patch("bedrock_agentcore_starter_toolkit.operations.runtime.launch.boto3.Session") as mock_session,
+        ):
+            mock_session.return_value.client.return_value = mock_iam_client
+
+            result = _ensure_execution_role(
+                agent_config=agent_config,
+                project_config=project_config,
+                config_path=config_path,
+                agent_name="test-agent",
+                region="us-west-2",
+                account_id="123456789012",
+            )
+
+            # Verify role creation was NOT called
+            mock_create_role.assert_not_called()
+
+            # Verify return value is existing role
+            assert result == existing_role_arn
+
+    def test_ensure_execution_role_no_role_no_auto_create(self, tmp_path):
+        """Test error when no execution role and auto-create disabled."""
+        # Create agent config without role and auto-create disabled
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role_auto_create=False,
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+
+        with pytest.raises(ValueError, match="Execution role not configured and auto-create not enabled"):
+            _ensure_execution_role(
+                agent_config=agent_config,
+                project_config=project_config,
+                config_path=config_path,
+                agent_name="test-agent",
+                region="us-west-2",
+                account_id="123456789012",
+            )
+
+    def test_ensure_execution_role_creation_failure(self, tmp_path):
+        """Test error handling when role creation fails."""
+        # Create agent config with auto-create enabled
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role_auto_create=True,
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+
+        with patch(
+            "bedrock_agentcore_starter_toolkit.operations.runtime.launch.get_or_create_runtime_execution_role"
+        ) as mock_get_or_create_role:
+            # Mock role creation failure
+            mock_get_or_create_role.side_effect = Exception("IAM permission denied")
+
+            with pytest.raises(Exception, match="IAM permission denied"):
+                _ensure_execution_role(
+                    agent_config=agent_config,
+                    project_config=project_config,
+                    config_path=config_path,
+                    agent_name="test-agent",
+                    region="us-west-2",
+                    account_id="123456789012",
+                )

--- a/tests/utils/runtime/test_policy_template.py
+++ b/tests/utils/runtime/test_policy_template.py
@@ -1,0 +1,140 @@
+"""Test policy template utilities."""
+
+import json
+
+import pytest
+
+from bedrock_agentcore_starter_toolkit.utils.runtime.policy_template import (
+    render_execution_policy_template,
+    render_trust_policy_template,
+    validate_rendered_policy,
+)
+
+
+class TestPolicyTemplate:
+    """Test policy template rendering."""
+
+    def test_render_trust_policy_template(self):
+        """Test rendering trust policy template."""
+        region = "us-east-1"
+        account_id = "123456789012"
+
+        result = render_trust_policy_template(region, account_id)
+
+        # Validate it's valid JSON
+        policy = json.loads(result)
+
+        # Check structure
+        assert policy["Version"] == "2012-10-17"
+        assert len(policy["Statement"]) == 1
+
+        statement = policy["Statement"][0]
+        assert statement["Effect"] == "Allow"
+        assert statement["Principal"]["Service"] == "bedrock-agentcore.amazonaws.com"
+        assert statement["Action"] == "sts:AssumeRole"
+
+        # Check substitutions
+        assert account_id in str(statement["Condition"])
+        assert region in str(statement["Condition"])
+
+    def test_render_execution_policy_template(self):
+        """Test rendering execution policy template."""
+        region = "us-west-2"
+        account_id = "123456789012"
+        agent_name = "test-agent"
+
+        result = render_execution_policy_template(region, account_id, agent_name)
+
+        # Validate it's valid JSON
+        policy = json.loads(result)
+
+        # Check structure
+        assert policy["Version"] == "2012-10-17"
+        assert len(policy["Statement"]) > 0
+
+        # Find specific statements
+        ecr_statement = next((s for s in policy["Statement"] if s.get("Sid") == "ECRImageAccess"), None)
+        assert ecr_statement is not None
+        assert "ecr:BatchGetImage" in ecr_statement["Action"]
+
+        bedrock_statement = next((s for s in policy["Statement"] if s.get("Sid") == "BedrockModelInvocation"), None)
+        assert bedrock_statement is not None
+        assert "bedrock:InvokeModel" in bedrock_statement["Action"]
+
+        # Check substitutions
+        policy_str = json.dumps(policy)
+        assert region in policy_str
+        assert account_id in policy_str
+        assert agent_name in policy_str
+
+    def test_validate_rendered_policy_valid(self):
+        """Test validating valid policy JSON."""
+        valid_policy = '{"Version": "2012-10-17", "Statement": []}'
+
+        result = validate_rendered_policy(valid_policy)
+
+        assert isinstance(result, dict)
+        assert result["Version"] == "2012-10-17"
+        assert result["Statement"] == []
+
+    def test_validate_rendered_policy_invalid(self):
+        """Test validating invalid policy JSON."""
+        invalid_policy = '{"Version": "2012-10-17", "Statement": [}'  # Missing closing bracket
+
+        with pytest.raises(ValueError, match="Invalid policy JSON"):
+            validate_rendered_policy(invalid_policy)
+
+    def test_template_files_exist(self):
+        """Test that template files exist in expected location."""
+        from bedrock_agentcore_starter_toolkit.utils.runtime.policy_template import _get_template_dir
+
+        template_dir = _get_template_dir()
+
+        trust_template = template_dir / "execution_role_trust_policy.json.j2"
+        execution_template = template_dir / "execution_role_policy.json.j2"
+
+        assert trust_template.exists(), f"Trust policy template not found at {trust_template}"
+        assert execution_template.exists(), f"Execution policy template not found at {execution_template}"
+
+    def test_policy_has_required_permissions(self):
+        """Test that the execution policy contains all required permissions."""
+        region = "us-east-1"
+        account_id = "123456789012"
+        agent_name = "test-agent"
+
+        result = render_execution_policy_template(region, account_id, agent_name)
+        policy = json.loads(result)
+
+        # Collect all actions from all statements
+        all_actions = []
+        for statement in policy["Statement"]:
+            actions = statement.get("Action", [])
+            if isinstance(actions, str):
+                all_actions.append(actions)
+            elif isinstance(actions, list):
+                all_actions.extend(actions)
+
+        # Check for required permissions from the original policy template
+        required_permissions = [
+            "ecr:BatchGetImage",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:GetAuthorizationToken",
+            "logs:DescribeLogStreams",
+            "logs:CreateLogGroup",
+            "logs:DescribeLogGroups",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+            "xray:PutTraceSegments",
+            "xray:PutTelemetryRecords",
+            "xray:GetSamplingRules",
+            "xray:GetSamplingTargets",
+            "cloudwatch:PutMetricData",
+            "bedrock-agentcore:GetWorkloadAccessToken",
+            "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+            "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
+            "bedrock:InvokeModel",
+            "bedrock:InvokeModelWithResponseStream",
+        ]
+
+        for permission in required_permissions:
+            assert permission in all_actions, f"Missing required permission: {permission}"

--- a/tests/utils/test_logging_config.py
+++ b/tests/utils/test_logging_config.py
@@ -1,0 +1,214 @@
+"""Tests for the centralized logging configuration module."""
+
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+
+from bedrock_agentcore_starter_toolkit.utils.logging_config import (
+    _setup_cli_logging,
+    _setup_sdk_logging,
+    is_logging_configured,
+    reset_logging_config,
+    setup_toolkit_logging,
+)
+
+
+class TestSetupToolkitLogging:
+    """Test the main setup_toolkit_logging function."""
+
+    def setup_method(self):
+        """Reset logging state before each test."""
+        reset_logging_config()
+        # Clear any existing handlers
+        toolkit_logger = logging.getLogger("bedrock_agentcore_starter_toolkit")
+        for handler in toolkit_logger.handlers[:]:
+            toolkit_logger.removeHandler(handler)
+        # Reset root logger handlers
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+
+    def test_setup_cli_mode(self):
+        """Test explicit CLI mode setup."""
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_cli_logging") as mock_cli:
+            setup_toolkit_logging(mode="cli")
+            mock_cli.assert_called_once()
+            assert is_logging_configured()
+
+    def test_setup_sdk_mode(self):
+        """Test explicit SDK mode setup."""
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_sdk_logging") as mock_sdk:
+            setup_toolkit_logging(mode="sdk")
+            mock_sdk.assert_called_once()
+            assert is_logging_configured()
+
+    def test_duplicate_setup_prevention(self):
+        """Test that duplicate setup calls are ignored."""
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_sdk_logging") as mock_sdk:
+            setup_toolkit_logging(mode="sdk")
+            setup_toolkit_logging(mode="sdk")  # Second call should be ignored
+            mock_sdk.assert_called_once()  # Should only be called once
+
+    def test_invalid_mode_raises_error(self):
+        """Test that invalid mode raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid logging mode: invalid"):
+            setup_toolkit_logging(mode="invalid")
+
+    def test_default_mode_is_sdk(self):
+        """Test that default mode is sdk."""
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_sdk_logging") as mock_sdk:
+            setup_toolkit_logging()  # No mode specified
+            mock_sdk.assert_called_once()
+
+
+class TestCliLoggingSetup:
+    """Test CLI logging setup functionality."""
+
+    def setup_method(self):
+        """Reset logging state before each test."""
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+
+    @patch("rich.logging.RichHandler")
+    @patch("bedrock_agentcore_starter_toolkit.cli.common.console")
+    def test_cli_logging_setup_with_rich(self, mock_console, mock_rich_handler):
+        """Test CLI logging setup with RichHandler."""
+        mock_handler = Mock()
+        mock_rich_handler.return_value = mock_handler
+
+        _setup_cli_logging()
+
+        mock_rich_handler.assert_called_once_with(
+            show_time=False, show_path=False, show_level=False, console=mock_console
+        )
+
+    @patch("rich.logging.RichHandler", side_effect=ImportError)
+    @patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_basic_logging")
+    def test_cli_logging_fallback_without_rich(self, mock_basic_logging, mock_rich_handler):
+        """Test CLI logging fallback when RichHandler is not available."""
+        _setup_cli_logging()
+        mock_basic_logging.assert_called_once()
+
+
+class TestSdkLoggingSetup:
+    """Test SDK logging setup functionality."""
+
+    def setup_method(self):
+        """Reset logging state before each test."""
+        toolkit_logger = logging.getLogger("bedrock_agentcore_starter_toolkit")
+        for handler in toolkit_logger.handlers[:]:
+            toolkit_logger.removeHandler(handler)
+
+    def test_sdk_logging_setup(self):
+        """Test SDK logging setup with StreamHandler."""
+        _setup_sdk_logging()
+
+        toolkit_logger = logging.getLogger("bedrock_agentcore_starter_toolkit")
+        assert len(toolkit_logger.handlers) == 1
+        assert isinstance(toolkit_logger.handlers[0], logging.StreamHandler)
+        assert toolkit_logger.level == logging.INFO
+
+    def test_sdk_logging_no_duplicate_handlers(self):
+        """Test that SDK logging doesn't add duplicate handlers."""
+        _setup_sdk_logging()
+        _setup_sdk_logging()  # Call again
+
+        toolkit_logger = logging.getLogger("bedrock_agentcore_starter_toolkit")
+        assert len(toolkit_logger.handlers) == 1
+
+
+class TestLoggingStateManagement:
+    """Test logging state management functions."""
+
+    def setup_method(self):
+        """Reset logging state before each test."""
+        reset_logging_config()
+
+    def test_is_logging_configured_initial_state(self):
+        """Test initial state of logging configuration."""
+        assert is_logging_configured() is False
+
+    def test_is_logging_configured_after_setup(self):
+        """Test logging configuration state after setup."""
+        setup_toolkit_logging(mode="sdk")
+        assert is_logging_configured() is True
+
+    def test_reset_logging_config(self):
+        """Test resetting logging configuration state."""
+        setup_toolkit_logging(mode="sdk")
+        assert is_logging_configured() is True
+
+        reset_logging_config()
+        assert is_logging_configured() is False
+
+
+class TestIntegrationScenarios:
+    """Test integration scenarios and edge cases."""
+
+    def setup_method(self):
+        """Reset logging state before each test."""
+        reset_logging_config()
+        # Clear any existing handlers
+        toolkit_logger = logging.getLogger("bedrock_agentcore_starter_toolkit")
+        for handler in toolkit_logger.handlers[:]:
+            toolkit_logger.removeHandler(handler)
+
+    def test_cli_then_sdk_no_duplication(self):
+        """Test that CLI setup prevents SDK setup from adding duplicate handlers."""
+        # First setup CLI
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_cli_logging"):
+            setup_toolkit_logging(mode="cli")
+
+        # Then try SDK setup - should be ignored due to _LOGGING_CONFIGURED flag
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_sdk_logging") as mock_sdk:
+            setup_toolkit_logging(mode="sdk")
+            mock_sdk.assert_not_called()
+
+    def test_sdk_then_cli_no_duplication(self):
+        """Test that SDK setup prevents CLI setup from adding duplicate handlers."""
+        # First setup SDK
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_sdk_logging"):
+            setup_toolkit_logging(mode="sdk")
+
+        # Then try CLI setup - should be ignored due to _LOGGING_CONFIGURED flag
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_cli_logging") as mock_cli:
+            setup_toolkit_logging(mode="cli")
+            mock_cli.assert_not_called()
+
+    def test_multiple_sdk_setups(self):
+        """Test multiple SDK setups don't cause issues."""
+        with patch("bedrock_agentcore_starter_toolkit.utils.logging_config._setup_sdk_logging") as mock_sdk:
+            setup_toolkit_logging()  # First SDK setup (default)
+            setup_toolkit_logging()  # Second SDK setup
+            setup_toolkit_logging()  # Third SDK setup
+
+            mock_sdk.assert_called_once()  # Should only be called once
+
+    def test_actual_logging_output_sdk(self, caplog):
+        """Test that actual logging output works correctly in SDK mode."""
+        reset_logging_config()
+        setup_toolkit_logging(mode="sdk")
+
+        # Get the toolkit logger and test actual logging
+        logger = logging.getLogger("bedrock_agentcore_starter_toolkit.test")
+
+        # Use caplog to capture log records
+        with caplog.at_level(logging.INFO, logger="bedrock_agentcore_starter_toolkit"):
+            logger.info("Test message")
+
+        # Check that the message was logged
+        assert "Test message" in caplog.text
+
+    def test_logger_hierarchy(self):
+        """Test that child loggers inherit the configuration."""
+        setup_toolkit_logging(mode="sdk")
+
+        # Test that child loggers work
+        child_logger = logging.getLogger("bedrock_agentcore_starter_toolkit.operations.test")
+        parent_logger = logging.getLogger("bedrock_agentcore_starter_toolkit")
+
+        # Child logger should inherit from parent
+        assert child_logger.parent == parent_logger
+        assert len(parent_logger.handlers) == 1

--- a/tests_integ/notebook/test_runtime.py
+++ b/tests_integ/notebook/test_runtime.py
@@ -3,11 +3,7 @@ if __name__ == "__main__":
 
     runtime = Runtime()
 
-    runtime.configure(
-        entrypoint="tests_integ/strands_agent/agent_example.py",
-        execution_role="arn:aws:iam::381492293490:role/Admin",  # replace with your own role
-        agent_name="agent_example_notebook_runtime",
-    )
+    runtime.configure(entrypoint="agent_example.py", agent_name="test14", auto_create_execution_role=True)
 
-    resp = runtime.launch(local=True)
+    resp = runtime.launch(use_codebuild=True, auto_update_on_conflict=True)
     print(resp)


### PR DESCRIPTION
Implement automatic creation of IAM execution role for Bedrock AgentCore Runtime.
This feature allows users to deploy without manually creating IAM roles first.

## Key changes
- Add policy templates for execution role and trust policy
- Implement role creation with proper permissions
- Update CLI to support auto-creation option
- Add comprehensive tests for new functionality
- Add detailed logging for better visibility during role creation
- Include informative messages for common error scenarios

🤖 Assisted by [Amazon Q Developer](https://aws.amazon.com/q/developer)