### PR TITLE
Support for Cross Account Code Builds

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
+++ b/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
@@ -46,6 +46,8 @@ class Runtime:
         region: Optional[str] = None,
         protocol: Optional[Literal["HTTP", "MCP"]] = None,
         disable_otel: bool = False,
+        build_account: Optional[str] = None,
+        build_role_arn: Optional[str] = None,
     ) -> ConfigureResult:
         """Configure Bedrock AgentCore from notebook using an entrypoint file.
 
@@ -64,7 +66,8 @@ class Runtime:
             region: AWS region for deployment
             protocol: agent server protocol, must be either HTTP or MCP
             disable_otel: Whether to disable OpenTelemetry observability (default: False)
-
+            build_account: Optional AWS account ID for CodeBuild (if different from deployment account)
+            build_role_arn: Optional IAM role ARN to assume for CodeBuild operations
         Returns:
             ConfigureResult with configuration details
         """
@@ -117,6 +120,8 @@ class Runtime:
             authorizer_configuration=authorizer_configuration,
             region=region,
             protocol=protocol.upper() if protocol else None,
+            build_account=build_account,
+            build_role_arn=build_role_arn,
         )
 
         self._config_path = result.config_path

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
@@ -35,6 +35,8 @@ def configure_bedrock_agentcore(
     verbose: bool = False,
     region: Optional[str] = None,
     protocol: Optional[str] = None,
+    build_account: Optional[str] = None,
+    build_role_arn: Optional[str] = None,    
 ) -> ConfigureResult:
     """Configure Bedrock AgentCore application with deployment settings.
 
@@ -190,6 +192,8 @@ def configure_bedrock_agentcore(
             network_configuration=NetworkConfiguration(network_mode="PUBLIC"),
             protocol_configuration=ProtocolConfiguration(server_protocol=protocol or "HTTP"),
             observability=ObservabilityConfig(enabled=enable_observability),
+            build_account=build_account,
+            build_role_arn=build_role_arn,
         ),
         bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
         authorizer_configuration=authorizer_configuration,

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -23,7 +23,41 @@ from .models import LaunchResult
 
 log = logging.getLogger(__name__)
 
-
+def _create_build_session(agent_config, region: str) -> boto3.Session:
+    """Create AWS session for CodeBuild operations.
+    
+    Args:
+        agent_config: Agent configuration containing build account settings
+        region: AWS region
+        
+    Returns:
+        boto3.Session configured for CodeBuild operations
+    """
+    build_role_arn = agent_config.aws.get_build_role_arn()
+    
+    if build_role_arn:
+        # Assume role for CodeBuild operations
+        sts_client = boto3.client('sts', region_name=region)
+        
+        try:
+            response = sts_client.assume_role(
+                RoleArn=build_role_arn,
+                RoleSessionName=f"bedrock-agentcore-build-{int(time.time())}"
+            )
+            
+            credentials = response['Credentials']
+            return boto3.Session(
+                aws_access_key_id=credentials['AccessKeyId'],
+                aws_secret_access_key=credentials['SecretAccessKey'],
+                aws_session_token=credentials['SessionToken'],
+                region_name=region
+            )
+        except ClientError as e:
+            raise RuntimeError(f"Failed to assume build role {build_role_arn}: {e}")
+    
+    # Use current session if no build role specified
+    return boto3.Session(region_name=region)
+    
 def _ensure_ecr_repository(agent_config, project_config, config_path, agent_name, region):
     """Ensure ECR repository exists (idempotent)."""
     ecr_uri = agent_config.aws.ecr_repository
@@ -394,7 +428,6 @@ def launch_bedrock_agentcore(
         build_output=output,
     )
 
-
 def _execute_codebuild_workflow(
     config_path: Path,
     agent_name: str,
@@ -405,44 +438,87 @@ def _execute_codebuild_workflow(
     env_vars: Optional[dict] = None,
 ) -> LaunchResult:
     """Launch using CodeBuild for ARM64 builds."""
+    
+    region = agent_config.aws.region
+    deployment_account = agent_config.aws.account
+    build_account = agent_config.aws.get_build_account()
+    ecr_account = agent_config.aws.get_ecr_account()
+    scenario = agent_config.aws.get_deployment_scenario()
+    
     log.info(
         "Starting CodeBuild ARM64 deployment for agent '%s' to account %s (%s)",
         agent_name,
         agent_config.aws.account,
         agent_config.aws.region,
     )
+    log.info("Deployment scenario: %s", scenario)
+    log.info("Deployment account: %s", deployment_account)
+    log.info("Build account: %s", build_account)
+    log.info("ECR account: %s", ecr_account)
+
+    if agent_config.aws.is_cross_account_build():
+        log.info("Cross-account CodeBuild enabled")
+        log.info("Build role: %s", agent_config.aws.get_build_role_arn())
+    
+    if agent_config.aws.is_cross_account_ecr():
+        log.info("Cross-account ECR enabled")
+        
     # Validate configuration
     errors = agent_config.validate(for_local=False)
     if errors:
         raise ValueError(f"Invalid configuration: {', '.join(errors)}")
-
-    region = agent_config.aws.region
+    
     if not region:
         raise ValueError("Region not found in configuration")
 
-    session = boto3.Session(region_name=region)
-    account_id = agent_config.aws.account  # Use existing account from config
-
+    #session = boto3.Session(region_name=region)
+    #account_id = agent_config.aws.account  # Use existing account from config
+    # Create sessions based on scenario
+    deployment_session = boto3.Session(region_name=region)
+    # Only create build session if CodeBuild is cross-account
+    if agent_config.aws.is_cross_account_build():
+        build_session = _create_build_session(agent_config, region)
+    else:
+        build_session = deployment_session
+        
     # Setup AWS resources
     log.info("Setting up AWS resources (ECR repository%s)...", "" if ecr_only else ", execution roles")
     ecr_uri = _ensure_ecr_repository(agent_config, project_config, config_path, agent_name, region)
-    ecr_repository_arn = f"arn:aws:ecr:{region}:{account_id}:repository/{ecr_uri.split('/')[-1]}"
+
+    # Parse ECR URI to get account and repository name
+    ecr_parts = ecr_uri.split('/')
+    ecr_account = ecr_parts[0].split('.')[0]
+    ecr_repo_name = ecr_parts[-1]
+    ecr_repository_arn = f"arn:aws:ecr:{region}:{ecr_account}:repository/{ecr_repo_name}"
+    #ecr_repository_arn = f"arn:aws:ecr:{region}:{account_id}:repository/{ecr_uri.split('/')[-1]}"
 
     # Setup execution role only if not ECR-only mode
     if not ecr_only:
-        _ensure_execution_role(agent_config, project_config, config_path, agent_name, region, account_id)
+        #_ensure_execution_role(agent_config, project_config, config_path, agent_name, region, account_id)
+        _ensure_execution_role(agent_config, project_config, config_path, agent_name, region, deployment_account)
 
     # Prepare CodeBuild
     log.info("Preparing CodeBuild project and uploading source...")
-    codebuild_service = CodeBuildService(session)
-
+    #codebuild_service = CodeBuildService(session)
+    if scenario in ["cross_account_build_only", "full_cross_account"]:
+        # CodeBuild is cross-account: use separate sessions
+        log.info("Using cross-account CodeBuild session")
+        codebuild_service = CodeBuildService(deployment_session, build_session)
+        account_for_codebuild = build_account
+    else:
+        # CodeBuild is same-account: use deployment session only
+        log.info("Using same-account CodeBuild session")
+        codebuild_service = CodeBuildService(deployment_session)
+        account_for_codebuild = deployment_account
+        
     # Use cached CodeBuild role from config if available
     if hasattr(agent_config, "codebuild") and agent_config.codebuild.execution_role:
         log.info("Using CodeBuild role from config: %s", agent_config.codebuild.execution_role)
         codebuild_execution_role = agent_config.codebuild.execution_role
     else:
         codebuild_execution_role = codebuild_service.create_codebuild_execution_role(
-            account_id=account_id, ecr_repository_arn=ecr_repository_arn, agent_name=agent_name
+            #account_id=account_id, ecr_repository_arn=ecr_repository_arn, agent_name=agent_name
+            account_id=account_for_codebuild, ecr_repository_arn=ecr_repository_arn, agent_name=agent_name
         )
 
     source_location = codebuild_service.upload_source(agent_name=agent_name)

--- a/src/bedrock_agentcore_starter_toolkit/services/codebuild.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/codebuild.py
@@ -7,7 +7,7 @@ import tempfile
 import time
 import zipfile
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -18,20 +18,64 @@ from ..operations.runtime.create_role import get_or_create_codebuild_execution_r
 class CodeBuildService:
     """Service for managing CodeBuild projects and builds for ARM64."""
 
-    def __init__(self, session: boto3.Session):
-        """Initialize CodeBuild service with AWS session."""
+    # def __init__(self, session: boto3.Session):
+    #     """Initialize CodeBuild service with AWS session."""
+    #     self.session = session
+    #     self.client = session.client("codebuild")
+    #     self.s3_client = session.client("s3")
+    #     self.iam_client = session.client("iam")
+    #     self.logger = logging.getLogger(__name__)
+    #     self.source_bucket = None
+    def __init__(self, session: boto3.Session, build_session: Optional[boto3.Session] = None):
+        """Initialize CodeBuild service with AWS session.
+        
+        Args:
+            session: Primary AWS session for deployment account
+            build_session: Optional separate session for CodeBuild operations (for cross-account)
+        """
         self.session = session
-        self.client = session.client("codebuild")
-        self.s3_client = session.client("s3")
-        self.iam_client = session.client("iam")
-        self.logger = logging.getLogger(__name__)
+        self.build_session = build_session or session
+        
+        # Determine if this is cross-account CodeBuild
+        self.is_cross_account_codebuild = (
+            build_session is not None and 
+            build_session != session and
+            self._get_account_id(build_session) != self._get_account_id(session)
+        )
+        
+        # Use appropriate session for CodeBuild operations
+        if self.is_cross_account_codebuild:
+            # Cross-account mode: use build_session for CodeBuild operations
+            self.client = self.build_session.client("codebuild")
+            self.s3_client = self.build_session.client("s3")
+            self.iam_client = self.build_session.client("iam")
+            self.logger.info("CodeBuildService initialized in cross-account mode")
+        else:
+            # Same-account mode: use deployment session (backward compatibility)
+            self.client = self.session.client("codebuild")
+            self.s3_client = self.session.client("s3")
+            self.iam_client = self.session.client("iam")
+            self.logger.info("CodeBuildService initialized in same-account mode")
+        
         self.source_bucket = None
-
+        
+    def _get_account_id(self, session: boto3.Session) -> str:
+        """Get account ID from session."""
+        try:
+            return session.client("sts").get_caller_identity()["Account"]
+        except Exception:
+            return "unknown"
+            
     def get_source_bucket_name(self, account_id: str) -> str:
         """Get S3 bucket name for CodeBuild sources."""
-        region = self.session.region_name
+        # region = self.session.region_name
+        # return f"bedrock-agentcore-codebuild-sources-{account_id}-{region}"
+        if self.is_cross_account_codebuild:
+            region = self.build_session.region_name
+        else:
+            region = self.session.region_name
         return f"bedrock-agentcore-codebuild-sources-{account_id}-{region}"
-
+        
     def ensure_source_bucket(self, account_id: str) -> str:
         """Ensure S3 bucket exists for CodeBuild sources."""
         bucket_name = self.get_source_bucket_name(account_id)
@@ -41,7 +85,11 @@ class CodeBuildService:
             self.logger.debug("Using existing S3 bucket: %s", bucket_name)
         except ClientError:
             # Create bucket
-            region = self.session.region_name
+            #region = self.session.region_name
+            if self.is_cross_account_codebuild:
+                region = self.build_session.region_name
+            else:
+                region = self.session.region_name
             if region == "us-east-1":
                 self.s3_client.create_bucket(Bucket=bucket_name)
             else:
@@ -63,7 +111,17 @@ class CodeBuildService:
 
     def upload_source(self, agent_name: str) -> str:
         """Upload current directory to S3, respecting .dockerignore patterns."""
-        account_id = self.session.client("sts").get_caller_identity()["Account"]
+        
+        #account_id = self.session.client("sts").get_caller_identity()["Account"]
+        # Use appropriate session to get account ID where CodeBuild resources should be created
+        if self.is_cross_account_codebuild:
+            # Cross-account CodeBuild: use build account
+            account_id = self.build_session.client("sts").get_caller_identity()["Account"]
+            self.logger.info("Using build account for S3 bucket: %s", account_id)
+        else:
+            # Same-account CodeBuild: use deployment account
+            account_id = self.session.client("sts").get_caller_identity()["Account"]
+            self.logger.info("Using deployment account for S3 bucket: %s", account_id)       
         bucket_name = self.ensure_source_bucket(account_id)
         self.source_bucket = bucket_name
 
@@ -116,10 +174,19 @@ class CodeBuildService:
 
     def create_codebuild_execution_role(self, account_id: str, ecr_repository_arn: str, agent_name: str) -> str:
         """Get or create CodeBuild execution role using shared role creation logic."""
+            # Use appropriate session for role creation
+        if self.is_cross_account_codebuild:
+            session_for_role = self.build_session
+            region_for_role = self.build_session.region_name
+        else:
+            session_for_role = self.session
+            region_for_role = self.session.region_name
         return get_or_create_codebuild_execution_role(
-            session=self.session,
+            #session=self.session,
+            session=session_for_role,
             logger=self.logger,
-            region=self.session.region_name,
+            #region=self.session.region_name,
+            region=region_for_role,
             account_id=account_id,
             agent_name=agent_name,
             ecr_repository_arn=ecr_repository_arn,

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
@@ -43,6 +43,10 @@ class AWSConfig(BaseModel):
     network_configuration: NetworkConfiguration = Field(default_factory=NetworkConfiguration)
     protocol_configuration: ProtocolConfiguration = Field(default_factory=ProtocolConfiguration)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
+    # NEW FIELDS FOR CROSS-ACCOUNT CODEBUILD
+    build_account: Optional[str] = Field(default=None, description="AWS account ID for CodeBuild operations")
+    build_role_arn: Optional[str] = Field(default=None, description="IAM role ARN to assume for CodeBuild")
+    
 
     @field_validator("account")
     @classmethod
@@ -53,7 +57,43 @@ class AWSConfig(BaseModel):
                 raise ValueError("Invalid AWS account ID")
         return v
 
-
+    def get_build_account(self) -> str:
+        """Get the account to use for CodeBuild operations."""
+        return self.build_account or self.account
+    
+    def get_build_role_arn(self) -> Optional[str]:
+        """Get the role ARN to assume for CodeBuild operations."""
+        return self.build_role_arn
+    
+    def get_ecr_account(self) -> Optional[str]:
+        """Get the account where ECR repository is located."""
+        if self.ecr_repository:
+            # Extract account from ECR URI: account.dkr.ecr.region.amazonaws.com/repo
+            return self.ecr_repository.split('.')[0]
+        return self.account
+    def is_cross_account_build(self) -> bool:
+        """Check if CodeBuild should run in a different account."""
+        return self.build_account is not None and self.build_account != self.account
+    
+    def is_cross_account_ecr(self) -> bool:
+        """Check if ECR is in a different account."""
+        ecr_account = self.get_ecr_account()
+        return ecr_account != self.account
+    
+    def get_deployment_scenario(self) -> str:
+        """Determine the deployment scenario."""
+        cross_build = self.is_cross_account_build()
+        cross_ecr = self.is_cross_account_ecr()
+        
+        if not cross_build and not cross_ecr:
+            return "same_account"
+        elif cross_build and not cross_ecr:
+            return "cross_account_build_only"
+        elif not cross_build and cross_ecr:
+            return "cross_account_ecr_only"
+        else:
+            return "full_cross_account"
+            
 class CodeBuildConfig(BaseModel):
     """CodeBuild deployment information."""
 


### PR DESCRIPTION
## Description

Brief description of changes
Organizations use a central build account for the ECR and for CodeBuild. The changes support cross account ECR and Builds with the following deployment modes:
(a) Same Account (Regular): Everything in deployment account
(b) Cross-Account ECR Only: CodeBuild in deployment account, ECR in different account
(c) Cross-Account CodeBuild Only: CodeBuild in different account, ECR in deployment account
(d) Full Cross-Account: Both CodeBuild and ECR in different account(s)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [x ] Manual testing completed

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [ ] No hardcoded secrets or credentials
- [ ] No new security warnings from bandit
- [ ] Dependencies are from trusted sources
- [ ] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
