### PR TITLE
feat: make CodeBuild the default launch option with improved UX

### DIFF
--- a/documentation/docs/user-guide/runtime/overview.md
+++ b/documentation/docs/user-guide/runtime/overview.md
@@ -1,87 +1,8 @@
 # AgentCore Runtime SDK Overview
 
-The Amazon Bedrock AgentCore Runtime SDK transforms your Python functions into production-ready AI agents that can be deployed, scaled, and managed in the cloud. At its core, the SDK provides `BedrockAgentCoreApp` - a powerful HTTP service wrapper that handles all the complexity of agent deployment while letting you focus on your agent's logic.
+The Amazon Bedrock AgentCore Runtime SDK transforms your Python functions into production-ready AI agents with built-in HTTP service wrapper, session management, and complete deployment workflows.
 
-## What is the AgentCore Runtime SDK?
-
-The Runtime SDK is a comprehensive Python framework that bridges the gap between your AI agent code and Amazon Bedrock AgentCore's managed infrastructure. It provides HTTP service wrapper, decorator-based programming, session management, authentication integration, streaming support, async task management, and complete local development tools.
-
-## Core SDK Components
-
-### BedrockAgentCoreApp: The Foundation
-
-`BedrockAgentCoreApp` extends Starlette to provide an agent-optimized web server with built-in endpoints:
-
-- **`/invocations`** - Main endpoint for processing agent requests
-- **`/ping`** - Health check endpoint with status reporting
-- **Built-in logging** - Request tracking with correlation IDs
-- **Error handling** - Automatic error formatting and status codes
-- **Concurrency control** - Request limiting and thread pool management
-
-```python
-from bedrock_agentcore import BedrockAgentCoreApp
-
-# Initialize with optional debug mode
-app = BedrockAgentCoreApp(debug=True)
-```
-
-### Core Decorators
-
-The SDK uses a decorator-based approach that makes agent development intuitive:
-
-#### @app.entrypoint - Main Agent Function
-
-The fundamental decorator that registers your primary agent logic:
-
-```python
-@app.entrypoint
-def invoke(payload):
-    """Process requests synchronously"""
-    user_message = payload.get("prompt", "Hello")
-    # Your agent logic here
-    return {"result": "Response"}
-
-# Async version for streaming
-@app.entrypoint
-async def invoke_async(payload):
-    """Process requests asynchronously with streaming"""
-    user_message = payload.get("prompt", "Hello")
-    # Can yield for streaming responses
-    yield {"chunk": "Partial response"}
-```
-
-#### @app.ping - Custom Health Checks
-
-Override default health status logic:
-
-```python
-from bedrock_agentcore.runtime.models import PingStatus
-
-@app.ping
-def custom_health():
-    """Custom health logic"""
-    if system_busy():
-        return PingStatus.HEALTHY_BUSY
-    return PingStatus.HEALTHY
-```
-
-#### @app.async_task - Background Processing
-
-Automatically track long-running operations:
-
-```python
-@app.async_task
-async def background_processing():
-    """Automatically tracked async task"""
-    await asyncio.sleep(30)  # Status becomes HEALTHY_BUSY
-    return "completed"       # Status returns to HEALTHY
-```
-
-## Agent Development Patterns
-
-### Synchronous Agents
-
-Perfect for quick, deterministic responses:
+## Quick Start
 
 ```python
 from bedrock_agentcore import BedrockAgentCoreApp
@@ -89,24 +10,78 @@ from bedrock_agentcore import BedrockAgentCoreApp
 app = BedrockAgentCoreApp()
 
 @app.entrypoint
-def simple_agent(payload):
-    """Basic request-response agent"""
-    prompt = payload.get("prompt", "")
-
-    # Simple processing logic
-    if "weather" in prompt.lower():
-        return {"result": "It's sunny today!"}
-
-    return {"result": f"You said: {prompt}"}
+def my_agent(payload):
+    return {"result": f"Hello {payload.get('name', 'World')}!"}
 
 if __name__ == "__main__":
     app.run()
 ```
 
+```bash
+# Configure and deploy your agent
+agentcore configure --entrypoint my_agent.py
+agentcore launch
+agentcore invoke '{"name": "Alice"}'
+```
+
+## What is the AgentCore Runtime SDK?
+
+The Runtime SDK is a comprehensive Python framework that bridges the gap between your AI agent code and Amazon Bedrock AgentCore's managed infrastructure. It provides HTTP service wrapper, decorator-based programming, session management, authentication integration, streaming support, async task management, and complete local development tools.
+
+## Core Components
+
+**BedrockAgentCoreApp** - HTTP service wrapper with:
+- `/invocations` endpoint for agent logic
+- `/ping` endpoint for health checks  
+- Built-in logging, error handling, and session management
+
+**Key Decorators:**
+- `@app.entrypoint` - Define your agent's main logic
+- `@app.ping` - Custom health checks
+- `@app.async_task` - Background processing
+
+## Deployment Modes
+
+### 🚀 Cloud Build (RECOMMENDED)
+```bash
+agentcore configure --entrypoint my_agent.py
+agentcore launch                    # Uses CodeBuild - no Docker needed
+```
+- **No Docker required** - builds in the cloud
+- **Production-ready** - standardized ARM64 containers
+- **Works everywhere** - SageMaker Notebooks, Cloud9, laptops
+
+### 💻 Local Development
+```bash
+agentcore launch --local           # Build and run locally
+```
+- **Fast iteration** - immediate feedback and debugging
+- **Requires:** Docker, Finch, or Podman
+
+### 🔧 Hybrid Build
+```bash
+agentcore launch --local-build     # Build locally, deploy to cloud
+```
+- **Custom builds** with cloud deployment
+- **Requires:** Docker, Finch, or Podman
+
+## Agent Development Patterns
+
+### Synchronous Agents
+```python
+from bedrock_agentcore import BedrockAgentCoreApp
+
+app = BedrockAgentCoreApp()
+
+@app.entrypoint
+def simple_agent(payload):
+    prompt = payload.get("prompt", "")
+    if "weather" in prompt.lower():
+        return {"result": "It's sunny today!"}
+    return {"result": f"You said: {prompt}"}
+```
+
 ### Streaming Agents
-
-For real-time, dynamic responses that build over time:
-
 ```python
 from strands import Agent
 from bedrock_agentcore import BedrockAgentCoreApp
@@ -138,12 +113,11 @@ if __name__ == "__main__":
 - **Real-time Processing**: Immediate response chunks as they're available
 
 ### Framework Integration
-
 The SDK works seamlessly with popular AI frameworks:
 
 **Strands Integration:**
 ```python
-from strands import Agent, tool
+from strands import Agent
 from bedrock_agentcore import BedrockAgentCoreApp
 
 agent = Agent(tools=[your_tools])
@@ -151,11 +125,9 @@ app = BedrockAgentCoreApp()
 
 @app.entrypoint
 def strands_agent(payload):
-    """Strands-powered agent"""
     result = agent(payload.get("prompt"))
     return {"result": result.message}
 ```
-
 **Custom Framework Integration:**
 ```python
 @app.entrypoint
@@ -170,7 +142,10 @@ async def custom_framework_agent(payload):
 
 ## Session Management
 
-The SDK provides built-in session handling for stateful conversations with automatic session creation and management, 15-minute timeout, cross-invocation context persistence, and complete session isolation for security:
+Built-in session handling with automatic creation, 15-minute timeout, and cross-invocation persistence:
+
+```python
+from bedrock_agentcore.runtime.context import RequestContext
 
 ```python
 from bedrock_agentcore.runtime.context import RequestContext
@@ -189,12 +164,15 @@ def session_aware_agent(payload, context: RequestContext):
 ```
 
 ```bash
+# CLI session management
 # Using AgentCore CLI with session management
 agentcore invoke '{"prompt": "Hello, remember this conversation"}' --session-id "conversation-123"
+
 agentcore invoke '{"prompt": "What did I say earlier?"}' --session-id "conversation-123"
 ```
 
-## Authentication and Authorization
+## Authentication & Authorization
+
 
 The SDK integrates with AgentCore's identity services providing automatic AWS credential validation (IAM SigV4) by default or JWT Bearer tokens for OAuth-compatible authentication:
 
@@ -206,129 +184,88 @@ agentcore configure --entrypoint my_agent.py \
 
 ## Asynchronous Processing
 
-For long-running operations, the SDK provides comprehensive async support with automatic task tracking that transitions agent status to HEALTHY_BUSY during processing, or fine-grained manual control:
+AgentCore Runtime supports asynchronous processing for long-running tasks. Your agent can start background work and immediately respond to users, with automatic health status management.
 
+### Key Features
+
+**Automatic Status Management:**
+- Agent status changes to "HealthyBusy" during background processing
+- Returns to "Healthy" when tasks complete
+- Sessions automatically terminate after 15 minutes of inactivity
+
+**Three Processing Approaches:**
+
+1. **Async Task Decorator (Recommended)**
 ```python
-# Automatic task tracking
 @app.async_task
-async def long_running_task():
-    """Automatically tracked - agent status becomes BUSY"""
-    await process_large_dataset()
-    return "completed"
+async def background_work():
+    await process_data()  # Status becomes "HealthyBusy"
+    return "done"
 
 @app.entrypoint
-async def start_processing(payload):
-    """Start background task"""
-    asyncio.create_task(long_running_task())
-    return {"status": "Processing started in background"}
-
-# Manual task management
-@app.entrypoint
-def manual_task_control(payload):
-    """Manual async task management"""
-    task_id = app.add_async_task("data_processing", {"batch_size": 1000})
-
-    def background_work():
-        time.sleep(60)
-        app.complete_async_task(task_id)
-
-    threading.Thread(target=background_work, daemon=True).start()
-    return {"task_id": task_id, "status": "started"}
+async def handler(event):
+    asyncio.create_task(background_work())
+    return {"status": "started"}
 ```
+
+2. **Manual Task Management**
+```python
+@app.entrypoint
+def handler(event):
+    task_id = app.add_async_task("data_processing", {"batch": 100})
+    
+    def background_work():
+        time.sleep(30)
+        app.complete_async_task(task_id)
+    
+    threading.Thread(target=background_work, daemon=True).start()
+    return {"task_id": task_id}
+```
+
+3. **Custom Ping Handler**
+```python
+@app.ping
+def custom_status():
+    if processing_data or system_busy():
+        return PingStatus.HEALTHY_BUSY
+    return PingStatus.HEALTHY
+```
+
+**Common Use Cases:**
+- Data processing that takes minutes or hours
+- File uploads and conversions
+- External API calls with retries
+- Batch operations and reports
+
+See the [Async Processing Guide](async.md) for detailed examples and testing strategies.
 
 ## Local Development
 
-The SDK provides a complete local development environment with debug mode for additional capabilities and comprehensive logging with automatic request correlation:
-
+### Debug Mode
 ```python
-# Development server with debug mode
-app = BedrockAgentCoreApp(debug=True)
+app = BedrockAgentCoreApp(debug=True)  # Enhanced logging
 
 if __name__ == "__main__":
-    app.run()  # Default port 8080, auto-detects Docker vs local
-
-# Custom logging
-import logging
-logger = logging.getLogger("my_agent")
-
-@app.entrypoint
-def my_agent(payload):
-    logger.info("Processing request: %s", payload)
-    # Your logic here
+    app.run()  # Auto-detects Docker vs local
 ```
 
+### Complete Development Workflow
 ```bash
-# Configure and test locally using AgentCore CLI
-agentcore configure --entrypoint my_agent.py --name my-agent
+# 1. Configure
+agentcore configure --entrypoint my_agent.py
+
+# 2. Develop locally
 agentcore launch --local
-agentcore invoke '{"prompt": "Hello world"}'
-agentcore invoke '{"prompt": "Remember this"}' --session-id "test-session"
-agentcore invoke '{"prompt": "Hello"}' --bearer-token "your-jwt-token"
-```
 
-## Launch
+# 3. Test
+agentcore invoke '{"prompt": "Hello"}'
+agentcore invoke '{"prompt": "Remember this"}' --session-id "test"
 
-The AgentCore Runtime SDK provides flexible deployment options to accommodate different development environments:
-
-### Development Environment Recommendations
-
-#### ✅ Recommended: CodeBuild Deployment (Default)
-```bash
-# Default deployment method (no flags needed)
+# 4. Deploy to cloud
 agentcore launch
+
+# 5. Monitor
+agentcore status
 ```
 
-**Benefits:**
-- **No Docker installation required** - builds ARM64 containers in the cloud
-- **Zero local setup** - just AWS credentials needed
-- **Consistent builds** - standardized ARM64 environment
-- **Perfect for managed environments** - works in environment sucah SageMaker Notebooks
-- **Integrated with AWS services** - seamless ECR and AgentCore integration
-
-#### Local Development & Testing
-**Perfect for:** Local development, rapid iteration, debugging
-
-```bash
-# Local development (runs locally, requires Docker/Finch/Podman)
-agentcore launch --local
-```
-
-**Benefits:**
-- Full local testing capabilities
-- Immediate feedback during development
-- Complete control over build environment
-- **Note:** Requires Docker/Finch/Podman installation
-
-### Deployment Modes
-
-#### CodeBuild Cloud Deployment (Default)
-- ✅ **Recommended approach**
-- Uses AWS CodeBuild for ARM64 container builds
-- **No local Docker required**
-- Pushes to ECR and deploys to AgentCore
-
-```bash
-# Default deployment (CodeBuild in the cloud)
-agentcore launch
-```
-
-#### Local Build Cloud Deployment
-- Uses local Docker for container builds
-- Pushes ARM64 images to ECR
-- Deploys to Bedrock AgentCore
-- **Requires Docker/Finch/Podman installed**
-
-```bash
-# Local Docker build deployment (requires Docker/Finch/Podman)
-agentcore launch --local-build
-```
-
-#### ECR Push Only
-- Builds and pushes to ECR without deployment
-- Useful manual deployment workflows
-- Can use either CodeBuild (default) or local Docker (`--local-build`)
-
-```bash
-agentcore launch --push-ecr        # Uses CodeBuild (default)
-agentcore launch --push-ecr --local-build  # Uses local Docker
-```
+The AgentCore Runtime SDK provides everything needed to build, test, and deploy production-ready AI agents with minimal setup and maximum flexibility.

--- a/documentation/docs/user-guide/runtime/overview.md
+++ b/documentation/docs/user-guide/runtime/overview.md
@@ -266,32 +266,30 @@ agentcore invoke '{"prompt": "Remember this"}' --session-id "test-session"
 agentcore invoke '{"prompt": "Hello"}' --bearer-token "your-jwt-token"
 ```
 
-## Deployment Options
+## Launch
 
 The AgentCore Runtime SDK provides flexible deployment options to accommodate different development environments:
 
 ### Development Environment Recommendations
 
-#### SageMaker Notebooks & Cloud Environments
-For cloud-based development environments like SageMaker notebooks, Cloud9, or other managed environments:
-
+#### ✅ Recommended: CodeBuild Deployment (Default)
 ```bash
-# Recommended deployment method
-agentcore launch --codebuild
+# Default deployment method (no flags needed)
+agentcore launch
 ```
 
 **Benefits:**
-- No Docker installation required
-- ARM64 architecture builds
-- Integrated with AWS services
-- Consistent build environment
-- Perfect for notebook-based development workflows
+- **No Docker installation required** - builds ARM64 containers in the cloud
+- **Zero local setup** - just AWS credentials needed
+- **Consistent builds** - standardized ARM64 environment
+- **Perfect for managed environments** - works in environment sucah SageMaker Notebooks
+- **Integrated with AWS services** - seamless ECR and AgentCore integration
 
-#### Local Development
-For local development and testing:
+#### Local Development & Testing
+**Perfect for:** Local development, rapid iteration, debugging
 
 ```bash
-# Local development (runs locally)
+# Local development (runs locally, requires Docker/Finch/Podman)
 agentcore launch --local
 ```
 
@@ -299,28 +297,38 @@ agentcore launch --local
 - Full local testing capabilities
 - Immediate feedback during development
 - Complete control over build environment
+- **Note:** Requires Docker/Finch/Podman installation
 
 ### Deployment Modes
 
-#### Standard Cloud Deployment
-- Uses local Docker for container builds
-- Pushes ARM64 images to ECR
-- Deploys to Bedrock AgentCore
+#### CodeBuild Cloud Deployment (Default)
+- ✅ **Recommended approach**
+- Uses AWS CodeBuild for ARM64 container builds
+- **No local Docker required**
+- Pushes to ECR and deploys to AgentCore
 
 ```bash
-# Standard cloud deployment (requires local Docker)
+# Default deployment (CodeBuild in the cloud)
 agentcore launch
 ```
 
-#### CodeBuild Deployment
-- Uses AWS CodeBuild for ARM64 container builds
-- Automatically handles Docker build process
-- Pushes to ECR and deploys to AgentCore
-- Ideal for environments without Docker
+#### Local Build Cloud Deployment
+- Uses local Docker for container builds
+- Pushes ARM64 images to ECR
+- Deploys to Bedrock AgentCore
+- **Requires Docker/Finch/Podman installed**
+
+```bash
+# Local Docker build deployment (requires Docker/Finch/Podman)
+agentcore launch --local-build
+```
 
 #### ECR Push Only
-```bash
-agentcore launch --push-ecr
-```
 - Builds and pushes to ECR without deployment
-- Useful for CI/CD pipelines or manual deployment workflows
+- Useful manual deployment workflows
+- Can use either CodeBuild (default) or local Docker (`--local-build`)
+
+```bash
+agentcore launch --push-ecr        # Uses CodeBuild (default)
+agentcore launch --push-ecr --local-build  # Uses local Docker
+```

--- a/documentation/docs/user-guide/runtime/permissions.md
+++ b/documentation/docs/user-guide/runtime/permissions.md
@@ -46,11 +46,11 @@ agentcore configure -e my_agent.py
 agentcore configure -e my_agent.py
 ```
 
-**Auto-Creation with CodeBuild Deployment:**
+**Auto-Creation with Default Deployment:**
 ```bash
-# Perfect for SageMaker notebooks
+# Uses CodeBuild by default
 agentcore configure -e my_agent.py
-agentcore launch --codebuild
+agentcore launch
 ```
 
 **Mixed Approach:**
@@ -249,7 +249,7 @@ The toolkit uses AWS CodeBuild for ARM64 container builds, especially useful in 
 The Runtime Execution Role is an IAM role that AgentCore Runtime assumes to run an agent. Replace the following:
 
 - `region` with the AWS Region that you are using
-- `accountId` with your AWS account ID  
+- `accountId` with your AWS account ID
 - `agentName` with the name of your agent. You'll need to decide the agent name before creating the role and AgentCore Runtime.
 
 ### Permissions Policy

--- a/documentation/docs/user-guide/runtime/quickstart.md
+++ b/documentation/docs/user-guide/runtime/quickstart.md
@@ -2,6 +2,19 @@
 
 Get your AI agent running on Amazon Bedrock AgentCore in 3 simple steps.
 
+## Prerequisites
+
+Before starting, make sure you have:
+
+- **AWS Account** with credentials configured (`aws configure`)
+- **Python 3.10+** installed
+- **AWS Permissions**:
+  - `AmazonBedrockAgentCoreFullAccess` managed policy
+  - `AmazonBedrockFullAccess` managed policy
+  - **Caller permissions**: [See detailed policy here](permissions.md#developercaller-permissions)
+- **Model Access**: Anthropic Claude 4.0 enabled in [Amazon Bedrock console](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)
+
+
 ## Step 1: Install and Create Your Agent
 
 ```bash
@@ -71,19 +84,6 @@ agentcore invoke '{"prompt": "tell me a joke"}'
 🎉 **Congratulations!** Your agent is now running on Amazon Bedrock AgentCore!
 
 ---
-
-## Prerequisites
-
-Before starting, make sure you have:
-
-- **AWS Account** with credentials configured (`aws configure`)
-- **Python 3.10+** installed
-- **AWS Permissions**:
-  - `AmazonBedrockAgentCoreFullAccess` managed policy
-  - `AmazonBedrockFullAccess` managed policy
-  - **Caller permissions**: [See detailed policy here](permissions.md#developercaller-permissions)
-- **Model Access**: Anthropic Claude 4.0 enabled in [Amazon Bedrock console](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)
-
 > **💡 Tip**: The toolkit auto-creates IAM roles and ECR repositories - no manual setup needed!
 
 ---
@@ -105,7 +105,7 @@ lsof -ti:8080 | xargs kill -9
 
 **"Docker not found" warnings**
 - ✅ **Ignore this!** Default deployment uses CodeBuild (no Docker needed)
-- Only install Docker if you want to use `--local` flag
+- Only install Docker/Finch/Podman if you want to use `--local` or `--local-build` flags
 
 **"Model access denied"**
 - Enable Anthropic Claude 4.0 in the [Bedrock console](https://console.aws.amazon.com/bedrock/)
@@ -128,28 +128,32 @@ lsof -ti:8080 | xargs kill -9
 <details>
 <summary>🔧 Click to expand advanced configuration options</summary>
 
-### Local Development
+### Deployment Modes
+
+Choose the right deployment approach for your needs:
+
+**🚀 Default: CodeBuild + Cloud Runtime (RECOMMENDED)**
 ```bash
-# Run locally for development (requires Docker)
-agentcore launch --local
+agentcore launch  # Uses CodeBuild (no Docker needed)
 ```
+Perfect for production, managed environments, teams without Docker
+
+**💻 Local Development**
+```bash
+agentcore launch --local  # Build and run locally (requires Docker/Finch/Podman)
+```
+Perfect for development, rapid iteration, debugging
+
+**🔧 Hybrid: Local Build + Cloud Runtime**
+```bash
+agentcore launch --local-build  # Build locally, deploy to cloud (requires Docker/Finch/Podman)
+```
+Perfect for teams with Docker expertise needing build customization
 
 ### Custom Roles
 ```bash
 # Use existing IAM role
 agentcore configure -e my_agent.py --execution-role arn:aws:iam::123456789012:role/MyRole
-```
-
-### Local Docker Build
-```bash
-# Build locally, deploy to AWS (requires Docker)
-agentcore launch --local-build
-```
-
-### Environment-Specific Deployment
-```bash
-# Perfect for SageMaker Notebooks, Cloud9
-agentcore launch  # Uses CodeBuild (default, no Docker needed)
 ```
 
 </details>

--- a/documentation/docs/user-guide/runtime/quickstart.md
+++ b/documentation/docs/user-guide/runtime/quickstart.md
@@ -1,45 +1,15 @@
 # QuickStart: Your First Agent in 5 Minutes! 🚀
 
-Let's get your first AI agent running on Amazon Bedrock AgentCore in just a few minutes!
+Get your AI agent running on Amazon Bedrock AgentCore in 3 simple steps.
 
-## What You Need
-
-### Prerequisites
-
-- An AWS account with the following permissions:
-  - **AgentCore Full Access**: `AmazonBedrockAgentCoreFullAccess` managed policy
-  - **Bedrock Access** (one of the following):
-    - **Option 1 (Development)**: `AmazonBedrockFullAccess` managed policy
-    - **Option 2 (Production Recommended)**: Custom policy with scoped permissions for specific models
-  - **Caller permissions**: [See detailed policy here](permissions.md#developercaller-permissions)
-- Python 3.10+ installed
-- 5 minutes of your time ⏰
-
-### Development Environment Considerations
-
-**For SageMaker Notebooks, Cloud9, or other cloud environments:**
-- Use the `--codebuild` flag for deployment (no Docker required)
-- CodeBuild handles ARM64 container builds automatically
-
-**For local development:**
-- Docker Desktop (for standard deployment)
-- Or use `--codebuild` flag to avoid Docker requirements
-
-## Step 1: Install the SDK
+## Step 1: Install and Create Your Agent
 
 ```bash
-pip install bedrock-agentcore
+# Install both packages
+pip install bedrock-agentcore strands-agents bedrock-agentcore-starter-toolkit
 ```
 
-## Step 2: Create Your Agent
-
-First, install the Strands framework:
-
-```bash
-pip install strands-agents
-```
-
-Create a file called `my_agent.py` and add this code:
+Create `my_agent.py`:
 
 ```python
 from bedrock_agentcore import BedrockAgentCoreApp
@@ -52,8 +22,6 @@ agent = Agent()
 def invoke(payload):
     """Your AI agent function"""
     user_message = payload.get("prompt", "Hello! How can I help you today?")
-
-    # Let Strands AI handle the response
     result = agent(user_message)
     return {"result": result.message}
 
@@ -61,110 +29,136 @@ if __name__ == "__main__":
     app.run()
 ```
 
-## Step 3: Test It Locally
+Create `requirements.txt`:
+```
+bedrock-agentcore
+strands-agents
+```
+
+Run
+```bash
+cat > requirements.txt << EOF
+bedrock-agentcore
+strands-agents
+EOF
+```
+
+## Step 2: Test Locally
 
 ```bash
 # Start your agent
 python my_agent.py
 
-# In another terminal, test it:
+# Test it (in another terminal)
 curl -X POST http://localhost:8080/invocations \
   -H "Content-Type: application/json" \
   -d '{"prompt": "Hello!"}'
 ```
 
-You should see something like: `{"result": "Hello! I'm here to help you with any questions or tasks you have. What would you like to know or do today?"}`
+✅ **Success**: You should see a response like `{"result": "Hello! I'm here to help..."}`
 
-🎉 **Congratulations!** Your AI agent is working locally!
-
-> **Note**: To run this example hello world agent you will need to set up credentials for our model provider and enable model access. The default model provider for Strands Agents SDK is [Amazon Bedrock](https://aws.amazon.com/bedrock/) and the default model is Claude 3.7 Sonnet in the US Oregon (us-west-2) region.
-
-> For the default Amazon Bedrock model provider, see the [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) for setting up AWS credentials. Typically for development, AWS credentials are defined in `AWS_` prefixed environment variables or configured with `aws configure`. You will also need to enable Claude 3.7 model access in Amazon Bedrock, following the [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) to enable access.
-
-## Step 4: Deploy to AWS
-
-Ready to deploy to the cloud? The toolkit makes this incredibly simple with **automatic role creation**!
+## Step 3: Deploy to AWS
 
 ```bash
-# Install the starter toolkit
-pip install bedrock-agentcore-starter-toolkit
-
-# Create requirements.txt
-echo "bedrock-agentcore
-strands-agents" > requirements.txt
-
-# 🎯 Configure your agent - roles are auto-created!
+# Configure and deploy (auto-creates all required resources)
 agentcore configure -e my_agent.py
+agentcore launch
 
-# 🚀 Deploy to AWS with CodeBuild (perfect for SageMaker notebooks!)
-agentcore launch --codebuild
-
-# 🎉 Test your deployed agent
+# Test your deployed agent
 agentcore invoke '{"prompt": "tell me a joke"}'
 ```
 
-### ✨ What Just Happened?
+🎉 **Congratulations!** Your agent is now running on Amazon Bedrock AgentCore!
 
-The toolkit automatically handled all the complex setup:
+---
 
-1. **🔐 Auto-Created Execution Role**: The toolkit created `AmazonBedrockAgentCoreSDKRuntime-{region}-{hash}` with all required permissions
-2. **🏗️ CodeBuild Resources**: ARM64 build environment and CodeBuild role configured automatically
-3. **📦 ECR Repository**: Container registry created automatically
+## Prerequisites
 
-### 🎯 Key Benefits of Auto-Creation
+Before starting, make sure you have:
 
-**🚀 Zero Configuration Required**
-- No need to manually create IAM roles
-- No need to configure trust policies
-- No need to attach permissions policies
+- **AWS Account** with credentials configured (`aws configure`)
+- **Python 3.10+** installed
+- **AWS Permissions**:
+  - `AmazonBedrockAgentCoreFullAccess` managed policy
+  - `AmazonBedrockFullAccess` managed policy
+  - **Caller permissions**: [See detailed policy here](permissions.md#developercaller-permissions)
+- **Model Access**: Anthropic Claude 4.0 enabled in [Amazon Bedrock console](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html)
 
-**📱 Perfect for SageMaker Notebooks**
-- No Docker installation needed
-- ARM64 builds handled in the cloud
-- Works seamlessly in managed environments
+> **💡 Tip**: The toolkit auto-creates IAM roles and ECR repositories - no manual setup needed!
 
-### 🔧 Advanced Configuration (Optional)
+---
 
-**If you prefer to use existing roles:**
+## Troubleshooting
+
+### Common Issues
+
+**"Port 8080 already in use"**
 ```bash
-# Use existing execution role
-agentcore configure -e my_agent.py -er arn:aws:iam::123456789012:role/MyExistingRole
-
-# Use existing ECR repository
-agentcore configure -e my_agent.py -ecr my-existing-repo
+# Find and stop the process using port 8080
+lsof -ti:8080 | xargs kill -9
 ```
 
-**For local development and testing:**
+**"Permission denied" errors**
+- Verify AWS credentials: `aws sts get-caller-identity`
+- Check you have the required managed policies attached
+- Review [caller permissions policy](permissions.md#required-caller-policy) for detailed requirements
+
+**"Docker not found" warnings**
+- ✅ **Ignore this!** Default deployment uses CodeBuild (no Docker needed)
+- Only install Docker if you want to use `--local` flag
+
+**"Model access denied"**
+- Enable Anthropic Claude 4.0 in the [Bedrock console](https://console.aws.amazon.com/bedrock/)
+- Make sure you're in the correct AWS region (us-west-2 by default)
+
+**"CodeBuild build error"**
+- Check CodeBuild project logs in AWS console
+- Verify your [caller permissions](permissions.md#developercaller-permissions) include CodeBuild access
+
+### Getting Help
+
+- **Detailed permissions**: [Runtime Permissions Guide](permissions.md)
+- **Advanced deployment**: [Runtime Overview](overview.md)
+- **More examples**: [Examples Directory](../../examples/README.md)
+
+---
+
+## Advanced Options (Optional)
+
+<details>
+<summary>🔧 Click to expand advanced configuration options</summary>
+
+### Local Development
 ```bash
-# Local development (runs locally)
+# Run locally for development (requires Docker)
 agentcore launch --local
 ```
 
-**For standard cloud deployment:**
+### Custom Roles
 ```bash
-# Standard cloud deployment (requires local Docker)
-agentcore launch
+# Use existing IAM role
+agentcore configure -e my_agent.py --execution-role arn:aws:iam::123456789012:role/MyRole
 ```
 
-> **💡 Pro Tip**: The auto-creation feature is perfect for getting started quickly, especially in SageMaker notebooks, Cloud9, or any environment where you want to focus on building your agent rather than managing infrastructure!
+### Local Docker Build
+```bash
+# Build locally, deploy to AWS (requires Docker)
+agentcore launch --local-build
+```
 
-##  Quick Troubleshooting
+### Environment-Specific Deployment
+```bash
+# Perfect for SageMaker Notebooks, Cloud9
+agentcore launch  # Uses CodeBuild (default, no Docker needed)
+```
 
-**Port 8080 already in use?**
-- Stop other services or use a different port
+</details>
 
-**"Docker not found" error?**
-- Install Docker Desktop for deployment
+---
 
-**Permission errors?**
-- Make sure your AWS credentials are configured: `aws configure`
+## Next Steps
 
-**Code build error?**
-- Check code build project with agent name as suffix for latest build and its logs
-
-## 🚀 Next Steps
-
-Ready to build something amazing? Check out:
+Ready to build something more advanced?
 
 - **[Runtime Overview](overview.md)** - Deep dive into AgentCore features
 - **[Memory Guide](../memory/quickstart.md)** - Add persistent memory

--- a/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
+++ b/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
@@ -141,7 +141,17 @@ class Runtime:
             LaunchResult with deployment details
         """
         if not self._config_path:
+            log.warning("Configuration required before launching")
+            log.info("Call .configure() first to set up your agent")
+            log.info("Example: runtime.configure(entrypoint='my_agent.py')")
             raise ValueError("Must configure before launching. Call .configure() first.")
+
+        # Inform user about deployment mode
+        if local:
+            log.info("Local mode requires Docker/Finch/Podman installation")
+            log.info("Alternative: Use .launch() without local=True for CodeBuild deployment")
+        else:
+            log.info("Using CodeBuild for cloud deployment (no local Docker required)")
 
         # Validate mutually exclusive options
         exclusive_options = [local, push_ecr, use_codebuild]
@@ -213,6 +223,12 @@ class Runtime:
             Response from the Bedrock AgentCore endpoint
         """
         if not self._config_path:
+            log.warning("Agent not configured and deployed")
+            log.info("Required workflow: .configure() → .launch() → .invoke()")
+            log.info("Example:")
+            log.info("  runtime.configure(entrypoint='my_agent.py')")
+            log.info("  runtime.launch()")
+            log.info("  runtime.invoke({'message': 'Hello'})")
             raise ValueError("Must configure and launch first.")
 
         result = invoke_bedrock_agentcore(
@@ -232,6 +248,9 @@ class Runtime:
             StatusResult with configuration, agent, and endpoint status
         """
         if not self._config_path:
+            log.warning("Configuration not found")
+            log.info("Call .configure() first to set up your agent")
+            log.info("Example: runtime.configure(entrypoint='my_agent.py')")
             raise ValueError("Must configure first. Call .configure() first.")
 
         result = get_status(self._config_path)

--- a/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
+++ b/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
@@ -45,6 +45,7 @@ class Runtime:
         authorizer_configuration: Optional[Dict[str, Any]] = None,
         region: Optional[str] = None,
         protocol: Optional[Literal["HTTP", "MCP"]] = None,
+        disable_otel: bool = False,
     ) -> ConfigureResult:
         """Configure Bedrock AgentCore from notebook using an entrypoint file.
 
@@ -62,6 +63,7 @@ class Runtime:
             authorizer_configuration: JWT authorizer configuration dictionary
             region: AWS region for deployment
             protocol: agent server protocol, must be either HTTP or MCP
+            disable_otel: Whether to disable OpenTelemetry observability (default: False)
 
         Returns:
             ConfigureResult with configuration details
@@ -110,6 +112,7 @@ class Runtime:
             ecr_repository=ecr_repository,
             container_runtime=container_runtime,
             auto_create_ecr=auto_create_ecr,
+            enable_observability=not disable_otel,
             requirements_file=final_requirements_file,
             authorizer_configuration=authorizer_configuration,
             region=region,
@@ -123,17 +126,15 @@ class Runtime:
     def launch(
         self,
         local: bool = False,
-        push_ecr: bool = False,
-        use_codebuild: bool = False,
+        local_build: bool = False,
         auto_update_on_conflict: bool = False,
         env_vars: Optional[Dict] = None,
     ) -> LaunchResult:
         """Launch Bedrock AgentCore from notebook.
 
         Args:
-            local: Whether to build for local execution only
-            push_ecr: Whether to push to ECR only (no deployment)
-            use_codebuild: Whether to use CodeBuild for ARM64 builds (cloud deployment only)
+            local: Whether to build and run locally (requires Docker/Finch/Podman)
+            local_build: Whether to build locally and deploy to cloud (requires Docker/Finch/Podman)
             auto_update_on_conflict: Whether to automatically update resources on conflict (default: False)
             env_vars: environment variables for agent container
 
@@ -146,31 +147,68 @@ class Runtime:
             log.info("Example: runtime.configure(entrypoint='my_agent.py')")
             raise ValueError("Must configure before launching. Call .configure() first.")
 
-        # Inform user about deployment mode
+        # Enhanced validation for mutually exclusive options with helpful guidance
+        if local and local_build:
+            raise ValueError(
+                "Cannot use both 'local' and 'local_build' flags together.\n"
+                "Choose one deployment mode:\n"
+                "• runtime.launch(local=True) - for local development\n"
+                "• runtime.launch(local_build=True) - for local build + cloud deployment\n"
+                "• runtime.launch() - for CodeBuild deployment (recommended)"
+            )
+
+        # Inform user about deployment mode with enhanced migration guidance
         if local:
-            log.info("Local mode requires Docker/Finch/Podman installation")
-            log.info("Alternative: Use .launch() without local=True for CodeBuild deployment")
+            log.info("🏠 Local mode: building and running locally")
+            log.info("   • Build and run container locally")
+            log.info("   • Requires Docker/Finch/Podman to be installed") 
+            log.info("   • Perfect for development and testing")
+        elif local_build:
+            log.info("🔧 Local build mode: building locally, deploying to cloud (NEW OPTION!)")
+            log.info("   • Build container locally with Docker")
+            log.info("   • Deploy to Bedrock AgentCore cloud runtime")
+            log.info("   • Requires Docker/Finch/Podman to be installed")
+            log.info("   • Use when you need custom build control")
         else:
-            log.info("Using CodeBuild for cloud deployment (no local Docker required)")
+            log.info("🚀 CodeBuild mode: building in cloud (RECOMMENDED - DEFAULT)")
+            log.info("   • Build ARM64 containers in the cloud with CodeBuild")
+            log.info("   • No local Docker required")
+            
+            # Show deployment options hint for first-time notebook users
+            log.info("💡 Available deployment modes:")
+            log.info("   • runtime.launch()                           → CodeBuild (current)")
+            log.info("   • runtime.launch(local=True)                 → Local development")
+            log.info("   • runtime.launch(local_build=True)           → Local build + cloud deploy (NEW)")
 
-        # Validate mutually exclusive options
-        exclusive_options = [local, push_ecr, use_codebuild]
-        if sum(exclusive_options) > 1:
-            raise ValueError("Only one of 'local', 'push_ecr', or 'use_codebuild' can be True")
+        # Map to the underlying operation's use_codebuild parameter
+        # use_codebuild=False when local=True OR local_build=True
+        use_codebuild = not (local or local_build)
 
-        result = launch_bedrock_agentcore(
-            self._config_path,
-            local=local,
-            push_ecr_only=push_ecr,
-            use_codebuild=use_codebuild,
-            auto_update_on_conflict=auto_update_on_conflict,
-            env_vars=env_vars,
-        )
+        try:
+            result = launch_bedrock_agentcore(
+                self._config_path,
+                local=local,
+                use_codebuild=use_codebuild,
+                auto_update_on_conflict=auto_update_on_conflict,
+                env_vars=env_vars,
+            )
+        except RuntimeError as e:
+            # Enhance Docker-related error messages
+            error_msg = str(e)
+            if "docker" in error_msg.lower() or "container runtime" in error_msg.lower():
+                if local or local_build:
+                    enhanced_msg = f"Docker/Finch/Podman is required for {'local' if local else 'local-build'} mode.\n\n"
+                    enhanced_msg += "Options to fix this:\n"
+                    enhanced_msg += "1. Install Docker/Finch/Podman and try again\n"
+                    enhanced_msg += "2. Use CodeBuild mode instead: runtime.launch() - no Docker required\n\n"
+                    enhanced_msg += f"Original error: {error_msg}"
+                    raise RuntimeError(enhanced_msg) from e
+            raise
 
         if result.mode == "cloud":
             log.info("Deployed to cloud: %s", result.agent_arn)
-            # Show log information for cloud deployments
-            if result.agent_id:
+            # For local_build mode, show minimal output; for pure cloud mode, show log details
+            if not local_build and result.agent_id:
                 from ...utils.runtime.logs import get_agent_log_paths, get_aws_tail_commands
 
                 runtime_logs, otel_logs = get_agent_log_paths(result.agent_id)
@@ -195,10 +233,13 @@ class Runtime:
                 log.info("   %s", otel_logs)
                 log.info("💡 Tail logs with: %s", follow_cmd)
                 log.info("💡 Or view recent logs: %s", since_cmd)
-        elif result.mode == "push-ecr":
-            log.info("Pushed to ECR: %s", result.ecr_uri)
         else:
             log.info("Built for local: %s", result.tag)
+
+        # For notebook interface, clear verbose build output to keep output clean
+        # especially for local_build mode where build logs can be very verbose
+        if local_build and hasattr(result, 'build_output'):
+            result.build_output = None
 
         return result
 
@@ -256,3 +297,39 @@ class Runtime:
         result = get_status(self._config_path)
         log.info("Retrieved Bedrock AgentCore status for: %s", self.name or "Bedrock AgentCore")
         return result
+    
+    def help_deployment_modes(self):
+        """Display information about available deployment modes and migration guidance."""
+        print("\n🚀 Bedrock AgentCore Deployment Modes:")
+        print("=" * 50)
+        
+        print("\n1. 📦 CodeBuild Mode (RECOMMENDED - DEFAULT)")
+        print("   Usage: runtime.launch()")
+        print("   • Build ARM64 containers in the cloud with CodeBuild")
+        print("   • No local Docker/Finch/Podman required")
+        print("   • ✅ Works in SageMaker Notebooks, Cloud9, laptops")
+        
+        print("\n2. 🏠 Local Development Mode")
+        print("   Usage: runtime.launch(local=True)")
+        print("   • Build and run container locally")
+        print("   • Requires Docker/Finch/Podman installation")
+        print("   • Perfect for development and testing")
+        print("   • Fast iteration and debugging")
+        
+        print("\n3. 🔧 Local Build Mode (NEW!)")
+        print("   Usage: runtime.launch(local_build=True)")
+        print("   • Build container locally with Docker")
+        print("   • Deploy to Bedrock AgentCore cloud runtime") 
+        print("   • Requires Docker/Finch/Podman installation")
+        print("   • Use when you need custom build control")
+        
+        print("\n📋 Migration Guide:")
+        print("   • CodeBuild is now the default (no code changes needed)")
+        print("   • Previous --code-build flag is deprecated")
+        print("   • local_build=True option for hybrid workflows")
+        
+        print("\n💡 Quick Start:")
+        print("   runtime.configure(entrypoint='my_agent.py')")
+        print("   runtime.launch()  # Uses CodeBuild by default")
+        print('   runtime.invoke({"prompt": "Hello"})')
+        print()

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -251,7 +251,6 @@ def launch_bedrock_agentcore(
     config_path: Path,
     agent_name: Optional[str] = None,
     local: bool = False,
-    push_ecr_only: bool = False,
     use_codebuild: bool = True,
     env_vars: Optional[dict] = None,
     auto_update_on_conflict: bool = False,
@@ -262,7 +261,6 @@ def launch_bedrock_agentcore(
         config_path: Path to BedrockAgentCore configuration file
         agent_name: Name of agent to launch (for project configurations)
         local: Whether to run locally
-        push_ecr_only: Whether to only build and push to ECR without deploying
         use_codebuild: Whether to use CodeBuild for ARM64 builds
         env_vars: Environment variables to pass to local container (dict of key-value pairs)
         auto_update_on_conflict: Whether to automatically update when agent already exists (default: False)
@@ -274,19 +272,8 @@ def launch_bedrock_agentcore(
     project_config = load_config(config_path)
     agent_config = project_config.get_agent_config(agent_name)
 
-    # Handle push ECR only mode first (before CodeBuild routing)
-    if push_ecr_only:
-        if use_codebuild:
-            return _launch_with_codebuild_ecr_only(
-                config_path=config_path,
-                agent_name=agent_config.name,
-                agent_config=agent_config,
-                project_config=project_config,
-            )
-        # Continue with local build + ECR push workflow below
-
-    # Handle CodeBuild deployment (but not for local mode or push_ecr_only with codebuild)
-    elif use_codebuild and not local:
+    # Handle CodeBuild deployment (but not for local mode)
+    if use_codebuild and not local:
         return _launch_with_codebuild(
             config_path=config_path,
             agent_name=agent_config.name,
@@ -296,7 +283,7 @@ def launch_bedrock_agentcore(
         )
 
     # Log which agent is being launched
-    mode = "locally" if local else "to ECR only" if push_ecr_only else "to cloud"
+    mode = "locally" if local else "to cloud"
     log.info("Launching Bedrock AgentCore agent '%s' %s", agent_config.name, mode)
 
     # Validate configuration
@@ -308,21 +295,22 @@ def launch_bedrock_agentcore(
     runtime = ContainerRuntime(agent_config.container_runtime)
 
     # Check if we need local runtime for this operation
-    if (local or push_ecr_only) and not runtime.has_local_runtime:
-        if local:
-            raise RuntimeError(
-                "Cannot run locally - no container runtime available\n"
-                "💡 Recommendation: Use CodeBuild for cloud deployment\n"
-                "💡 Run 'agentcore launch' (without --local) for CodeBuild deployment\n"
-                "💡 For local runs, please install Docker, Finch, or Podman"
-            )
-        else:  # push_ecr_only
-            raise RuntimeError(
-                "Cannot build locally - no container runtime available\n"
-                "💡 Recommendation: Use CodeBuild for building containers in the cloud\n"
-                "💡 Run 'agentcore launch' (without --push-ecr) for CodeBuild deployment\n"
-                "💡 For local builds, please install Docker, Finch, or Podman"
-            )
+    if local and not runtime.has_local_runtime:
+        raise RuntimeError(
+            "Cannot run locally - no container runtime available\n"
+            "💡 Recommendation: Use CodeBuild for cloud deployment\n"
+            "💡 Run 'agentcore launch' (without --local) for CodeBuild deployment\n"
+            "💡 For local runs, please install Docker, Finch, or Podman"
+        )
+
+    # Check if we need local runtime for local-build mode (cloud deployment with local build)
+    if not local and not use_codebuild and not runtime.has_local_runtime:
+        raise RuntimeError(
+            "Cannot build locally - no container runtime available\n"
+            "💡 Recommendation: Use CodeBuild for cloud deployment (no Docker needed)\n"
+            "💡 Run 'agentcore launch' (without --local-build) for CodeBuild deployment\n"
+            "💡 For local builds, please install Docker, Finch, or Podman"
+        )
 
     # Get build context - always use project root (where config and Dockerfile are)
     build_dir = config_path.parent
@@ -378,15 +366,6 @@ def launch_bedrock_agentcore(
     deploy_to_ecr(tag, repo_name, region, runtime)
 
     log.info("Image uploaded to ECR: %s", ecr_uri)
-
-    # If push_ecr_only, return early
-    if push_ecr_only:
-        return LaunchResult(
-            mode="push-ecr",
-            tag=tag,
-            ecr_uri=ecr_uri,
-            build_output=output,
-        )
 
     # Step 4: Deploy agent (with retry logic for role readiness)
     agent_id, agent_arn = _deploy_to_bedrock_agentcore(
@@ -489,40 +468,6 @@ def _execute_codebuild_workflow(
         log.info("✅ ECR-only build completed (project configuration not saved)")
 
     return build_id, ecr_uri, region, account_id
-
-
-def _launch_with_codebuild_ecr_only(
-    config_path: Path,
-    agent_name: str,
-    agent_config,
-    project_config,
-) -> LaunchResult:
-    """Launch using CodeBuild for ARM64 builds - ECR push only (no agent deployment)."""
-    log.info(
-        "Starting CodeBuild ARM64 ECR-only build for agent '%s' to account %s (%s)",
-        agent_name,
-        agent_config.aws.account,
-        agent_config.aws.region,
-    )
-
-    # Execute shared CodeBuild workflow with ECR-only mode
-    build_id, ecr_uri, region, account_id = _execute_codebuild_workflow(
-        config_path=config_path,
-        agent_name=agent_name,
-        agent_config=agent_config,
-        project_config=project_config,
-        ecr_only=True,
-    )
-
-    log.info("ECR-only deployment completed successfully - Image: %s:latest", ecr_uri)
-
-    return LaunchResult(
-        mode="push-ecr",
-        tag=f"bedrock_agentcore-{agent_name}:latest",
-        codebuild_id=build_id,
-        ecr_uri=ecr_uri,
-        build_output=[f"CodeBuild {build_id} completed successfully"],
-    )
 
 
 def _launch_with_codebuild(

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/models.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/models.py
@@ -27,7 +27,7 @@ class ConfigureResult(BaseModel):
 class LaunchResult(BaseModel):
     """Result of launch operation."""
 
-    mode: str = Field(..., description="Launch mode: local, push-ecr, cloud, or codebuild")
+    mode: str = Field(..., description="Launch mode: local, cloud, or codebuild")
     tag: str = Field(..., description="Docker image tag")
     env_vars: Optional[Dict[str, str]] = Field(default=None, description="Environment variables for local deployment")
 

--- a/src/bedrock_agentcore_starter_toolkit/services/runtime.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/runtime.py
@@ -128,7 +128,19 @@ class BedrockAgentCoreClient:
             if error_code == "ConflictException":
                 if not auto_update_on_conflict:
                     self.logger.error("Agent '%s' already exists and auto_update_on_conflict is disabled", agent_name)
-                    raise
+                    # Create a more helpful error message
+                    raise ClientError(
+                        {
+                            "Error": {
+                                "Code": "ConflictException",
+                                "Message": (
+                                    f"Agent '{agent_name}' already exists. To update the existing agent, "
+                                    "use the --auto-update-on-conflict flag with the launch command."
+                                ),
+                            }
+                        },
+                        "CreateAgentRuntime",
+                    ) from e
 
                 self.logger.info("Agent '%s' already exists, searching for existing agent...", agent_name)
 

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
@@ -39,12 +39,12 @@ class ContainerRuntime:
                     self.has_local_runtime = True
                     break
             else:
-                # Convert hard error to warning - suggest CodeBuild instead
+                # Informational message - default CodeBuild deployment works fine
                 _handle_warn(
-                    "⚠️  No container runtime found (Docker/Finch/Podman not installed)\n"
-                    "💡 Recommendation: Use CodeBuild for building containers in the cloud\n"
-                    "💡 Run 'agentcore launch' (default) for CodeBuild deployment\n"
-                    "💡 For local builds, please install Docker, Finch, or Podman"
+                    "ℹ️  No container engine found (Docker/Finch/Podman not installed)\n"
+                    "✅ Default deployment uses CodeBuild (no container engine needed)\n"
+                    "💡 Run 'agentcore launch' for cloud-based building and deployment\n"
+                    "💡 For local builds, install Docker, Finch, or Podman"
                 )
                 self.runtime = "none"
                 self.has_local_runtime = False
@@ -63,7 +63,22 @@ class ContainerRuntime:
                 self.runtime = "none"
                 self.has_local_runtime = False
         else:
-            raise ValueError(f"Unsupported runtime: {runtime_type}")
+            if runtime_type == "none":
+                raise ValueError(
+                    "No supported container engine found.\n\n"
+                    "AgentCore requires one of the following container engines for local builds:\n"
+                    "• Docker (any recent version, including Docker Desktop)\n"
+                    "• Finch (Amazon's open-source container engine)\n"
+                    "• Podman (compatible alternative to Docker)\n\n"
+                    "To install:\n"
+                    "• Docker: https://docs.docker.com/get-docker/\n"
+                    "• Finch: https://github.com/runfinch/finch\n"
+                    "• Podman: https://podman.io/getting-started/installation\n\n"
+                    "Alternative: Use CodeBuild for cloud-based building (no container engine needed):\n"
+                    "  agentcore launch  # Uses CodeBuild (default)"
+                )
+            else:
+                raise ValueError(f"Unsupported runtime: {runtime_type}")
 
     def _is_runtime_installed(self, runtime: str) -> bool:
         """Check if runtime is installed."""

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
@@ -29,19 +29,39 @@ class ContainerRuntime:
         """
         runtime_type = runtime_type or self.DEFAULT_RUNTIME
         self.available_runtimes = ["finch", "docker", "podman"]
+        self.runtime = None
+        self.has_local_runtime = False
 
         if runtime_type == "auto":
             for runtime in self.available_runtimes:
                 if self._is_runtime_installed(runtime):
                     self.runtime = runtime
+                    self.has_local_runtime = True
                     break
             else:
-                raise RuntimeError("No container runtime found. Please install Docker, Finch, or Podman.")
+                # Convert hard error to warning - suggest CodeBuild instead
+                _handle_warn(
+                    "⚠️  No container runtime found (Docker/Finch/Podman not installed)\n"
+                    "💡 Recommendation: Use CodeBuild for building containers in the cloud\n"
+                    "💡 Run 'agentcore launch' (default) for CodeBuild deployment\n"
+                    "💡 For local builds, please install Docker, Finch, or Podman"
+                )
+                self.runtime = "none"
+                self.has_local_runtime = False
         elif runtime_type in self.available_runtimes:
             if self._is_runtime_installed(runtime_type):
                 self.runtime = runtime_type
+                self.has_local_runtime = True
             else:
-                raise RuntimeError(f"{runtime_type.capitalize()} is not installed")
+                # Convert hard error to warning - suggest CodeBuild instead
+                _handle_warn(
+                    f"⚠️  {runtime_type.capitalize()} is not installed\n"
+                    "💡 Recommendation: Use CodeBuild for building containers in the cloud\n"
+                    "💡 Run 'agentcore launch' (default) for CodeBuild deployment\n"
+                    f"💡 For local builds, please install {runtime_type.capitalize()}"
+                )
+                self.runtime = "none"
+                self.has_local_runtime = False
         else:
             raise ValueError(f"Unsupported runtime: {runtime_type}")
 
@@ -190,6 +210,14 @@ class ContainerRuntime:
 
     def build(self, dockerfile_dir: Path, tag: str, platform: Optional[str] = None) -> Tuple[bool, List[str]]:
         """Build container image."""
+        if not self.has_local_runtime:
+            return False, [
+                "No container runtime available for local build",
+                "💡 Recommendation: Use CodeBuild for building containers in the cloud",
+                "💡 Run 'agentcore launch' (default) for CodeBuild deployment",
+                "💡 For local builds, please install Docker, Finch, or Podman",
+            ]
+
         if not dockerfile_dir.exists():
             return False, [f"Directory not found: {dockerfile_dir}"]
 
@@ -212,6 +240,14 @@ class ContainerRuntime:
             port: Port to expose (default: 8080)
             env_vars: Additional environment variables to pass to container
         """
+        if not self.has_local_runtime:
+            raise RuntimeError(
+                "No container runtime available for local run\n"
+                "💡 Recommendation: Use CodeBuild for building containers in the cloud\n"
+                "💡 Run 'agentcore launch' (default) for CodeBuild deployment\n"
+                "💡 For local runs, please install Docker, Finch, or Podman"
+            )
+
         container_name = f"{tag.split(':')[0]}-{int(time.time())}"
         cmd = [self.runtime, "run", "-it", "--rm", "-p", f"{port}:8080", "--name", container_name]
 

--- a/tests/cli/runtime/test_commands.py
+++ b/tests/cli/runtime/test_commands.py
@@ -188,8 +188,7 @@ agents:
                     config_path=config_file,
                     agent_name=None,
                     local=False,
-                    push_ecr_only=False,
-                    use_codebuild=True,
+                    use_codebuild=False,  # Should be False due to --local-build
                     env_vars=None,
                     auto_update_on_conflict=False,
                 )
@@ -461,7 +460,6 @@ agents:
                     config_path=config_file,
                     agent_name=None,
                     local=False,
-                    push_ecr_only=False,
                     use_codebuild=True,
                     env_vars=None,
                     auto_update_on_conflict=False,
@@ -1141,107 +1139,12 @@ agents:
 
     def test_launch_command_mutually_exclusive_options(self):
         """Test launch command with mutually exclusive options."""
-        # Test local and push-ecr together (not allowed)
-        result = self.runner.invoke(app, ["launch", "--local", "--push-ecr"])
-        assert result.exit_code == 1
-        assert "cannot be used together" in result.stdout
-
         # Test local and local-build together (not allowed)
         result = self.runner.invoke(app, ["launch", "--local", "--local-build"])
         assert result.exit_code == 1
         assert "cannot be used together" in result.stdout
 
-    def test_launch_command_allows_push_ecr_with_local_build(self):
-        """Test that --push-ecr and --local-build can be used together."""
-        # This combination should be allowed - no error expected, just missing config file
-        result = self.runner.invoke(app, ["launch", "--push-ecr", "--local-build"])
-        # Should fail due to missing config file, not validation error
-        assert result.exit_code == 1
-        assert ".bedrock_agentcore.yaml not found" in result.stdout
 
-    def test_launch_command_push_ecr_codebuild_success(self, tmp_path):
-        """Test launch command with --push-ecr using CodeBuild (default)."""
-        config_file = tmp_path / ".bedrock_agentcore.yaml"
-        config_content = """
-default_agent: test-agent
-agents:
-  test-agent:
-    name: test-agent
-    entrypoint: test.py
-"""
-        config_file.write_text(config_content.strip())
-
-        with patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.launch_bedrock_agentcore") as mock_launch:
-            mock_result = Mock()
-            mock_result.mode = "push-ecr"
-            mock_result.tag = "bedrock_agentcore-test-agent"
-            mock_result.ecr_uri = "123456789012.dkr.ecr.us-west-2.amazonaws.com/test"
-            mock_result.codebuild_id = "build-123"
-            mock_launch.return_value = mock_result
-
-            original_cwd = Path.cwd()
-            os.chdir(tmp_path)
-
-            try:
-                result = self.runner.invoke(app, ["launch", "--push-ecr"])
-                assert result.exit_code == 0
-                assert "ECR Push Successful!" in result.stdout
-                assert "CodeBuild + ECR push only" not in result.stdout  # Should use default CodeBuild
-
-                # Verify the core function was called with correct parameters
-                mock_launch.assert_called_once_with(
-                    config_path=config_file,
-                    agent_name=None,
-                    local=False,
-                    push_ecr_only=True,
-                    use_codebuild=True,  # Should default to True
-                    env_vars=None,
-                    auto_update_on_conflict=False,
-                )
-            finally:
-                os.chdir(original_cwd)
-
-    def test_launch_command_push_ecr_local_build_success(self, tmp_path):
-        """Test launch command with --push-ecr --local-build combination."""
-        config_file = tmp_path / ".bedrock_agentcore.yaml"
-        config_content = """
-default_agent: test-agent
-agents:
-  test-agent:
-    name: test-agent
-    entrypoint: test.py
-"""
-        config_file.write_text(config_content.strip())
-
-        with patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.launch_bedrock_agentcore") as mock_launch:
-            mock_result = Mock()
-            mock_result.mode = "push-ecr"
-            mock_result.tag = "bedrock_agentcore-test-agent"
-            mock_result.ecr_uri = "123456789012.dkr.ecr.us-west-2.amazonaws.com/test"
-            mock_result.build_output = ["Successfully built test-image"]
-            mock_launch.return_value = mock_result
-
-            original_cwd = Path.cwd()
-            os.chdir(tmp_path)
-
-            try:
-                result = self.runner.invoke(app, ["launch", "--push-ecr", "--local-build"])
-                assert result.exit_code == 0
-                assert "ECR Push Successful!" in result.stdout
-                assert "push-ecr" in result.stdout
-
-                # Verify the core function was called with correct parameters
-                mock_launch.assert_called_once_with(
-                    config_path=config_file,
-                    agent_name=None,
-                    local=False,
-                    push_ecr_only=True,
-                    use_codebuild=False,  # Should be False due to --local-build
-                    env_vars=None,
-                    auto_update_on_conflict=False,
-                )
-            finally:
-                os.chdir(original_cwd)
 
     def test_launch_command_local_build_success(self, tmp_path):
         """Test launch command with --local-build for cloud deployment."""
@@ -1279,7 +1182,6 @@ agents:
                     config_path=config_file,
                     agent_name=None,
                     local=False,
-                    push_ecr_only=False,
                     use_codebuild=False,  # Should be False due to --local-build
                     env_vars=None,
                     auto_update_on_conflict=False,
@@ -1288,20 +1190,25 @@ agents:
                 os.chdir(original_cwd)
 
     def test_launch_help_text_updated(self):
-        """Test that help text reflects new behavior."""
+        """Test that help text reflects the three simplified launch modes."""
         result = self.runner.invoke(app, ["launch", "--help"])
         assert result.exit_code == 0
 
-        # Check that push-ecr help text mentions CodeBuild as default - be more flexible with line wrapping
-        assert "Build and push to ECR only" in result.stdout
-        assert "default: CodeBuild" in result.stdout
-        # Check for the key parts separately to handle line wrapping
-        assert "--local-build" in result.stdout
-        assert "or use" in result.stdout
+        # Check that old flags are no longer in help text
+        assert "--push-ecr" not in result.stdout
+        assert "--codebuild" not in result.stdout
+        assert "Build and push to ECR only" not in result.stdout
 
-        # Check that local-build help text mentions Docker requirement - be flexible with line wrapping
-        assert "Build container locally" in result.stdout
-        assert "Docker instead of CodeBuild" in result.stdout
+        # Check that the three modes are clearly described
+        assert "DEFAULT (no flags): CodeBuild + cloud runtime (RECOMMENDED)" in result.stdout
+        assert "--local: Local build + local runtime" in result.stdout
+        assert "--local-build: Local build + cloud runtime" in result.stdout
+
+        # Check that remaining options are present
+        assert "--local" in result.stdout
+        assert "--local-build" in result.stdout
+
+        # Check that Docker requirements are mentioned for local modes
         assert "requires Docker/Finch/Podman" in result.stdout
 
     def test_launch_missing_config(self, tmp_path):
@@ -1791,44 +1698,6 @@ agents:
         finally:
             os.chdir(original_cwd)
 
-    def test_launch_command_push_ecr_success(self, tmp_path):
-        """Test launch command in push-ecr mode."""
-        config_file = tmp_path / ".bedrock_agentcore.yaml"
-        config_content = """
-default_agent: test-agent
-agents:
-  test-agent:
-    name: test-agent
-    entrypoint: test.py
-"""
-        config_file.write_text(config_content.strip())
-
-        with patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.launch_bedrock_agentcore") as mock_launch:
-            mock_result = Mock()
-            mock_result.mode = "push-ecr"
-            mock_result.tag = "bedrock_agentcore-test-agent"
-            mock_result.ecr_uri = "123456789012.dkr.ecr.us-west-2.amazonaws.com/test"
-            mock_launch.return_value = mock_result
-
-            original_cwd = Path.cwd()
-            os.chdir(tmp_path)
-
-            try:
-                result = self.runner.invoke(app, ["launch", "--push-ecr"])
-                assert result.exit_code == 0
-                assert "ECR Push Successful!" in result.stdout
-                assert "123456789012.dkr.ecr.us-west-2.amazonaws.com/test:latest" in result.stdout
-                mock_launch.assert_called_once_with(
-                    config_path=config_file,
-                    agent_name=None,
-                    local=False,
-                    push_ecr_only=True,
-                    use_codebuild=True,
-                    env_vars=None,
-                    auto_update_on_conflict=False,
-                )
-            finally:
-                os.chdir(original_cwd)
 
     def test_launch_command_with_env_vars(self, tmp_path):
         """Test launch command with environment variables."""
@@ -1928,7 +1797,6 @@ agents:
                     config_path=config_file,
                     agent_name=None,
                     local=False,
-                    push_ecr_only=False,
                     use_codebuild=True,
                     env_vars=None,
                     auto_update_on_conflict=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,7 @@ def mock_container_runtime(monkeypatch):
     # Create a mock runtime object with all required attributes and methods
     mock_runtime = Mock(spec=ContainerRuntime)
     mock_runtime.runtime = "docker"
+    mock_runtime.has_local_runtime = True  # Add the new attribute
     mock_runtime.get_name.return_value = "Docker"
     mock_runtime.build.return_value = (True, ["Successfully built test-image"])
     mock_runtime.login.return_value = True

--- a/tests/operations/runtime/test_launch.py
+++ b/tests/operations/runtime/test_launch.py
@@ -19,31 +19,146 @@ from bedrock_agentcore_starter_toolkit.utils.runtime.schema import (
 )
 
 
+# Test Helper Functions
+def create_test_config(
+    tmp_path,
+    agent_name="test-agent",
+    entrypoint="test_agent.py",
+    region="us-west-2",
+    account="123456789012",
+    execution_role=None,
+    execution_role_auto_create=False,
+    ecr_repository=None,
+    ecr_auto_create=False,
+    agent_id=None,
+    agent_session_id=None,
+):
+    """Create a test configuration with customizable parameters."""
+    config_path = tmp_path / ".bedrock_agentcore.yaml"
+    agent_config = BedrockAgentCoreAgentSchema(
+        name=agent_name,
+        entrypoint=entrypoint,
+        container_runtime="docker",
+        aws=AWSConfig(
+            region=region,
+            account=account,
+            execution_role=execution_role,
+            execution_role_auto_create=execution_role_auto_create,
+            ecr_repository=ecr_repository,
+            ecr_auto_create=ecr_auto_create,
+            network_configuration=NetworkConfiguration(),
+            observability=ObservabilityConfig(),
+        ),
+        bedrock_agentcore=BedrockAgentCoreDeploymentInfo(
+            agent_id=agent_id,
+            agent_session_id=agent_session_id,
+        ),
+    )
+    project_config = BedrockAgentCoreConfigSchema(default_agent=agent_name, agents={agent_name: agent_config})
+    save_config(project_config, config_path)
+    return config_path
+
+
+def create_test_agent_file(tmp_path, filename="test_agent.py", content="# test agent"):
+    """Create a test agent file."""
+    agent_file = tmp_path / filename
+    agent_file.write_text(content)
+    return agent_file
+
+
+class MockAWSClientFactory:
+    """Factory for creating consistent AWS client mocks."""
+
+    def __init__(self, account="123456789012", region="us-west-2"):
+        self.account = account
+        self.region = region
+        self._setup_clients()
+
+    def _setup_clients(self):
+        """Setup all AWS service client mocks."""
+        # IAM Client Mock
+        self.iam_client = MagicMock()
+        self.iam_client.get_role.return_value = {
+            "Role": {
+                "Arn": f"arn:aws:iam::{self.account}:role/TestRole",
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                },
+            }
+        }
+
+        # CodeBuild Client Mock
+        self.codebuild_client = MagicMock()
+        self.codebuild_client.batch_get_builds.return_value = {
+            "builds": [{"buildStatus": "SUCCEEDED", "currentPhase": "COMPLETED"}]
+        }
+        self.codebuild_client.create_project.return_value = {}
+        self.codebuild_client.start_build.return_value = {"build": {"id": "build-123"}}
+
+        # S3 Client Mock
+        self.s3_client = MagicMock()
+        self.s3_client.head_bucket.return_value = {}
+        self.s3_client.upload_file.return_value = {}
+
+        # STS Client Mock
+        self.sts_client = MagicMock()
+        self.sts_client.get_caller_identity.return_value = {"Account": self.account}
+
+    def get_client(self, service_name):
+        """Get a mock client for the specified service."""
+        clients = {
+            "iam": self.iam_client,
+            "codebuild": self.codebuild_client,
+            "s3": self.s3_client,
+            "sts": self.sts_client,
+        }
+        return clients.get(service_name, MagicMock())
+
+    def setup_full_session_mock(self, mock_boto3_clients):
+        """Setup the complete session mock with all AWS clients."""
+        mock_session = mock_boto3_clients["session"]
+        mock_session.client.side_effect = self.get_client
+        mock_session.region_name = self.region
+
+    def setup_session_mock(self, mock_boto3_clients):
+        """Setup the session mock to use our client factory (legacy method)."""
+        self.setup_full_session_mock(mock_boto3_clients)
+
+
+def assert_codebuild_workflow_called(mock_factory):
+    """Assert that CodeBuild workflow was properly executed."""
+    mock_factory.codebuild_client.create_project.assert_called()
+    mock_factory.codebuild_client.start_build.assert_called()
+    mock_factory.codebuild_client.batch_get_builds.assert_called()
+
+
+def assert_config_updated_with_role(config_path, expected_role_arn):
+    """Assert that config was updated with the expected execution role."""
+    from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+
+    updated_config = load_config(config_path)
+    updated_agent = list(updated_config.agents.values())[0]
+    assert updated_agent.aws.execution_role == expected_role_arn
+    assert updated_agent.aws.execution_role_auto_create is False
+
+
+def assert_no_agent_deployment_calls(mock_boto3_clients):
+    """Assert that no agent deployment calls were made (for ECR-only tests)."""
+    mock_boto3_clients["bedrock_agentcore"].create_agent_runtime.assert_not_called()
+    mock_boto3_clients["bedrock_agentcore"].update_agent_runtime.assert_not_called()
+
+
 class TestLaunchBedrockAgentCore:
     """Test launch_bedrock_agentcore functionality."""
 
     def test_launch_local_mode(self, mock_container_runtime, tmp_path):
         """Test local deployment."""
-        # Create config file
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(network_configuration=NetworkConfiguration(), observability=ObservabilityConfig()),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
-        )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        config_path = create_test_config(tmp_path)
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
 
-        # Patch ContainerRuntime in the launch module
         with patch(
             "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
             return_value=mock_container_runtime,
@@ -55,138 +170,68 @@ class TestLaunchBedrockAgentCore:
         assert result.tag == "bedrock_agentcore-test-agent:latest"
         assert result.port == 8080
         assert hasattr(result, "runtime")
-
-        # Verify build was called
         mock_container_runtime.build.assert_called_once()
 
     def test_launch_cloud_with_ecr_auto_create(self, mock_boto3_clients, mock_container_runtime, tmp_path):
         """Test cloud deployment with ECR creation."""
-        # Create config file with auto-create ECR
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role="arn:aws:iam::123456789012:role/TestRole",
-                ecr_auto_create=True,
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_auto_create=True,
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
+        create_test_agent_file(tmp_path)
 
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
-
-        # Mock the build to return success
-        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
-
-        # Mock IAM client response for role validation
-        mock_iam_client = MagicMock()
-        mock_iam_client.get_role.return_value = {
-            "Role": {
-                "AssumeRolePolicyDocument": {
-                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
-            }
-        }
-        mock_boto3_clients["session"].client.return_value = mock_iam_client
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_factory.setup_session_mock(mock_boto3_clients)
 
         with (
-            patch("bedrock_agentcore_starter_toolkit.services.ecr.create_ecr_repository") as mock_create_ecr,
-            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr") as mock_deploy_ecr,
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.get_or_create_ecr_repository") as mock_create_ecr,
             patch(
-                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
-                return_value=mock_container_runtime,
-            ),
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.get_or_create_runtime_execution_role"
+            ) as mock_create_role,
         ):
             mock_create_ecr.return_value = "123456789012.dkr.ecr.us-west-2.amazonaws.com/bedrock_agentcore-test-agent"
-            mock_deploy_ecr.return_value = (
-                "123456789012.dkr.ecr.us-west-2.amazonaws.com/bedrock_agentcore-test-agent:latest"
-            )
+            mock_create_role.return_value = "arn:aws:iam::123456789012:role/TestRole"
 
             result = launch_bedrock_agentcore(config_path, local=False)
 
-            # Verify cloud mode result
-            assert result.mode == "cloud"
+            # Verify codebuild mode result
+            assert result.mode == "codebuild"
             assert hasattr(result, "agent_arn")
             assert hasattr(result, "agent_id")
             assert hasattr(result, "ecr_uri")
+            assert hasattr(result, "codebuild_id")
 
-            # Verify ECR creation was called
-            mock_create_ecr.assert_called_once()
+            # Verify CodeBuild workflow was executed
+            assert_codebuild_workflow_called(mock_factory)
 
     def test_launch_cloud_existing_agent(self, mock_boto3_clients, mock_container_runtime, tmp_path):
         """Test updating existing agent."""
-        # Create config file with existing agent
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="023456789012",
-                execution_role="arn:aws:iam::123456789012:role/TestRole",
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(agent_id="existing-agent-id"),
+        config_path = create_test_config(
+            tmp_path,
+            account="023456789012",
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+            agent_id="existing-agent-id",
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
+        create_test_agent_file(tmp_path)
 
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory(account="023456789012")
+        mock_factory.setup_session_mock(mock_boto3_clients)
 
-        # Mock the build to return success
-        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
-
-        # Mock IAM client response for role validation
-        mock_iam_client = MagicMock()
-        mock_iam_client.get_role.return_value = {
-            "Role": {
-                "AssumeRolePolicyDocument": {
-                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
-            }
-        }
-        mock_boto3_clients["session"].client.return_value = mock_iam_client
-
-        with (
-            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
-            patch(
-                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
-                return_value=mock_container_runtime,
-            ),
-        ):
+        with patch("bedrock_agentcore_starter_toolkit.services.ecr.get_or_create_ecr_repository"):
             result = launch_bedrock_agentcore(config_path, local=False)
 
             # Verify update was called (not create)
             mock_boto3_clients["bedrock_agentcore"].update_agent_runtime.assert_called_once()
-            assert result.mode == "cloud"
+            assert result.mode == "codebuild"
 
     def test_launch_build_failure(self, mock_container_runtime, tmp_path):
         """Test error handling for build failures."""
-        # Create config file
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(network_configuration=NetworkConfiguration(), observability=ObservabilityConfig()),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
-        )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
+        config_path = create_test_config(tmp_path)
+        create_test_agent_file(tmp_path)
 
         # Mock build failure
         mock_container_runtime.build.return_value = (False, ["Error: build failed", "Missing dependency"])
@@ -207,44 +252,81 @@ class TestLaunchBedrockAgentCore:
 
     def test_launch_invalid_config(self, tmp_path):
         """Test validation errors."""
-        # Create incomplete config (missing entrypoint)
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="",  # Invalid empty entrypoint
-            aws=AWSConfig(network_configuration=NetworkConfiguration(), observability=ObservabilityConfig()),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
-        )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
+        config_path = create_test_config(tmp_path, entrypoint="")  # Invalid empty entrypoint
+        create_test_agent_file(tmp_path)
 
         with pytest.raises(ValueError, match="Invalid configuration"):
             launch_bedrock_agentcore(config_path, local=False)
 
-    def test_launch_push_ecr_only(self, mock_boto3_clients, mock_container_runtime, tmp_path):
-        """Test push_ecr_only mode."""
-        # Create config file
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role="arn:aws:iam::123456789012:role/TestRole",
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+    def test_launch_push_ecr_only_local_build(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test push_ecr_only mode with local build."""
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
+        create_test_agent_file(tmp_path)
 
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        # Mock the build to return success
+        mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
+
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_boto3_clients["session"].client.return_value = mock_factory.iam_client
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+                return_value=mock_container_runtime,
+            ),
+        ):
+            result = launch_bedrock_agentcore(config_path, local=False, push_ecr_only=True, use_codebuild=False)
+
+            # Verify push_ecr_only mode result
+            assert result.mode == "push-ecr"
+            assert result.tag == "bedrock_agentcore-test-agent:latest"
+            assert hasattr(result, "ecr_uri")
+            assert hasattr(result, "build_output")
+
+    def test_launch_push_ecr_only_codebuild_mode(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test push_ecr_only mode with CodeBuild (default)."""
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+        )
+        create_test_agent_file(tmp_path)
+
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_factory.setup_session_mock(mock_boto3_clients)
+
+        with patch("bedrock_agentcore_starter_toolkit.services.ecr.get_or_create_ecr_repository") as mock_create_ecr:
+            mock_create_ecr.return_value = "123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo"
+
+            result = launch_bedrock_agentcore(config_path, local=False, push_ecr_only=True, use_codebuild=True)
+
+            # Verify push_ecr_only CodeBuild mode result
+            assert result.mode == "push-ecr"
+            assert result.tag == "bedrock_agentcore-test-agent:latest"
+            assert hasattr(result, "ecr_uri")
+            assert hasattr(result, "codebuild_id")
+            assert hasattr(result, "build_output")
+
+            # Verify CodeBuild workflow was executed
+            assert_codebuild_workflow_called(mock_factory)
+            # Verify no agent deployment occurred
+            assert_no_agent_deployment_calls(mock_boto3_clients)
+
+    def test_launch_local_build_cloud_deployment(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test local build with cloud deployment (use_codebuild=False)."""
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+        )
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -253,9 +335,10 @@ class TestLaunchBedrockAgentCore:
         mock_iam_client = MagicMock()
         mock_iam_client.get_role.return_value = {
             "Role": {
+                "Arn": "arn:aws:iam::123456789012:role/TestRole",
                 "AssumeRolePolicyDocument": {
                     "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
+                },
             }
         }
         mock_boto3_clients["session"].client.return_value = mock_iam_client
@@ -267,38 +350,78 @@ class TestLaunchBedrockAgentCore:
                 return_value=mock_container_runtime,
             ),
         ):
-            result = launch_bedrock_agentcore(config_path, local=False, push_ecr_only=True)
+            result = launch_bedrock_agentcore(config_path, local=False, push_ecr_only=False, use_codebuild=False)
 
-            # Verify push_ecr_only mode result
-            assert result.mode == "push-ecr"
+            # Verify local build with cloud deployment
+            assert result.mode == "cloud"
             assert result.tag == "bedrock_agentcore-test-agent:latest"
+            assert hasattr(result, "agent_arn")
+            assert hasattr(result, "agent_id")
             assert hasattr(result, "ecr_uri")
             assert hasattr(result, "build_output")
 
+            # Verify local build was used (not CodeBuild)
+            mock_container_runtime.build.assert_called_once()
+            mock_boto3_clients["bedrock_agentcore"].create_agent_runtime.assert_called_once()
+
+    def test_launch_push_ecr_codebuild_no_docker_succeeds(self, mock_boto3_clients, tmp_path):
+        """Test push_ecr_only with CodeBuild succeeds even without Docker."""
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+        )
+        create_test_agent_file(tmp_path)
+
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_factory.iam_client.get_role.return_value = {
+            "Role": {"Arn": "arn:aws:iam::123456789012:role/AmazonBedrockAgentCoreSDKCodeBuild-us-west-2-test"}
+        }
+        mock_factory.setup_full_session_mock(mock_boto3_clients)
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.services.ecr.get_or_create_ecr_repository") as mock_create_ecr,
+        ):
+            mock_create_ecr.return_value = "123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo"
+
+            # Should succeed even without Docker since it uses CodeBuild
+            result = launch_bedrock_agentcore(config_path, local=False, push_ecr_only=True, use_codebuild=True)
+
+            assert result.mode == "push-ecr"
+            assert result.tag == "bedrock_agentcore-test-agent:latest"
+            assert hasattr(result, "codebuild_id")
+            mock_factory.codebuild_client.start_build.assert_called_once()
+
+    def test_launch_push_ecr_local_build_no_docker_error(self, tmp_path):
+        """Test push_ecr_only with local build fails without Docker."""
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+        )
+        create_test_agent_file(tmp_path)
+
+        # Create a mock runtime without Docker available
+        mock_runtime_no_docker = MagicMock()
+        mock_runtime_no_docker.runtime = "none"
+        mock_runtime_no_docker.has_local_runtime = False  # No Docker available
+
+        with patch(
+            "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+            return_value=mock_runtime_no_docker,
+        ):
+            with pytest.raises(RuntimeError, match="Cannot build locally - no container runtime available"):
+                launch_bedrock_agentcore(config_path, local=False, push_ecr_only=True, use_codebuild=False)
+
     def test_launch_missing_ecr_repository(self, mock_boto3_clients, mock_container_runtime, tmp_path):
         """Test error when ECR repository not configured."""
-        # Create config file without ECR repository
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role="arn:aws:iam::123456789012:role/TestRole",
-                ecr_auto_create=False,  # No auto-create and no ECR repository
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_auto_create=False,  # No auto-create and no ECR repository
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -307,9 +430,10 @@ class TestLaunchBedrockAgentCore:
         mock_iam_client = MagicMock()
         mock_iam_client.get_role.return_value = {
             "Role": {
+                "Arn": "arn:aws:iam::123456789012:role/TestRole",
                 "AssumeRolePolicyDocument": {
                     "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
+                },
             }
         }
         mock_boto3_clients["session"].client.return_value = mock_iam_client
@@ -323,28 +447,12 @@ class TestLaunchBedrockAgentCore:
 
     def test_launch_cloud_with_execution_role_auto_create(self, mock_boto3_clients, mock_container_runtime, tmp_path):
         """Test cloud deployment with execution role auto-creation."""
-        # Create config file with execution role auto-create enabled
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role_auto_create=True,  # Enable auto-creation
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role_auto_create=True,  # Enable auto-creation
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -356,12 +464,16 @@ class TestLaunchBedrockAgentCore:
         mock_iam_client = MagicMock()
         mock_iam_client.get_role.return_value = {
             "Role": {
+                "Arn": "arn:aws:iam::123456789012:role/TestRole",
                 "AssumeRolePolicyDocument": {
                     "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
+                },
             }
         }
-        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_factory.setup_full_session_mock(mock_boto3_clients)
 
         with (
             patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
@@ -375,7 +487,7 @@ class TestLaunchBedrockAgentCore:
         ):
             mock_get_or_create_role.return_value = created_role_arn
 
-            result = launch_bedrock_agentcore(config_path, local=False)
+            result = launch_bedrock_agentcore(config_path, local=False, use_codebuild=False)
 
             # Verify execution role creation was called
             mock_get_or_create_role.assert_called_once()
@@ -403,29 +515,13 @@ class TestLaunchBedrockAgentCore:
         """Test cloud deployment with existing execution role (no auto-creation)."""
         existing_role_arn = "arn:aws:iam::123456789012:role/existing-test-role"
 
-        # Create config file with existing execution role
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role=existing_role_arn,
-                execution_role_auto_create=True,  # Should be ignored since role exists
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role=existing_role_arn,
+            execution_role_auto_create=True,  # Should be ignored since role exists
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -434,9 +530,10 @@ class TestLaunchBedrockAgentCore:
         mock_iam_client = MagicMock()
         mock_iam_client.get_role.return_value = {
             "Role": {
+                "Arn": existing_role_arn,
                 "AssumeRolePolicyDocument": {
                     "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
+                },
             }
         }
         mock_boto3_clients["session"].client.return_value = mock_iam_client
@@ -451,7 +548,7 @@ class TestLaunchBedrockAgentCore:
                 return_value=mock_container_runtime,
             ),
         ):
-            result = launch_bedrock_agentcore(config_path, local=False)
+            result = launch_bedrock_agentcore(config_path, local=False, use_codebuild=False)
 
             # Verify execution role creation was NOT called (role already exists)
             mock_create_role.assert_not_called()
@@ -470,28 +567,12 @@ class TestLaunchBedrockAgentCore:
 
     def test_launch_missing_execution_role_no_auto_create(self, mock_boto3_clients, mock_container_runtime, tmp_path):
         """Test error when execution role not configured and auto-create disabled."""
-        # Create config file without execution role and auto-create disabled
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role_auto_create=False,  # No auto-create and no execution role
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role_auto_create=False,  # No auto-create and no execution role
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -510,28 +591,12 @@ class TestLaunchBedrockAgentCore:
         self, mock_boto3_clients, mock_container_runtime, tmp_path
     ):
         """Test graceful handling of ConflictException when agent already exists."""
-        # Create config file without agent_id (simulating first deployment after agent already exists)
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role="arn:aws:iam::123456789012:role/TestRole",
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),  # No agent_id set
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -540,12 +605,17 @@ class TestLaunchBedrockAgentCore:
         mock_iam_client = MagicMock()
         mock_iam_client.get_role.return_value = {
             "Role": {
+                "Arn": "arn:aws:iam::123456789012:role/TestRole",
                 "AssumeRolePolicyDocument": {
                     "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
+                },
             }
         }
-        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_factory.iam_client = mock_iam_client  # Use provided IAM client
+        mock_factory.setup_full_session_mock(mock_boto3_clients)
 
         # Mock ConflictException on create, then successful list and update
         from botocore.exceptions import ClientError
@@ -583,7 +653,9 @@ class TestLaunchBedrockAgentCore:
                 return_value=mock_container_runtime,
             ),
         ):
-            result = launch_bedrock_agentcore(config_path, local=False, auto_update_on_conflict=True)
+            result = launch_bedrock_agentcore(
+                config_path, local=False, auto_update_on_conflict=True, use_codebuild=False
+            )
 
             # Verify that create was attempted first
             mock_boto3_clients["bedrock_agentcore"].create_agent_runtime.assert_called_once()
@@ -614,28 +686,12 @@ class TestLaunchBedrockAgentCore:
         self, mock_boto3_clients, mock_container_runtime, tmp_path
     ):
         """Test ConflictException when auto_update_on_conflict is disabled."""
-        # Create config file
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role="arn:aws:iam::123456789012:role/TestRole",
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -644,12 +700,17 @@ class TestLaunchBedrockAgentCore:
         mock_iam_client = MagicMock()
         mock_iam_client.get_role.return_value = {
             "Role": {
+                "Arn": "arn:aws:iam::123456789012:role/TestRole",
                 "AssumeRolePolicyDocument": {
                     "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
+                },
             }
         }
-        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_factory.iam_client = mock_iam_client  # Use provided IAM client
+        mock_factory.setup_full_session_mock(mock_boto3_clients)
 
         # Mock ConflictException on create
         from botocore.exceptions import ClientError
@@ -678,31 +739,14 @@ class TestLaunchBedrockAgentCore:
 
     def test_launch_cloud_with_existing_session_id_reset(self, mock_boto3_clients, mock_container_runtime, tmp_path):
         """Test that session ID gets reset when deploying to cloud."""
-        # Create config file with existing session ID
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
         existing_session_id = "existing-session-123"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role="arn:aws:iam::123456789012:role/TestRole",
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(
-                agent_session_id=existing_session_id  # Pre-existing session ID
-            ),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+            agent_session_id=existing_session_id,  # Pre-existing session ID
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -711,12 +755,17 @@ class TestLaunchBedrockAgentCore:
         mock_iam_client = MagicMock()
         mock_iam_client.get_role.return_value = {
             "Role": {
+                "Arn": "arn:aws:iam::123456789012:role/TestRole",
                 "AssumeRolePolicyDocument": {
                     "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
+                },
             }
         }
-        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_factory.iam_client = mock_iam_client  # Use provided IAM client
+        mock_factory.setup_full_session_mock(mock_boto3_clients)
 
         with (
             patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
@@ -726,7 +775,7 @@ class TestLaunchBedrockAgentCore:
             ),
             patch("bedrock_agentcore_starter_toolkit.operations.runtime.launch.log") as mock_log,
         ):
-            result = launch_bedrock_agentcore(config_path, local=False)
+            result = launch_bedrock_agentcore(config_path, local=False, use_codebuild=False)
 
             # Verify deployment succeeded
             assert result.mode == "cloud"
@@ -751,30 +800,13 @@ class TestLaunchBedrockAgentCore:
         self, mock_boto3_clients, mock_container_runtime, tmp_path
     ):
         """Test that no session ID reset occurs when no session ID exists."""
-        # Create config file without existing session ID
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            container_runtime="docker",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role="arn:aws:iam::123456789012:role/TestRole",
-                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(
-                agent_session_id=None  # No existing session ID
-            ),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+            agent_session_id=None,  # No existing session ID
         )
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
-        save_config(project_config, config_path)
-
-        # Create a test agent file
-        agent_file = tmp_path / "test_agent.py"
-        agent_file.write_text("# test agent")
+        create_test_agent_file(tmp_path)
 
         # Mock the build to return success
         mock_container_runtime.build.return_value = (True, ["Successfully built test-image"])
@@ -783,12 +815,17 @@ class TestLaunchBedrockAgentCore:
         mock_iam_client = MagicMock()
         mock_iam_client.get_role.return_value = {
             "Role": {
+                "Arn": "arn:aws:iam::123456789012:role/TestRole",
                 "AssumeRolePolicyDocument": {
                     "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
-                }
+                },
             }
         }
-        mock_boto3_clients["session"].client.return_value = mock_iam_client
+
+        # Setup mock AWS clients
+        mock_factory = MockAWSClientFactory()
+        mock_factory.iam_client = mock_iam_client  # Use provided IAM client
+        mock_factory.setup_full_session_mock(mock_boto3_clients)
 
         with (
             patch("bedrock_agentcore_starter_toolkit.services.ecr.deploy_to_ecr"),
@@ -798,7 +835,7 @@ class TestLaunchBedrockAgentCore:
             ),
             patch("bedrock_agentcore_starter_toolkit.operations.runtime.launch.log") as mock_log,
         ):
-            result = launch_bedrock_agentcore(config_path, local=False)
+            result = launch_bedrock_agentcore(config_path, local=False, use_codebuild=False)
 
             # Verify deployment succeeded
             assert result.mode == "cloud"
@@ -815,31 +852,55 @@ class TestLaunchBedrockAgentCore:
         updated_agent = updated_config.agents["test-agent"]
         assert updated_agent.bedrock_agentcore.agent_session_id is None
 
+    def test_launch_local_mode_no_docker_runtime(self, tmp_path):
+        """Test local mode when Docker is not available."""
+        config_path = create_test_config(tmp_path)
+
+        # Create a mock runtime without Docker available
+        mock_runtime_no_docker = MagicMock()
+        mock_runtime_no_docker.runtime = "none"
+        mock_runtime_no_docker.has_local_runtime = False  # No Docker available
+
+        with patch(
+            "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+            return_value=mock_runtime_no_docker,
+        ):
+            with pytest.raises(RuntimeError, match="Cannot run locally - no container runtime available"):
+                launch_bedrock_agentcore(config_path, local=True)
+
+    def test_launch_push_ecr_no_docker_runtime(self, tmp_path):
+        """Test push ECR mode when Docker is not available."""
+        config_path = create_test_config(
+            tmp_path,
+            execution_role="arn:aws:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+        )
+
+        # Create a mock runtime without Docker available
+        mock_runtime_no_docker = MagicMock()
+        mock_runtime_no_docker.runtime = "none"
+        mock_runtime_no_docker.has_local_runtime = False  # No Docker available
+
+        with patch(
+            "bedrock_agentcore_starter_toolkit.operations.runtime.launch.ContainerRuntime",
+            return_value=mock_runtime_no_docker,
+        ):
+            with pytest.raises(RuntimeError, match="Cannot build locally - no container runtime available"):
+                launch_bedrock_agentcore(config_path, push_ecr_only=True, use_codebuild=False)
+
 
 class TestEnsureExecutionRole:
     """Test _ensure_execution_role functionality."""
 
     def test_ensure_execution_role_auto_create_success(self, mock_boto3_clients, tmp_path):
         """Test successful execution role auto-creation."""
-        # Create agent config with auto-create enabled
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role_auto_create=True,
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
-        )
+        config_path = create_test_config(tmp_path, execution_role_auto_create=True)
 
-        # Create project config
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        # Load the config to get the agent and project configs
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
 
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
-        save_config(project_config, config_path)
+        project_config = load_config(config_path)
+        agent_config = project_config.agents["test-agent"]
 
         # Role name will use random suffix, so we can't predict the exact name
         created_role_arn = "arn:aws:iam::123456789012:role/AmazonBedrockAgentCoreRuntimeSDKServiceRole-abc123xyz9"
@@ -882,24 +943,17 @@ class TestEnsureExecutionRole:
         """Test when execution role already exists (no auto-creation needed)."""
         existing_role_arn = "arn:aws:iam::123456789012:role/existing-role"
 
-        # Create agent config with existing role
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role=existing_role_arn,
-                execution_role_auto_create=True,  # Should be ignored
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        config_path = create_test_config(
+            tmp_path,
+            execution_role=existing_role_arn,
+            execution_role_auto_create=True,  # Should be ignored
         )
 
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        # Load the config to get the agent and project configs
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
 
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        project_config = load_config(config_path)
+        agent_config = project_config.agents["test-agent"]
 
         # Mock IAM client response for role validation
         mock_iam_client = MagicMock()
@@ -936,23 +990,13 @@ class TestEnsureExecutionRole:
 
     def test_ensure_execution_role_no_role_no_auto_create(self, tmp_path):
         """Test error when no execution role and auto-create disabled."""
-        # Create agent config without role and auto-create disabled
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role_auto_create=False,
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
-        )
+        config_path = create_test_config(tmp_path, execution_role_auto_create=False)
 
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        # Load the config to get the agent and project configs
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
 
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        project_config = load_config(config_path)
+        agent_config = project_config.agents["test-agent"]
 
         with pytest.raises(ValueError, match="Execution role not configured and auto-create not enabled"):
             _ensure_execution_role(
@@ -966,23 +1010,13 @@ class TestEnsureExecutionRole:
 
     def test_ensure_execution_role_creation_failure(self, tmp_path):
         """Test error handling when role creation fails."""
-        # Create agent config with auto-create enabled
-        agent_config = BedrockAgentCoreAgentSchema(
-            name="test-agent",
-            entrypoint="test_agent.py",
-            aws=AWSConfig(
-                region="us-west-2",
-                account="123456789012",
-                execution_role_auto_create=True,
-                network_configuration=NetworkConfiguration(),
-                observability=ObservabilityConfig(),
-            ),
-            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
-        )
+        config_path = create_test_config(tmp_path, execution_role_auto_create=True)
 
-        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        # Load the config to get the agent and project configs
+        from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
 
-        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        project_config = load_config(config_path)
+        agent_config = project_config.agents["test-agent"]
 
         with patch(
             "bedrock_agentcore_starter_toolkit.operations.runtime.launch.get_or_create_runtime_execution_role"

--- a/tests/services/test_runtime_conflict_error.py
+++ b/tests/services/test_runtime_conflict_error.py
@@ -1,0 +1,82 @@
+"""Test for improved ConflictException error handling."""
+
+from unittest.mock import Mock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from bedrock_agentcore_starter_toolkit.services.runtime import BedrockAgentCoreClient
+
+
+def test_conflict_exception_improved_error_message():
+    """Test that ConflictException shows helpful error message about --auto-update-on-conflict flag."""
+
+    # Create a mock client
+    client = BedrockAgentCoreClient("us-east-1")
+
+    # Mock the boto3 client to raise ConflictException
+    mock_error = ClientError(
+        {"Error": {"Code": "ConflictException", "Message": "AgentName already exists"}}, "CreateAgentRuntime"
+    )
+
+    client.client.create_agent_runtime = Mock(side_effect=mock_error)
+
+    # Test that the improved error message is raised when auto_update_on_conflict=False
+    with pytest.raises(ClientError) as exc_info:
+        client.create_agent(
+            agent_name="test_agent",
+            image_uri="123456789.dkr.ecr.us-east-1.amazonaws.com/test:latest",
+            execution_role_arn="arn:aws:iam::123456789:role/test-role",
+            auto_update_on_conflict=False,
+        )
+
+    # Verify the error message mentions --auto-update-on-conflict flag
+    error_message = exc_info.value.response["Error"]["Message"]
+    assert "test_agent" in error_message
+    assert "already exists" in error_message
+    assert "--auto-update-on-conflict" in error_message
+    assert "launch command" in error_message
+
+
+def test_conflict_exception_with_auto_update_enabled():
+    """Test that ConflictException triggers update flow when auto_update_on_conflict=True."""
+
+    # Create a mock client
+    client = BedrockAgentCoreClient("us-east-1")
+
+    # Mock the boto3 client to raise ConflictException initially
+    mock_error = ClientError(
+        {"Error": {"Code": "ConflictException", "Message": "AgentName already exists"}}, "CreateAgentRuntime"
+    )
+
+    client.client.create_agent_runtime = Mock(side_effect=mock_error)
+
+    # Mock find_agent_by_name to return existing agent
+    existing_agent = {
+        "agentRuntimeId": "existing-agent-id",
+        "agentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:123456789:agent-runtime/existing-agent-id",
+    }
+    client.find_agent_by_name = Mock(return_value=existing_agent)
+
+    # Mock update_agent to succeed
+    client.update_agent = Mock(
+        return_value={
+            "id": "existing-agent-id",
+            "arn": "arn:aws:bedrock-agentcore:us-east-1:123456789:agent-runtime/existing-agent-id",
+        }
+    )
+
+    # Test that auto_update_on_conflict=True triggers update flow
+    result = client.create_agent(
+        agent_name="test_agent",
+        image_uri="123456789.dkr.ecr.us-east-1.amazonaws.com/test:latest",
+        execution_role_arn="arn:aws:iam::123456789:role/test-role",
+        auto_update_on_conflict=True,
+    )
+
+    # Verify that update_agent was called
+    client.update_agent.assert_called_once()
+
+    # Verify the result contains the existing agent info
+    assert result["id"] == "existing-agent-id"
+    assert "existing-agent-id" in result["arn"]

--- a/tests_integ/notebook/test_runtime.py
+++ b/tests_integ/notebook/test_runtime.py
@@ -5,5 +5,7 @@ if __name__ == "__main__":
 
     runtime.configure(entrypoint="agent_example.py", agent_name="test14", auto_create_execution_role=True)
 
-    resp = runtime.launch(use_codebuild=True, auto_update_on_conflict=True)
+    resp = runtime.launch()
+
+
     print(resp)


### PR DESCRIPTION
This commit makes CodeBuild the default deployment method for better user experience:

BREAKING CHANGES:
- CodeBuild is now the default launch option (use_codebuild=True by default)
- Users must explicitly use --local-build flag to build locally with Docker
- Improved CLI help text to guide users toward recommended options

Key improvements:
- CodeBuild builds ARM64 containers in the cloud without requiring local Docker
- Better error messages with actionable recommendations
- Clearer CLI option descriptions and help text
- Enhanced conflict exception handling with --auto-update-on-conflict guidance
