### PR TITLE
Remove reference to IAM users, remove erroneous AWS CLI commands

### DIFF
--- a/documentation/docs/user-guide/identity/quickstart.md
+++ b/documentation/docs/user-guide/identity/quickstart.md
@@ -8,7 +8,7 @@ Before you begin, ensure you have:
 
 - An AWS account with appropriate permissions
 - Python 3.10+ installed
-- AWS CLI configured with your credentials
+- AWS credentials and region configured (`aws configure`)
 - (Optional) External service accounts for OAuth2 or API key integration
 
 ## Install the SDK
@@ -41,13 +41,6 @@ print(f"Workload Identity ARN: {workload_identity['workloadIdentityArn']}")
 print(f"Agent Name: {workload_identity['name']}")
 ```
 
-You can also use the AWS CLI:
-
-```bash
-aws bedrock-agentcore create-workload-identity \
-    --name "my-research-agent"
-```
-
 ## Configure Credential Providers
 
 Credential providers define how your agent accesses external services:
@@ -76,22 +69,6 @@ perplexity_provider = identity_client.create_api_key_credential_provider(req={
     "name": "myPerplexityAPIKeyCredentialProvider",
     "apiKey": "myApiKey"
 })
-```
-
-## Configure Environment Variables
-
-Set up environment variables for your development environment:
-
-```bash
-# AWS Configuration
-export AWS_REGION=us-west-2
-export AWS_ACCESS_KEY_ID=your-access-key-id
-export AWS_SECRET_ACCESS_KEY=your-secret-access-key
-
-# Agent Configuration
-export AGENT_IDENTITY_ID=your-agent-identity-id
-export AGENT_IDENTITY_ARN=your-agent-identity-arn
-export WORKLOAD_ACCESS_TOKEN=your-workload-access-token
 ```
 
 ## Building a Simple Research Agent


### PR DESCRIPTION
## Description

Not going to direct users to setup IAM users anymore, removing aws CLI commands that do not exist.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [ ] Manual testing completed

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [ ] No hardcoded secrets or credentials
- [ ] No new security warnings from bandit
- [ ] Dependencies are from trusted sources
- [ ] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
