### PR TITLE
fix custom overrides handling in s3 zip logic in code build

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/services/codebuild.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/codebuild.py
@@ -291,18 +291,19 @@ phases:
         if path.startswith("./"):
             path = path[2:]
 
+        should_ignore = False  # Default state: don't ignore
+
         for pattern in patterns:
             # Handle negation patterns
             if pattern.startswith("!"):
                 if self._matches_pattern(path, pattern[1:], is_dir):
-                    return False
-                continue
+                    should_ignore = False  # Negation pattern: don't ignore
+            else:
+                # Regular ignore patterns
+                if self._matches_pattern(path, pattern, is_dir):
+                    should_ignore = True  # Regular pattern: ignore
 
-            # Regular ignore patterns
-            if self._matches_pattern(path, pattern, is_dir):
-                return True
-
-        return False
+        return should_ignore
 
     def _matches_pattern(self, path: str, pattern: str, is_dir: bool) -> bool:
         """Check if path matches a dockerignore pattern."""

--- a/tests/operations/runtime/test_create_role.py
+++ b/tests/operations/runtime/test_create_role.py
@@ -10,6 +10,9 @@ from botocore.exceptions import ClientError
 
 from bedrock_agentcore_starter_toolkit.operations.runtime.create_role import (
     _attach_inline_policy,
+    _create_iam_role_with_policies,
+    _generate_deterministic_suffix,
+    get_or_create_codebuild_execution_role,
     get_or_create_runtime_execution_role,
 )
 
@@ -232,3 +235,331 @@ class TestCreateRole:
 
         mock_iam.put_role_policy.assert_called_once()
         mock_logger.error.assert_called()
+
+    def test_generate_deterministic_suffix(self):
+        """Test deterministic suffix generation."""
+        # Test deterministic behavior - same input should produce same output
+        suffix1 = _generate_deterministic_suffix("test-agent")
+        suffix2 = _generate_deterministic_suffix("test-agent")
+        assert suffix1 == suffix2
+        assert len(suffix1) == 10
+        assert suffix1.islower()
+        assert suffix1.isalnum()
+
+        # Test different inputs produce different outputs
+        suffix_a = _generate_deterministic_suffix("agent-a")
+        suffix_b = _generate_deterministic_suffix("agent-b")
+        assert suffix_a != suffix_b
+
+        # Test custom length
+        suffix_short = _generate_deterministic_suffix("test", length=5)
+        assert len(suffix_short) == 5
+
+        # Test empty string
+        suffix_empty = _generate_deterministic_suffix("")
+        assert len(suffix_empty) == 10
+
+    def test_create_iam_role_with_policies_success(self, mock_session, mock_logger):
+        """Test successful role creation with policies."""
+        session, mock_iam = mock_session
+
+        mock_iam.create_role.return_value = {"Role": {"Arn": "arn:aws:iam::123456789012:role/TestRole"}}
+
+        trust_policy = {"Version": "2012-10-17", "Statement": []}
+        inline_policies = {
+            "Policy1": {"Version": "2012-10-17", "Statement": []},
+            "Policy2": '{"Version": "2012-10-17", "Statement": []}',
+        }
+
+        with patch(
+            "bedrock_agentcore_starter_toolkit.operations.runtime.create_role._attach_inline_policy"
+        ) as mock_attach:
+            result = _create_iam_role_with_policies(
+                session=session,
+                logger=mock_logger,
+                role_name="TestRole",
+                trust_policy=trust_policy,
+                inline_policies=inline_policies,
+                description="Test role description",
+            )
+
+            assert result == "arn:aws:iam::123456789012:role/TestRole"
+            mock_iam.create_role.assert_called_once_with(
+                RoleName="TestRole",
+                AssumeRolePolicyDocument=json.dumps(trust_policy),
+                Description="Test role description",
+            )
+            assert mock_attach.call_count == 2
+
+    def test_create_iam_role_with_policies_already_exists(self, mock_session, mock_logger):
+        """Test role creation when role already exists."""
+        session, mock_iam = mock_session
+
+        # Mock role creation failure (already exists)
+        error_response = {"Error": {"Code": "EntityAlreadyExists"}}
+        mock_iam.create_role.side_effect = ClientError(error_response, "CreateRole")
+
+        # Mock get_role success
+        mock_iam.get_role.return_value = {"Role": {"Arn": "arn:aws:iam::123456789012:role/ExistingRole"}}
+
+        trust_policy = {"Version": "2012-10-17", "Statement": []}
+        inline_policies = {"Policy1": {"Version": "2012-10-17", "Statement": []}}
+
+        with patch(
+            "bedrock_agentcore_starter_toolkit.operations.runtime.create_role._attach_inline_policy"
+        ) as mock_attach:
+            result = _create_iam_role_with_policies(
+                session=session,
+                logger=mock_logger,
+                role_name="ExistingRole",
+                trust_policy=trust_policy,
+                inline_policies=inline_policies,
+                description="Test role description",
+            )
+
+            assert result == "arn:aws:iam::123456789012:role/ExistingRole"
+            mock_iam.create_role.assert_called_once()
+            mock_iam.get_role.assert_called_once_with(RoleName="ExistingRole")
+            mock_attach.assert_called_once()  # Should update existing policies
+
+    def test_create_iam_role_with_policies_get_existing_error(self, mock_session, mock_logger):
+        """Test error when getting existing role after EntityAlreadyExists."""
+        session, mock_iam = mock_session
+
+        # Mock role creation failure (already exists)
+        error_response = {"Error": {"Code": "EntityAlreadyExists"}}
+        mock_iam.create_role.side_effect = ClientError(error_response, "CreateRole")
+
+        # Mock get_role failure
+        error_response_get = {"Error": {"Code": "AccessDenied"}}
+        mock_iam.get_role.side_effect = ClientError(error_response_get, "GetRole")
+
+        trust_policy = {"Version": "2012-10-17", "Statement": []}
+        inline_policies = {"Policy1": {"Version": "2012-10-17", "Statement": []}}
+
+        with pytest.raises(RuntimeError, match="Failed to get existing role"):
+            _create_iam_role_with_policies(
+                session=session,
+                logger=mock_logger,
+                role_name="TestRole",
+                trust_policy=trust_policy,
+                inline_policies=inline_policies,
+                description="Test role description",
+            )
+
+    def test_create_iam_role_with_policies_access_denied(self, mock_session, mock_logger):
+        """Test AccessDenied error during role creation."""
+        session, mock_iam = mock_session
+
+        error_response = {"Error": {"Code": "AccessDenied"}}
+        mock_iam.create_role.side_effect = ClientError(error_response, "CreateRole")
+
+        trust_policy = {"Version": "2012-10-17", "Statement": []}
+        inline_policies = {"Policy1": {"Version": "2012-10-17", "Statement": []}}
+
+        with pytest.raises(RuntimeError, match="Failed to create role"):
+            _create_iam_role_with_policies(
+                session=session,
+                logger=mock_logger,
+                role_name="TestRole",
+                trust_policy=trust_policy,
+                inline_policies=inline_policies,
+                description="Test role description",
+            )
+
+        mock_logger.error.assert_called()
+
+    def test_create_iam_role_with_policies_limit_exceeded(self, mock_session, mock_logger):
+        """Test LimitExceeded error during role creation."""
+        session, mock_iam = mock_session
+
+        error_response = {"Error": {"Code": "LimitExceeded"}}
+        mock_iam.create_role.side_effect = ClientError(error_response, "CreateRole")
+
+        trust_policy = {"Version": "2012-10-17", "Statement": []}
+        inline_policies = {"Policy1": {"Version": "2012-10-17", "Statement": []}}
+
+        with pytest.raises(RuntimeError, match="Failed to create role"):
+            _create_iam_role_with_policies(
+                session=session,
+                logger=mock_logger,
+                role_name="TestRole",
+                trust_policy=trust_policy,
+                inline_policies=inline_policies,
+                description="Test role description",
+            )
+
+        mock_logger.error.assert_called()
+
+    def test_get_or_create_codebuild_execution_role_success(self, mock_session, mock_logger):
+        """Test successful CodeBuild role creation."""
+        session, mock_iam = mock_session
+
+        # First call (check if exists) - role doesn't exist
+        error_response = {"Error": {"Code": "NoSuchEntity"}}
+        mock_iam.get_role.side_effect = ClientError(error_response, "GetRole")
+
+        with patch(
+            "bedrock_agentcore_starter_toolkit.operations.runtime.create_role._create_iam_role_with_policies"
+        ) as mock_create:
+            mock_create.return_value = "arn:aws:iam::123456789012:role/CodeBuildRole"
+
+            with patch("time.sleep"):  # Mock sleep for IAM propagation
+                result = get_or_create_codebuild_execution_role(
+                    session=session,
+                    logger=mock_logger,
+                    region="us-west-2",
+                    account_id="123456789012",
+                    agent_name="test-agent",
+                    ecr_repository_arn="arn:aws:ecr:us-west-2:123456789012:repository/test-repo",
+                    source_bucket_name="test-bucket",
+                )
+
+            assert result == "arn:aws:iam::123456789012:role/CodeBuildRole"
+            mock_iam.get_role.assert_called_once()
+            mock_create.assert_called_once()
+
+            # Verify correct trust policy and permissions were passed
+            call_args = mock_create.call_args
+            trust_policy = call_args[1]["trust_policy"]
+            assert trust_policy["Statement"][0]["Principal"]["Service"] == "codebuild.amazonaws.com"
+
+            inline_policies = call_args[1]["inline_policies"]
+            permissions_policy = inline_policies["CodeBuildExecutionPolicy"]
+            assert "ecr:GetAuthorizationToken" in str(permissions_policy)
+            assert "arn:aws:ecr:us-west-2:123456789012:repository/test-repo" in str(permissions_policy)
+
+    def test_get_or_create_codebuild_execution_role_already_exists(self, mock_session, mock_logger):
+        """Test getting existing CodeBuild role."""
+        session, mock_iam = mock_session
+
+        mock_iam.get_role.return_value = {"Role": {"Arn": "arn:aws:iam::123456789012:role/ExistingCodeBuildRole"}}
+
+        result = get_or_create_codebuild_execution_role(
+            session=session,
+            logger=mock_logger,
+            region="us-west-2",
+            account_id="123456789012",
+            agent_name="test-agent",
+            ecr_repository_arn="arn:aws:ecr:us-west-2:123456789012:repository/test-repo",
+            source_bucket_name="test-bucket",
+        )
+
+        assert result == "arn:aws:iam::123456789012:role/ExistingCodeBuildRole"
+        mock_iam.get_role.assert_called_once()
+
+    def test_get_or_create_codebuild_execution_role_check_error(self, mock_session, mock_logger):
+        """Test error when checking CodeBuild role existence."""
+        session, mock_iam = mock_session
+
+        error_response = {"Error": {"Code": "AccessDenied"}}
+        mock_iam.get_role.side_effect = ClientError(error_response, "GetRole")
+
+        with pytest.raises(RuntimeError, match="Failed to check CodeBuild role existence"):
+            get_or_create_codebuild_execution_role(
+                session=session,
+                logger=mock_logger,
+                region="us-west-2",
+                account_id="123456789012",
+                agent_name="test-agent",
+                ecr_repository_arn="arn:aws:ecr:us-west-2:123456789012:repository/test-repo",
+                source_bucket_name="test-bucket",
+            )
+
+    def test_attach_inline_policy_limit_exceeded_error(self, mock_session, mock_logger):
+        """Test LimitExceeded error during policy attachment."""
+        _, mock_iam = mock_session
+
+        error_response = {"Error": {"Code": "LimitExceeded"}}
+        mock_iam.put_role_policy.side_effect = ClientError(error_response, "PutRolePolicy")
+
+        with pytest.raises(RuntimeError, match="Failed to attach policy"):
+            _attach_inline_policy(
+                iam_client=mock_iam,
+                role_name="TestRole",
+                policy_name="TestPolicy",
+                policy_document='{"Version": "2012-10-17", "Statement": []}',
+                logger=mock_logger,
+            )
+
+        mock_logger.error.assert_called()
+
+    def test_get_or_create_runtime_execution_role_entity_already_exists_during_creation(
+        self, mock_session, mock_logger
+    ):
+        """Test EntityAlreadyExists during runtime role creation."""
+        session, mock_iam = mock_session
+
+        # First call (check if exists) - role doesn't exist
+        error_response = {"Error": {"Code": "NoSuchEntity"}}
+        mock_iam.get_role.side_effect = [
+            ClientError(error_response, "GetRole"),  # First call fails
+            {"Role": {"Arn": "arn:aws:iam::123456789012:role/ExistingRole"}},  # Second call succeeds
+        ]
+
+        # Role creation fails with EntityAlreadyExists
+        error_response_create = {"Error": {"Code": "EntityAlreadyExists"}}
+        mock_iam.create_role.side_effect = ClientError(error_response_create, "CreateRole")
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_trust_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_execution_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.validate_rendered_policy",
+                return_value={"Version": "2012-10-17", "Statement": []},
+            ),
+        ):
+            result = get_or_create_runtime_execution_role(
+                session=session,
+                logger=mock_logger,
+                region="us-east-1",
+                account_id="123456789012",
+                agent_name="test-agent",
+            )
+
+            assert result == "arn:aws:iam::123456789012:role/ExistingRole"
+            mock_iam.create_role.assert_called_once()
+            assert mock_iam.get_role.call_count == 2
+
+    def test_get_or_create_runtime_execution_role_limit_exceeded_error(self, mock_session, mock_logger):
+        """Test LimitExceeded error during runtime role creation."""
+        session, mock_iam = mock_session
+
+        # First call (check if exists) - role doesn't exist
+        error_response = {"Error": {"Code": "NoSuchEntity"}}
+        mock_iam.get_role.side_effect = ClientError(error_response, "GetRole")
+
+        # Role creation fails with LimitExceeded
+        error_response_create = {"Error": {"Code": "LimitExceeded"}}
+        mock_iam.create_role.side_effect = ClientError(error_response_create, "CreateRole")
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_trust_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.render_execution_policy_template",
+                return_value='{"Version": "2012-10-17", "Statement": []}',
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.create_role.validate_rendered_policy",
+                return_value={"Version": "2012-10-17", "Statement": []},
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to create role"):
+                get_or_create_runtime_execution_role(
+                    session=session,
+                    logger=mock_logger,
+                    region="us-east-1",
+                    account_id="123456789012",
+                    agent_name="test-agent",
+                )
+
+            mock_logger.error.assert_called()


### PR DESCRIPTION
```
(bedrock-agentcore-starter-toolkit) siwabhi@7cf34dd64d09 bedrock-agentcore-starter-toolkit % uv run agentcore launch -cb                                                                
Launching Bedrock AgentCore (codebuild mode)...

Starting CodeBuild ARM64 deployment for agent 'sdk_prod_demo_4' to account 864899855746 (us-west-2)
Setting up AWS resources (ECR repository, execution roles)...
Using ECR repository from config: 864899855746.dkr.ecr.us-west-2.amazonaws.com/bedrock-agentcore-sdk_prod_demo_4
Using execution role from config: arn:aws:iam::864899855746:role/AmazonBedrockAgentCoreSDKRuntime-us-west-2-8242cbe2c1
⠧ Launching Bedrock AgentCore...✅ Execution role validation passed: arn:aws:iam::864899855746:role/AmazonBedrockAgentCoreSDKRuntime-us-west-2-8242cbe2c1
Preparing CodeBuild project and uploading source...
⠏ Launching Bedrock AgentCore...Getting or creating CodeBuild execution role for agent: sdk_prod_demo_4
Role name: AmazonBedrockAgentCoreSDKCodeBuild-us-west-2-8242cbe2c1
⠸ Launching Bedrock AgentCore...Reusing existing CodeBuild execution role: arn:aws:iam::864899855746:role/AmazonBedrockAgentCoreSDKCodeBuild-us-west-2-8242cbe2c1
⠧ Launching Bedrock AgentCore...Using .dockerignore with 44 patterns
⠋ Launching Bedrock AgentCore...Uploaded source to S3: sdk_prod_demo_4/20250722-150051.zip
⠙ Launching Bedrock AgentCore...Updated CodeBuild project: bedrock-agentcore-sdk_prod_demo_4-builder
Starting CodeBuild build (this may take several minutes)...
⠇ Launching Bedrock AgentCore...Starting CodeBuild monitoring...
⠹ Launching Bedrock AgentCore...🔄 QUEUED started (total: 0s)
⠋ Launching Bedrock AgentCore...✅ QUEUED completed in 5.4s
🔄 PROVISIONING started (total: 6s)
⠦ Launching Bedrock AgentCore...✅ PROVISIONING completed in 5.3s
🔄 PRE_BUILD started (total: 11s)
⠋ Launching Bedrock AgentCore...✅ PRE_BUILD completed in 10.7s
🔄 BUILD started (total: 22s)
⠧ Launching Bedrock AgentCore...✅ BUILD completed in 37.4s
🔄 POST_BUILD started (total: 59s)
⠼ Launching Bedrock AgentCore...✅ POST_BUILD completed in 5.4s
🔄 COMPLETED started (total: 65s)
✅ COMPLETED completed in 0.0s
🎉 CodeBuild completed successfully in 1m 4s
CodeBuild completed successfully
Deploying to Bedrock AgentCore...
⠋ Launching Bedrock AgentCore...✅ Agent created/updated: arn:aws:bedrock-agentcore:us-west-2:864899855746:runtime/sdk_prod_demo_4-bLDDYPD4JM
Polling for endpoint to be ready...
⠏ Launching Bedrock AgentCore...Agent endpoint: arn:aws:bedrock-agentcore:us-west-2:864899855746:runtime/sdk_prod_demo_4-bLDDYPD4JM/runtime-endpoint/DEFAULT
Deployment completed successfully - Agent: arn:aws:bedrock-agentcore:us-west-2:864899855746:runtime/sdk_prod_demo_4-bLDDYPD4JM
✓ CodeBuild completed: bedrock-agentcore-sdk_prod_demo_4-builder:53365e1a-1e21-4a7b-867c-ba48527d5eba
✓ ARM64 image pushed to ECR: 864899855746.dkr.ecr.us-west-2.amazonaws.com/bedrock-agentcore-sdk_prod_demo_4:latest
╭───────────────────────────────────────────────────────────────────────────────── CodeBuild Deployment Complete ─────────────────────────────────────────────────────────────────────────────────╮
│ CodeBuild ARM64 Deployment Successful!                                                                                                                                                          │
│                                                                                                                                                                                                 │
│ Agent Name: sdk_prod_demo_4                                                                                                                                                                     │
│ CodeBuild ID: bedrock-agentcore-sdk_prod_demo_4-builder:53365e1a-1e21-4a7b-867c-ba48527d5eba                                                                                                    │
│ Agent ARN: arn:aws:bedrock-agentcore:us-west-2:864899855746:runtime/sdk_prod_demo_4-bLDDYPD4JM                                                                                                  │
│ ECR URI: 864899855746.dkr.ecr.us-west-2.amazonaws.com/bedrock-agentcore-sdk_prod_demo_4:latest                                                                                                  │
│                                                                                                                                                                                                 │
│ ARM64 container deployed to Bedrock AgentCore.                                                                                                                                                  │
│                                                                                                                                                                                                 │
│ You can now check the status of your Bedrock AgentCore endpoint with:                                                                                                                           │
│ agentcore status                                                                                                                                                                                │
│                                                                                                                                                                                                 │
│ You can now invoke your Bedrock AgentCore endpoint with:                                                                                                                                        │
│ agentcore invoke '{"prompt": "Hello"}'                                                                                                                                                          │
│                                                                                                                                                                                                 │
│ 📋 Agent logs available at:                                                                                                                                                                     │
│    /aws/bedrock-agentcore/runtimes/sdk_prod_demo_4-bLDDYPD4JM-DEFAULT                                                                                                                           │
│    /aws/bedrock-agentcore/runtimes/sdk_prod_demo_4-bLDDYPD4JM-DEFAULT/runtime-logs                                                                                                              │
│                                                                                                                                                                                                 │
│ 💡 Tail logs with:                                                                                                                                                                              │
│    aws logs tail /aws/bedrock-agentcore/runtimes/sdk_prod_demo_4-bLDDYPD4JM-DEFAULT --follow                                                                                                    │
│    aws logs tail /aws/bedrock-agentcore/runtimes/sdk_prod_demo_4-bLDDYPD4JM-DEFAULT --since 1h                                                                                                  │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```