### PR TITLE
fix: close NameTemporaryFile for Windows

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/services/codebuild.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/codebuild.py
@@ -109,6 +109,7 @@ class CodeBuildService:
                 return f"s3://{bucket_name}/{s3_key}"
 
             finally:
+                temp_zip.close()
                 os.unlink(temp_zip.name)
 
     def _normalize_s3_location(self, source_location: str) -> str:


### PR DESCRIPTION
## Description

When developing on a Windows system `agentcore_runtime.launch()` always fails due to an existing file handle. While this is not an issue on unix systems, Windows refuses to proceed. 

Error message is as follows:

> PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [ ] Dependencies are from trusted sources
- [ ] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
