### PR TITLE
fix: invalid escape sequence in import agent URL regex

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/services/import_agent/scripts/base_bedrock_translate.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/import_agent/scripts/base_bedrock_translate.py
@@ -1031,6 +1031,10 @@ class BaseBedrockTranslator:
 
             return code_1p
 
+    def _get_url_regex_pattern(self) -> str:
+        """Get the URL regex pattern for source extraction."""
+        return r'(?:https?://|www\.)(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:/[^/\s]*)*'
+
     def generate_entrypoint_code(self, platform: str) -> str:
         """Generate entrypoint code for the agent."""
         entrypoint_code = ""
@@ -1059,6 +1063,7 @@ class BaseBedrockTranslator:
             else "tools_used.update([msg.name for msg in agent_result if isinstance(msg, ToolMessage)])"
         )
         response_content_code = "str(agent_result)" if platform == "strands" else "agent_result[-1].content"
+        url_pattern = self._get_url_regex_pattern()
 
         entrypoint_code += f"""
     def endpoint(payload, context):
@@ -1079,7 +1084,7 @@ class BaseBedrockTranslator:
 
             # Gathering sources from the response
             sources = []
-            urls = re.findall(r'(?:https?://|www\.)(?:[a-zA-Z0-9\-]+\.)+[a-zA-Z]{{2,}}(?:/[^/\s]*)*', response_content)
+            urls = re.findall({repr(url_pattern)}, response_content)
             source_tags = re.findall(r"<source>(.*?)</source>", response_content)
             sources.extend(urls)
             sources.extend(source_tags)


### PR DESCRIPTION
## Description

Resolves `SyntaxWarning` for invalid escape sequences (`\.` and `\s`) in URL regex pattern within generated agent code. The warnings appeared when running `agentcore configure`, indicating potential downstream issues with generated scripts.

Extracts regex pattern to separate method using raw string and embeds safely with `repr()` to avoid f-string escape issues.

**Error Fixed:**
Executing `agentcore configure` led to the following warning messages:
```
[...]/services/import_agent/scripts/base_bedrock_translate.py:1095: 
SyntaxWarning: invalid escape sequence '.'
[...]/services/import_agent/scripts/base_bedrock_translate.py:1095: 
SyntaxWarning: invalid escape sequence '\s'
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Unit tests pass locally
- [x] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

This is a bug fix. No breaking changes

## Additional Notes

The fix maintains identical functionality while eliminating Python `SyntaxWarnings`. Generated code remains unchanged in behavior, only the generation method is improved for better maintainability.
