### PR TITLE
release v0.1.3 - CodeBuild as default with UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.1.3] - 2025-08-01
+
+### BREAKING CHANGES
+- **CodeBuild is now the default launch method** - The `--codebuild` flag is no longer needed
+  - To use local Docker builds, you must now explicitly use `--local-build` flag
+  - This change improves the default user experience by building ARM64 containers in the cloud without requiring local Docker
+
+### Added
+- **Streaming invoke support re-enabled** - Restored streaming functionality for real-time agent responses
+- **Extended request timeout** - Increased invoke request timeout from default to 900 seconds (15 minutes) to support long-running agent operations
+
+### Changed
+- **Default launch behavior** - CodeBuild is now the default (`use_codebuild=True`)
+  - Users no longer need Docker installed locally for standard deployments
+  - Automatic ARM64 container builds in AWS CodeBuild
+  - Use `agentcore launch` for cloud builds (default)
+  - Use `agentcore launch --local-build` for local Docker builds
+
+### Improved
+- **Enhanced CLI help text** - Clearer descriptions guide users toward recommended options
+- **Better error messages** - Actionable recommendations for common issues
+- **Conflict handling** - Enhanced exception messages now suggest using `--auto-update-on-conflict` flag
+
+
 ## [0.1.2] - 2025-07-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bedrock-agentcore-starter-toolkit"
-version = "0.1.2"
+version = "0.1.3"
 description = "A starter toolkit for using Bedrock AgentCore"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "bedrock-agentcore-starter-toolkit"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },


### PR DESCRIPTION
BREAKING CHANGE: CodeBuild is now the default launch method
- Users must use --local-build flag for local Docker builds
- Increased invoke timeout to 900s
- Re-enabled streaming invoke support

## Description

Brief description of changes

## Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [X ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [ ] Manual testing completed

## Checklist

- [X ] My code follows the project's style guidelines (ruff/pre-commit)
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [X ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
- [X ] Any dependent changes have been merged and published

## Security Checklist

- [X ] No hardcoded secrets or credentials
- [X ] No new security warnings from bandit
- [X ] Dependencies are from trusted sources
- [X ] No sensitive data logged

