### PR TITLE
feat(cli): add non-interactive mode to configure command

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -68,13 +68,22 @@ def _prompt_for_requirements_file(prompt_text: str, default: str = "") -> Option
     return None
 
 
-def _handle_requirements_file_display(requirements_file: Optional[str]) -> Optional[str]:
+def _handle_requirements_file_display(requirements_file: Optional[str], non_interactive: bool = False) -> Optional[str]:
     """Handle requirements file with display logic for CLI."""
     from ...utils.runtime.entrypoint import detect_dependencies
 
     if requirements_file:
         # User provided file - validate and show confirmation
         return _validate_requirements_file(requirements_file)
+
+    if non_interactive:
+        # Auto-detection for non-interactive mode
+        deps = detect_dependencies(Path.cwd())
+        if deps.found:
+            _print_success(f"Using detected file: [dim]{deps.file}[/dim]")
+            return None  # Use detected file
+        else:
+            _handle_error("No requirements file specified and none found automatically")
 
     # Auto-detection with interactive prompt
     deps = detect_dependencies(Path.cwd())
@@ -170,6 +179,9 @@ def configure(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
     region: Optional[str] = typer.Option(None, "--region", "-r"),
     protocol: Optional[str] = typer.Option(None, "--protocol", "-p", help="Server protocol (HTTP or MCP)"),
+    non_interactive: bool = typer.Option(
+        False, "--non-interactive", help="Skip prompts; use defaults unless overridden"
+    ),
 ):
     """Configure a Bedrock AgentCore agent. The agent name defaults to your Python file name."""
     if ctx.invoked_subcommand is not None:
@@ -196,7 +208,7 @@ def configure(
 
     # Create configuration manager for clean, elegant prompting
     config_path = Path.cwd() / ".bedrock_agentcore.yaml"
-    config_manager = ConfigurationManager(config_path)
+    config_manager = ConfigurationManager(config_path, non_interactive)
 
     # Interactive prompts for missing values - clean and elegant
     if not execution_role:
@@ -217,7 +229,7 @@ def configure(
         _print_success(f"Using existing ECR repository: [dim]{ecr_repository}[/dim]")
 
     # Handle dependency file selection with simplified logic
-    final_requirements_file = _handle_requirements_file_display(requirements_file)
+    final_requirements_file = _handle_requirements_file_display(requirements_file, non_interactive)
 
     # Handle OAuth authorization configuration
     oauth_config = None

--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/configuration_manager.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/configuration_manager.py
@@ -10,19 +10,25 @@ from ..common import _handle_error, _print_success, _prompt_with_default, consol
 class ConfigurationManager:
     """Manages interactive configuration prompts with existing configuration defaults."""
 
-    def __init__(self, config_path: Path):
+    def __init__(self, config_path: Path, non_interactive: bool = False):
         """Initialize the ConfigPrompt with a configuration path.
 
         Args:
             config_path: Path to the configuration file
+            non_interactive: If True, use defaults without prompting
         """
         from ...utils.runtime.config import load_config_if_exists
 
         project_config = load_config_if_exists(config_path)
         self.existing_config = project_config.get_agent_config() if project_config else None
+        self.non_interactive = non_interactive
 
     def prompt_execution_role(self) -> Optional[str]:
         """Prompt for execution role. Returns role name/ARN or None for auto-creation."""
+        if self.non_interactive:
+            _print_success("Will auto-create execution role")
+            return None
+
         console.print("\n🔐 [cyan]Execution Role[/cyan]")
         console.print(
             "[dim]Press Enter to auto-create execution role, or provide execution role ARN/name to use existing[/dim]"
@@ -43,6 +49,10 @@ class ConfigurationManager:
 
     def prompt_ecr_repository(self) -> tuple[Optional[str], bool]:
         """Prompt for ECR repository. Returns (repository, auto_create_flag)."""
+        if self.non_interactive:
+            _print_success("Will auto-create ECR repository")
+            return None, True
+
         console.print("\n🏗️  [cyan]ECR Repository[/cyan]")
         console.print(
             "[dim]Press Enter to auto-create ECR repository, or provide ECR Repository URI to use existing[/dim]"
@@ -63,6 +73,10 @@ class ConfigurationManager:
 
     def prompt_oauth_config(self) -> Optional[dict]:
         """Prompt for OAuth configuration. Returns OAuth config dict or None."""
+        if self.non_interactive:
+            _print_success("Using default IAM authorization")
+            return None
+
         console.print("\n🔐 [cyan]Authorization Configuration[/cyan]")
         console.print("[dim]By default, Bedrock AgentCore uses IAM authorization.[/dim]")
 


### PR DESCRIPTION
## Summary

This PR adds a  flag to the ❌ --entrypoint is required command to support automated workflows and CI/CD pipelines.

## Changes

- **New Flag**: Added  option to skip all interactive prompts
- **Smart Defaults**: Uses sensible defaults for all configuration options:
  - Auto-creates execution role and ECR repository
  - Uses detected dependency files (requirements.txt/pyproject.toml) or fails gracefully
  - Defaults to IAM authorization (skips OAuth configuration prompts)
- **Backward Compatibility**: Existing behavior unchanged when flag is not used
- **Test Coverage**: Added comprehensive test for non-interactive mode with minimal defaults

## Use Cases

- **CI/CD Pipelines**: Automated agent deployment without manual intervention
- **Scripted Workflows**: Batch configuration of multiple agents
- **Development Automation**: Quick setup with sensible defaults

## Example Usage

```bash
# Non-interactive configuration with auto-created resources
agentcore configure --entrypoint my_agent.py --non-interactive

# Non-interactive with custom execution role
agentcore configure --entrypoint my_agent.py --execution-role MyRole --non-interactive
```

## Testing

- ✅ All existing tests pass
- ✅ New test for non-interactive mode with minimal defaults
- ✅ Pre-commit hooks pass (formatting, linting, security, coverage)
- ✅ Manual testing of both interactive and non-interactive modes

## Implementation Details

- Modified  to accept  parameter
- Updated all prompt methods to check flag and use defaults
- Enhanced requirements file detection for non-interactive mode
- Maintained clean separation between interactive and non-interactive flows