### PR TITLE
feat: support AWS_REGION environment variable for region configuration

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/services/ecr.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/ecr.py
@@ -1,6 +1,7 @@
 """ECR (Elastic Container Registry) service integration."""
 
 import base64
+import os
 
 import boto3
 
@@ -14,7 +15,7 @@ def get_account_id() -> str:
 
 def get_region() -> str:
     """Get AWS region."""
-    return boto3.Session().region_name or "us-west-2"
+    return os.getenv("AWS_REGION") or boto3.Session().region_name or "us-west-2"
 
 
 def create_ecr_repository(repo_name: str, region: str) -> str:

--- a/tests/services/test_ecr.py
+++ b/tests/services/test_ecr.py
@@ -1,5 +1,7 @@
 """Tests for Bedrock AgentCore ECR service integration."""
 
+import os
+
 import pytest
 
 from bedrock_agentcore_starter_toolkit.services.ecr import (
@@ -86,6 +88,12 @@ class TestECRService:
         """Test AWS region detection."""
         region = get_region()
         assert region == "us-west-2"
+
+        # Test if it can be overridden with AWS_REGION
+        os.environ["AWS_REGION"] = "us-east-1"
+        region = get_region()
+        assert region == "us-east-1"
+        del os.environ["AWS_REGION"]
 
         # Test default fallback
         mock_boto3_clients["session"].region_name = None


### PR DESCRIPTION
## Description

Under the current specification, setting the AWS_REGION environment variable and running agentcore launch results in an error because the region is not properly configured.

The reason AWS_REGION is not being read is that boto3 irregularly reads the AWS_DEFAULT_REGION environment variable instead. The status of environment variables for other CLIs and SDKs is summarized in the following link:

https://stackoverflow.com/questions/59961939/what-is-the-difference-between-aws-default-region-and-aws-region-system-variable

I believe we should align with the AWS standard specification rather than boto3's specific behavior. Therefore, I've made changes so that when AWS_REGION is set, agentcore launch will execute in that specified region.

This change is categorized as a breaking change because if AWS_REGION is unintentionally set, agentcore launch might execute in an unintended region. However, I believe such cases would be rare.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [-] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

If unintended deployment to a different region occurs due to AWS_REGION, you will need to either remove or override the AWS_REGION environment variable. AWS_DEFAULT_REGION remains available for use, but AWS_REGION takes higher precedence.

## Additional Notes

N/A
