### PR TITLE
fix #65: handle S3 bucket creation for us-east-1 region without Location Constraint

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/services/codebuild.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/codebuild.py
@@ -43,7 +43,13 @@ class CodeBuildService:
         except ClientError:
             # Create bucket
             region = self.session.region_name
-            self.s3_client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region})
+            if region == "us-east-1":
+                self.s3_client.create_bucket(Bucket=bucket_name)
+            else:
+                self.s3_client.create_bucket(
+                    Bucket=bucket_name,
+                    CreateBucketConfiguration={"LocationConstraint": region}
+                )
 
             # Set lifecycle to cleanup old builds
             self.s3_client.put_bucket_lifecycle_configuration(

--- a/tests/services/test_codebuild.py
+++ b/tests/services/test_codebuild.py
@@ -115,8 +115,7 @@ class TestCodeBuildService:
 
         # Should not specify LocationConstraint for us-east-1
         mock_clients["s3"].create_bucket.assert_called_once_with(
-            Bucket="bedrock-agentcore-codebuild-sources-123456789012-us-east-1",
-            CreateBucketConfiguration={"LocationConstraint": "us-east-1"},
+            Bucket="bedrock-agentcore-codebuild-sources-123456789012-us-east-1"
         )
 
     @patch("os.walk")


### PR DESCRIPTION
## Description

Fix #65 S3 bucket creation failure in us-east-1 region during CodeBuild launch. The issue was caused by incorrectly specifying LocationConstraint parameter for us-east-1, which is the default S3 region and does not accept this parameter. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A
