### PR TITLE
feat: Add Unicode support for JSON serialization in CLI and operations

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -484,7 +484,14 @@ def invoke(
 
         # Display payload
         console.print("[bold]Payload:[/bold]")
-        console.print(Syntax(json.dumps(payload_data, indent=2), "json", background_color="default", word_wrap=True))
+        console.print(
+            Syntax(
+                json.dumps(payload_data, indent=2, ensure_ascii=False),
+                "json",
+                background_color="default",
+                word_wrap=True,
+            )
+        )
 
         # Invoke
         result = invoke_bedrock_agentcore(
@@ -500,7 +507,10 @@ def invoke(
         console.print("\n[bold]Response:[/bold]")
         console.print(
             Syntax(
-                json.dumps(result.response, indent=2, default=str), "json", background_color="default", word_wrap=True
+                json.dumps(result.response, indent=2, default=str, ensure_ascii=False),
+                "json",
+                background_color="default",
+                word_wrap=True,
             )
         )
 
@@ -639,7 +649,10 @@ def status(
         else:  # full json verbose output
             console.print(
                 Syntax(
-                    json.dumps(status_json, indent=2, default=str), "json", background_color="default", word_wrap=True
+                    json.dumps(status_json, indent=2, default=str, ensure_ascii=False),
+                    "json",
+                    background_color="default",
+                    word_wrap=True,
                 )
             )
 

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/invoke.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/invoke.py
@@ -53,7 +53,7 @@ def invoke_bedrock_agentcore(
 
     # Convert payload to string if needed
     if isinstance(payload, dict):
-        payload_str = json.dumps(payload)
+        payload_str = json.dumps(payload, ensure_ascii=False)
     else:
         payload_str = str(payload)
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive Unicode support to the Bedrock AgentCore Starter Toolkit by ensuring proper JSON serialization and display of Unicode characters in CLI commands and operations.

## Changes

### Core Functionality
- **JSON Serialization**: Added `ensure_ascii=False` parameter to all `json.dumps()` calls in CLI commands and invoke operations
- **Unicode Display**: Ensured proper display of Unicode characters in payload and response output in the CLI
- **Cross-platform Support**: Unicode handling works consistently across different platforms and terminals

### Files Modified
- `src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py`: Updated JSON serialization in invoke and status commands
- `src/bedrock_agentcore_starter_toolkit/operations/runtime/invoke.py`: Updated payload serialization for invoke operations
- `tests/cli/runtime/test_commands.py`: Added comprehensive Unicode test coverage
- `tests/notebook/runtime/test_bedrock_agentcore.py`: Added Unicode tests for notebook runtime

### Test Coverage
Added extensive test coverage for Unicode handling including:
- Unicode characters in payloads and responses (Chinese, Hindi, Arabic, Russian, Japanese)
- Emoji support including composite emoji sequences
- Mixed Unicode and ASCII content
- Edge cases: RTL text, combining characters, zero-width spaces, high Unicode points
- Proper serialization and deserialization of Unicode data

## Testing

All tests pass including:
- Existing functionality remains unchanged
- New Unicode test cases cover various scenarios
- Pre-commit hooks pass (formatting, linting, security checks)
- Code coverage maintained at required levels

## Benefits

- **Better User Experience**: Users can now input and receive Unicode text without encoding issues
- **International Support**: Proper support for non-English languages and special characters
- **Emoji Support**: Full support for emoji in agent interactions
- **Developer Friendly**: Consistent Unicode handling across CLI and programmatic interfaces

## Backward Compatibility

This change is fully backward compatible. Existing ASCII-only usage continues to work exactly as before, while Unicode content now displays properly instead of being escaped.

🤖 Assisted by Amazon Q Developer