### PR TITLE
bump the default otel dependency

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/Dockerfile.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/Dockerfile.j2
@@ -14,7 +14,7 @@ RUN pip install -r {{ dependencies_file }}
 {% endif %}
 
 {% if observability_enabled %}
-RUN pip install aws-opentelemetry-distro>=0.10.0
+RUN pip install aws-opentelemetry-distro>=0.10.1
 {% endif %}
 
 # Set AWS region environment variable


### PR DESCRIPTION
## Description

This is to take in the fix: https://t.corp.amazon.com/V1869006757/, where otel was transforming bedrock tool outputs

