### PR TITLE
fix: Windows path separators in Dockerfile and config generation

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
@@ -145,11 +145,14 @@ def configure_bedrock_agentcore(
         log.debug("Agent name from BedrockAgentCoreApp: %s", agent_name)
         log.debug("Config path: %s", config_path)
 
+    # Convert to POSIX for cross-platform compatibility
+    entrypoint_path = entrypoint_path.as_posix()
+
     # Determine entrypoint format
     if bedrock_agentcore_name:
-        entrypoint = f"{str(entrypoint_path)}:{bedrock_agentcore_name}"
+        entrypoint = f"{entrypoint_path}:{bedrock_agentcore_name}"
     else:
-        entrypoint = str(entrypoint_path)
+        entrypoint = entrypoint_path
 
     if verbose:
         log.debug("Using entrypoint format: %s", entrypoint)


### PR DESCRIPTION
## Description
Fixes #58 - Windows path separators cause Docker build failure and config issues when launching agents.

## Problem
On Windows, `str(path)` generates backslash separators (`\`) in generated `Dockerfile` and `.bedrock_agentcore.yaml` files. Docker containers expect Unix-style forward slashes (`/`), causing build failures and invalid paths.

## Root Cause
Multiple locations in the code use `str(path)` instead of `path.as_posix()`, preserving Windows-specific path separators that break cross-platform compatibility.

## Solution
Replace relevant instances of `str(path)` with `path.as_posix()` ensure forward slashes are used in generated files regardless of host OS.

## Testing
- New tests verify Paths convert to POSIX format where applicable
- Existing tests continue to pass
- Manual verification confirms Docker builds now succeed on Windows
