### PR TITLE
fix: add UTF-8 encoding to subprocess calls for Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ requirements.txt
 documentation/site
 documentation/.cache
 .agentcore.yaml
+.idea/

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
@@ -285,7 +285,11 @@ class ContainerRuntime:
     def _execute_command(self, cmd: List[str]) -> Tuple[bool, List[str]]:
         """Execute command and capture output."""
         try:
-            process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)  # nosec B603
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True, encoding="utf-8", bufsize=1
+            )  # nosec B603
 
             output_lines = []
             if process.stdout:


### PR DESCRIPTION
## Description
Fixes `UnicodeDecodeError` on Windows when running `agentcore launch` by explicitly specifying UTF-8 encoding in subprocess calls.

## Problem
On Windows, when `subprocess.Popen` is called with `text=True` but without explicit encoding, Python defaults to using the 'charmap' codec (cp1252) which cannot handle UTF-8 bytes. This causes UnicodeDecodeError when Docker or other subprocesses output non-ASCII characters.

## Solution
Add `encoding='utf-8'` parameter to `subprocess.Popen` call in `util/runtime/container.py`.

## Changes Made
- Modified subprocess call in `bedrock_agentcore_starter_toolkit/utils/runtime/container.py` to include `encoding='utf-8'`

## Testing
- [x] Tested on Windows 11 with Python 3.13
- [x] Verified `agentcore launch` command works without encoding errors
- [x] Verified Python API calls to `agentcore_runtime.launch()` work correctly

## Related Issue
Closes #51 