### PR TITLE
preserve new lines in docstring for help text

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -6,7 +6,7 @@ from ..cli.gateway.commands import create_mcp_gateway, create_mcp_gateway_target
 from ..utils.logging_config import setup_toolkit_logging
 from .runtime.commands import configure_app, invoke, launch, status
 
-app = typer.Typer(name="agentcore", help="BedrockAgentCore CLI", add_completion=False)
+app = typer.Typer(name="agentcore", help="BedrockAgentCore CLI", add_completion=False, rich_markup_mode="rich")
 
 # Setup centralized logging for CLI
 setup_toolkit_logging(mode="cli")

--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -355,7 +355,7 @@ def launch(
 
             # Show deployment options hint for first-time users
             console.print("[dim]💡 Deployment options:[/dim]")
-            console.print("[dim]   • agentcore launch                 → CodeBuild (current)[/dim]")
+            console.print("[dim]   • agentcore launch                → CodeBuild (current)[/dim]")
             console.print("[dim]   • agentcore launch --local        → Local development[/dim]")
             console.print("[dim]   • agentcore launch --local-build  → Local build + cloud deploy[/dim]\n")
 


### PR DESCRIPTION
## Description

Change `rich_markup_mode` to `rich` to preserve newlines in docstrings when displaying help text

### Before
<img width="2537" height="792" alt="image" src="https://github.com/user-attachments/assets/9ba2fe76-e002-40b1-a91b-1e068faff90d" />
<img width="2534" height="627" alt="image" src="https://github.com/user-attachments/assets/592d52cf-d0b7-491d-a3ce-fa5bbacfb6b4" />
<img width="2537" height="824" alt="image" src="https://github.com/user-attachments/assets/5c7027f3-15c0-400e-940f-8421b0fea0f9" />

### After
<img width="2539" height="1226" alt="image" src="https://github.com/user-attachments/assets/7fb5d7ab-7706-465f-8282-121e8eb9673c" />
<img width="2532" height="718" alt="image" src="https://github.com/user-attachments/assets/6c292d00-73b1-48b0-bc9f-7fff88f8cee3" />
<img width="2536" height="992" alt="image" src="https://github.com/user-attachments/assets/6ae0890e-e8e9-4e98-9bba-d87bdeb81f43" />


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
