### PR TITLE
fix: Pass environment variables when using CodeBuild for deployment

### DIFF
--- a/documentation/docs/user-guide/runtime/permissions.md
+++ b/documentation/docs/user-guide/runtime/permissions.md
@@ -249,7 +249,7 @@ The toolkit uses AWS CodeBuild for ARM64 container builds, especially useful in 
 The Runtime Execution Role is an IAM role that AgentCore Runtime assumes to run an agent. Replace the following:
 
 - `region` with the AWS Region that you are using
-- `accountId` with your AWS account ID  
+- `accountId` with your AWS account ID
 - `agentName` with the name of your agent. You'll need to decide the agent name before creating the role and AgentCore Runtime.
 
 ### Permissions Policy

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -282,6 +282,7 @@ def launch_bedrock_agentcore(
             agent_config=agent_config,
             project_config=project_config,
             auto_update_on_conflict=auto_update_on_conflict,
+            env_vars=env_vars,
         )
 
     # Log which agent is being launched
@@ -378,6 +379,7 @@ def _launch_with_codebuild(
     agent_config,
     project_config,
     auto_update_on_conflict: bool = False,
+    env_vars: Optional[dict] = None,
 ) -> LaunchResult:
     """Launch using CodeBuild for ARM64 builds."""
     log.info(
@@ -441,7 +443,7 @@ def _launch_with_codebuild(
         agent_name,
         ecr_uri,
         region,
-        env_vars=None,
+        env_vars=env_vars,
         auto_update_on_conflict=auto_update_on_conflict,
     )
 

--- a/src/bedrock_agentcore_starter_toolkit/services/runtime.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/runtime.py
@@ -428,7 +428,7 @@ class HttpBedrockAgentCoreClient:
                 params={"qualifier": endpoint_name},
                 headers=headers,
                 json=body,
-                timeout=100,
+                timeout=900,
                 stream=True,
             )
             return _handle_http_response(response)
@@ -466,7 +466,7 @@ class LocalBedrockAgentCoreClient:
 
         try:
             # Make request with timeout
-            response = requests.post(url, headers=headers, json=body, timeout=100, stream=True)
+            response = requests.post(url, headers=headers, json=body, timeout=900, stream=True)
             return _handle_http_response(response)
         except requests.exceptions.RequestException as e:
             self.logger.error("Failed to invoke agent endpoint: %s", str(e))

--- a/tests/operations/runtime/test_launch.py
+++ b/tests/operations/runtime/test_launch.py
@@ -815,6 +815,47 @@ class TestLaunchBedrockAgentCore:
         updated_agent = updated_config.agents["test-agent"]
         assert updated_agent.bedrock_agentcore.agent_session_id is None
 
+    def test_launch_with_codebuild_from_main_function(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test that environment variables are passed from launch_bedrock_agentcore to _launch_with_codebuild."""
+        # Create config file
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role="arn:aws:iam::123456789012:role/TestRole",
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Test environment variables
+        test_env_vars = {"TEST_VAR1": "value1", "TEST_VAR2": "value2"}
+
+        with patch(
+            "bedrock_agentcore_starter_toolkit.operations.runtime.launch._launch_with_codebuild"
+        ) as mock_launch_with_codebuild:
+            mock_launch_with_codebuild.return_value = MagicMock()
+
+            # Run launch_bedrock_agentcore with use_codebuild=True and env_vars
+            launch_bedrock_agentcore(config_path=config_path, use_codebuild=True, env_vars=test_env_vars)
+
+            # Verify _launch_with_codebuild was called with the environment variables
+            mock_launch_with_codebuild.assert_called_once()
+            # Check that env_vars parameter was passed to _launch_with_codebuild
+            assert mock_launch_with_codebuild.call_args.kwargs["env_vars"] == test_env_vars
+
 
 class TestEnsureExecutionRole:
     """Test _ensure_execution_role functionality."""
@@ -1075,3 +1116,87 @@ class TestEnsureExecutionRole:
         result = _validate_execution_role("arn:aws:iam::123456789012:role/nonexistent-role", mock_session)
 
         assert result is False
+
+    def test_launch_with_codebuild_passes_env_vars(self, mock_boto3_clients, mock_container_runtime, tmp_path):
+        """Test that environment variables are passed with CodeBuild deployment."""
+        from bedrock_agentcore_starter_toolkit.operations.runtime.launch import _launch_with_codebuild
+
+        # Create config file
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        agent_config = BedrockAgentCoreAgentSchema(
+            name="test-agent",
+            entrypoint="test_agent.py",
+            container_runtime="docker",
+            aws=AWSConfig(
+                region="us-west-2",
+                account="123456789012",
+                execution_role="arn:aws:iam::123456789012:role/TestRole",
+                ecr_repository="123456789012.dkr.ecr.us-west-2.amazonaws.com/test-repo",
+                network_configuration=NetworkConfiguration(),
+                observability=ObservabilityConfig(),
+            ),
+            bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
+        )
+        project_config = BedrockAgentCoreConfigSchema(default_agent="test-agent", agents={"test-agent": agent_config})
+        save_config(project_config, config_path)
+
+        # Create a test agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        # Mock CodeBuild service
+        mock_codebuild_service = MagicMock()
+        mock_codebuild_service.create_codebuild_execution_role.return_value = (
+            "arn:aws:iam::123456789012:role/CodeBuildRole"
+        )
+        mock_codebuild_service.upload_source.return_value = "s3://test-bucket/test-source.zip"
+        mock_codebuild_service.create_or_update_project.return_value = "test-project"
+        mock_codebuild_service.start_build.return_value = "test-build-id"
+        mock_codebuild_service.wait_for_completion.return_value = None
+        mock_codebuild_service.source_bucket = "test-bucket"
+
+        # Test environment variables
+        test_env_vars = {"TEST_VAR1": "value1", "TEST_VAR2": "value2"}
+
+        # Mock IAM client for role validation
+        mock_iam_client = MagicMock()
+        mock_iam_client.get_role.return_value = {
+            "Role": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{"Effect": "Allow", "Principal": {"Service": "bedrock-agentcore.amazonaws.com"}}]
+                }
+            }
+        }
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.CodeBuildService",
+                return_value=mock_codebuild_service,
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch._deploy_to_bedrock_agentcore"
+            ) as mock_deploy,
+            patch("bedrock_agentcore_starter_toolkit.operations.runtime.launch.boto3.Session") as mock_session,
+        ):
+            # Set up the session's client method to return our mock IAM client
+            mock_session.return_value.client.return_value = mock_iam_client
+
+            # Configure _deploy_to_bedrock_agentcore mock to return agent_id and agent_arn
+            mock_deploy.return_value = (
+                "test-agent-id",
+                "arn:aws:bedrock-agentcore:us-west-2:123456789012:agent/test-agent-id",
+            )
+
+            # Run _launch_with_codebuild with environment variables
+            _launch_with_codebuild(
+                config_path=config_path,
+                agent_name="test-agent",
+                agent_config=agent_config,
+                project_config=project_config,
+                env_vars=test_env_vars,
+            )
+
+            # Verify _deploy_to_bedrock_agentcore was called with the environment variables
+            mock_deploy.assert_called_once()
+            # Check the env_vars parameter
+            assert mock_deploy.call_args.kwargs["env_vars"] == test_env_vars

--- a/tests/services/test_runtime.py
+++ b/tests/services/test_runtime.py
@@ -326,7 +326,7 @@ class TestHttpBedrockAgentCoreClient:
             assert params["qualifier"] == "DEFAULT"
 
             # Check timeout
-            assert call_args[1]["timeout"] == 100
+            assert call_args[1]["timeout"] == 900
 
             # Verify response
             assert result["response"] == "data: response content\n\n"
@@ -536,7 +536,7 @@ class TestLocalBedrockAgentCoreClient:
             assert body == {"message": "hello"}
 
             # Check timeout
-            assert call_args[1]["timeout"] == 100
+            assert call_args[1]["timeout"] == 900
             assert call_args[1]["stream"] is True
 
             # Verify response handling


### PR DESCRIPTION
- Added env_vars parameter to _launch_with_codebuild function
- Updated the function call in launch_bedrock_agentcore to pass env_vars
- Fixed tests for environment variables passing in CodeBuild deployments
- Increased HTTP client timeouts from 100s to 900s for better reliability

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
