### PR TITLE
Added request header allowlist configuration support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "boto3>=1.39.7",
-    "botocore>=1.39.7",
+    "boto3>=1.40.35",
+    "botocore>=1.40.35",
     "bedrock-agentcore>=0.1.4",
     "docstring_parser>=0.15,<1.0",
     "httpx>=0.28.1",
@@ -150,6 +150,9 @@ style = [
     ["text", ""],
     ["disabled", "fg:#858585 italic"]
 ]
+
+[tool.uv.sources]
+bedrock-agentcore = { path = "../bedrock-agentcore-sdk-python", editable = true }
 
 [dependency-groups]
 dev = [

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
@@ -32,6 +32,7 @@ def configure_bedrock_agentcore(
     enable_observability: bool = True,
     requirements_file: Optional[str] = None,
     authorizer_configuration: Optional[Dict[str, Any]] = None,
+    request_header_configuration: Optional[Dict[str, Any]] = None,
     verbose: bool = False,
     region: Optional[str] = None,
     protocol: Optional[str] = None,
@@ -49,6 +50,7 @@ def configure_bedrock_agentcore(
         enable_observability: Whether to enable observability
         requirements_file: Path to requirements file
         authorizer_configuration: JWT authorizer configuration dictionary
+        request_header_configuration: Request header configuration dictionary
         verbose: Whether to provide verbose output during configuration
         region: AWS region for deployment
         protocol: agent server protocol, must be either HTTP or MCP
@@ -173,6 +175,7 @@ def configure_bedrock_agentcore(
         ecr_repo_display = ecr_repository if ecr_repository else "Auto-create" if ecr_auto_create_value else "N/A"
         log.debug("  ECR repository: %s", ecr_repo_display)
         log.debug("  Enable observability: %s", enable_observability)
+        log.debug("  Request header configuration: %s", request_header_configuration)
 
     # Create new agent configuration
     config = BedrockAgentCoreAgentSchema(
@@ -193,6 +196,7 @@ def configure_bedrock_agentcore(
         ),
         bedrock_agentcore=BedrockAgentCoreDeploymentInfo(),
         authorizer_configuration=authorizer_configuration,
+        request_header_configuration=request_header_configuration,
     )
 
     # Use simplified config merging

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -171,6 +171,7 @@ def _deploy_to_bedrock_agentcore(
                 execution_role_arn=agent_config.aws.execution_role,
                 network_config=network_config,
                 authorizer_config=agent_config.get_authorizer_configuration(),
+                request_header_config=agent_config.request_header_configuration,
                 protocol_config=protocol_config,
                 env_vars=env_vars,
                 auto_update_on_conflict=auto_update_on_conflict,

--- a/src/bedrock_agentcore_starter_toolkit/services/runtime.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/runtime.py
@@ -122,6 +122,7 @@ class BedrockAgentCoreClient:
         execution_role_arn: str,
         network_config: Optional[Dict] = None,
         authorizer_config: Optional[Dict] = None,
+        request_header_config: Optional[Dict] = None,
         protocol_config: Optional[Dict] = None,
         env_vars: Optional[Dict] = None,
         auto_update_on_conflict: bool = False,
@@ -141,6 +142,9 @@ class BedrockAgentCoreClient:
 
             if authorizer_config is not None:
                 params["authorizerConfiguration"] = authorizer_config
+
+            if request_header_config is not None:
+                params["requestHeaderConfiguration"] = request_header_config
 
             if protocol_config is not None:
                 params["protocolConfiguration"] = protocol_config
@@ -196,6 +200,7 @@ class BedrockAgentCoreClient:
                     execution_role_arn,
                     network_config,
                     authorizer_config,
+                    request_header_config,
                     protocol_config,
                     env_vars,
                 )
@@ -216,6 +221,7 @@ class BedrockAgentCoreClient:
         execution_role_arn: str,
         network_config: Optional[Dict] = None,
         authorizer_config: Optional[Dict] = None,
+        request_header_config: Optional[Dict] = None,
         protocol_config: Optional[Dict] = None,
         env_vars: Optional[Dict] = None,
     ) -> Dict[str, str]:
@@ -234,6 +240,9 @@ class BedrockAgentCoreClient:
 
             if authorizer_config is not None:
                 params["authorizerConfiguration"] = authorizer_config
+
+            if request_header_config is not None:
+                params["requestHeaderConfiguration"] = request_header_config
 
             if protocol_config is not None:
                 params["protocolConfiguration"] = protocol_config
@@ -297,6 +306,7 @@ class BedrockAgentCoreClient:
         execution_role_arn: str,
         network_config: Optional[Dict] = None,
         authorizer_config: Optional[Dict] = None,
+        request_header_config: Optional[Dict] = None,
         protocol_config: Optional[Dict] = None,
         env_vars: Optional[Dict] = None,
         auto_update_on_conflict: bool = False,
@@ -304,7 +314,7 @@ class BedrockAgentCoreClient:
         """Create or update agent."""
         if agent_id:
             return self.update_agent(
-                agent_id, image_uri, execution_role_arn, network_config, authorizer_config, protocol_config, env_vars
+                agent_id, image_uri, execution_role_arn, network_config, authorizer_config, request_header_config, protocol_config, env_vars
             )
         return self.create_agent(
             agent_name,
@@ -312,6 +322,7 @@ class BedrockAgentCoreClient:
             execution_role_arn,
             network_config,
             authorizer_config,
+            request_header_config,
             protocol_config,
             env_vars,
             auto_update_on_conflict,

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
@@ -81,6 +81,7 @@ class BedrockAgentCoreAgentSchema(BaseModel):
     bedrock_agentcore: BedrockAgentCoreDeploymentInfo = Field(default_factory=BedrockAgentCoreDeploymentInfo)
     codebuild: CodeBuildConfig = Field(default_factory=CodeBuildConfig)
     authorizer_configuration: Optional[dict] = Field(default=None, description="JWT authorizer configuration")
+    request_header_configuration: Optional[dict] = Field(default=None, description="Request header configuration")
     oauth_configuration: Optional[dict] = Field(default=None, description="Oauth configuration")
 
     def get_authorizer_configuration(self) -> Optional[dict]:

--- a/tests/cli/runtime/test_configuration_manager.py
+++ b/tests/cli/runtime/test_configuration_manager.py
@@ -1,6 +1,7 @@
 """Tests for ConfigurationManager."""
 
 from unittest.mock import Mock, patch
+import pytest
 
 from bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager import ConfigurationManager
 
@@ -95,4 +96,241 @@ class TestConfigurationManager:
             mock_prompt.assert_called_once_with("Execution role ARN/name (or press Enter to auto-create)", "")
             mock_success.assert_called_once_with(
                 "Using existing execution role: [dim]arn:aws:iam::123456789012:role/NewRole[/dim]"
+            )
+
+    def test_prompt_request_header_allowlist_no_configuration(self, tmp_path):
+        """Test prompt_request_header_allowlist when user declines configuration."""
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._print_success") as mock_success,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            # Mock user declining configuration
+            mock_prompt.return_value = "no"
+
+            result = config_manager.prompt_request_header_allowlist()
+
+            assert result is None
+            mock_prompt.assert_called_once_with("Configure request header allowlist? (yes/no)", "no")
+            mock_success.assert_called_once_with("Using default request header configuration")
+
+    def test_prompt_request_header_allowlist_with_configuration(self, tmp_path):
+        """Test prompt_request_header_allowlist when user configures headers."""
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._print_success") as mock_success,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            # Mock user accepting configuration, then configuring headers
+            mock_prompt.side_effect = [
+                "yes",  # First call: "Configure request header allowlist?"
+                "Authorization,X-Custom-Header"  # Second call: "Enter allowed request headers"
+            ]
+
+            result = config_manager.prompt_request_header_allowlist()
+
+            assert result == {"requestHeaderAllowlist": ["Authorization", "X-Custom-Header"]}
+            assert mock_prompt.call_count == 2
+            mock_success.assert_called_once_with("Request header allowlist configured with 2 headers")
+
+    def test_prompt_request_header_allowlist_with_existing_config(self, tmp_path):
+        """Test prompt_request_header_allowlist with existing configuration."""
+        # Mock existing config
+        mock_project_config = Mock()
+        mock_agent_config = Mock()
+        mock_agent_config.request_header_configuration = {
+            "requestHeaderAllowlist": ["Authorization", "X-Existing-Header"]
+        }
+        mock_project_config.get_agent_config.return_value = mock_agent_config
+
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists",
+                return_value=mock_project_config,
+            ),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._print_success") as mock_success,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            # Mock user accepting existing configuration
+            mock_prompt.side_effect = [
+                "yes",  # First call: "Configure request header allowlist?"
+                "Authorization,X-Existing-Header"  # Second call: headers (using existing)
+            ]
+
+            result = config_manager.prompt_request_header_allowlist()
+
+            assert result == {"requestHeaderAllowlist": ["Authorization", "X-Existing-Header"]}
+            # Should use "yes" default since existing headers are present
+            first_call_args = mock_prompt.call_args_list[0]
+            assert first_call_args[0][1] == "yes"  # Default should be "yes"
+
+    def test_prompt_request_header_allowlist_non_interactive(self, tmp_path):
+        """Test prompt_request_header_allowlist in non-interactive mode."""
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._print_success") as mock_success,
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml", non_interactive=True)
+
+            result = config_manager.prompt_request_header_allowlist()
+
+            assert result is None
+            mock_success.assert_called_once_with("Using default request header configuration")
+
+    def test_configure_request_header_allowlist_basic(self, tmp_path):
+        """Test _configure_request_header_allowlist with basic input."""
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._print_success") as mock_success,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            # Mock user input with headers
+            mock_prompt.return_value = "Authorization,X-Custom-Header,X-Another-Header"
+
+            result = config_manager._configure_request_header_allowlist()
+
+            expected = {"requestHeaderAllowlist": ["Authorization", "X-Custom-Header", "X-Another-Header"]}
+            assert result == expected
+            mock_success.assert_called_once_with("Request header allowlist configured with 3 headers")
+
+    def test_configure_request_header_allowlist_with_existing_headers(self, tmp_path):
+        """Test _configure_request_header_allowlist with existing headers passed in."""
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._print_success") as mock_success,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            existing_headers = "Authorization,X-Existing-Header"
+            # Mock user accepting existing headers
+            mock_prompt.return_value = existing_headers
+
+            result = config_manager._configure_request_header_allowlist(existing_headers)
+
+            expected = {"requestHeaderAllowlist": ["Authorization", "X-Existing-Header"]}
+            assert result == expected
+            # Should use existing headers as default
+            mock_prompt.assert_called_once_with(
+                "Enter allowed request headers (comma-separated)", 
+                existing_headers
+            )
+
+    def test_configure_request_header_allowlist_with_whitespace(self, tmp_path):
+        """Test _configure_request_header_allowlist handles whitespace properly."""
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._print_success") as mock_success,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            # Mock input with various whitespace patterns
+            mock_prompt.return_value = " Authorization , X-Custom-Header ,  X-Another-Header  "
+
+            result = config_manager._configure_request_header_allowlist()
+
+            expected = {"requestHeaderAllowlist": ["Authorization", "X-Custom-Header", "X-Another-Header"]}
+            assert result == expected
+
+    def test_configure_request_header_allowlist_empty_input_error(self, tmp_path):
+        """Test _configure_request_header_allowlist handles empty input properly."""
+        import typer
+        
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._handle_error") as mock_error,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            # Mock empty input
+            mock_prompt.return_value = ""
+            # Mock _handle_error to raise typer.Exit to simulate real behavior
+            mock_error.side_effect = typer.Exit(1)
+
+            # Should raise typer.Exit when empty input is provided
+            with pytest.raises(typer.Exit):
+                config_manager._configure_request_header_allowlist()
+
+            mock_error.assert_called_once_with("At least one request header must be specified for allowlist configuration")
+
+    def test_configure_request_header_allowlist_only_commas_error(self, tmp_path):
+        """Test _configure_request_header_allowlist handles input with only commas."""
+        import typer
+        
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._handle_error") as mock_error,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            # Mock input with only commas and whitespace
+            mock_prompt.return_value = " , , , "
+            # Mock _handle_error to raise typer.Exit to simulate real behavior
+            mock_error.side_effect = typer.Exit(1)
+
+            # Should raise typer.Exit when only commas are provided
+            with pytest.raises(typer.Exit):
+                config_manager._configure_request_header_allowlist()
+
+            mock_error.assert_called_once_with("Empty request header allowlist provided")
+
+    def test_configure_request_header_allowlist_default_headers(self, tmp_path):
+        """Test _configure_request_header_allowlist uses default headers when no existing ones."""
+        with (
+            patch("bedrock_agentcore_starter_toolkit.utils.runtime.config.load_config_if_exists", return_value=None),
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._prompt_with_default"
+            ) as mock_prompt,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager._print_success") as mock_success,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.configuration_manager.console.print"),
+        ):
+            config_manager = ConfigurationManager(tmp_path / ".bedrock_agentcore.yaml")
+
+            # Mock user accepting defaults
+            default_headers = "Authorization,X-Amzn-Bedrock-AgentCore-Runtime-Custom-*"
+            mock_prompt.return_value = default_headers
+
+            result = config_manager._configure_request_header_allowlist()
+
+            expected = {"requestHeaderAllowlist": ["Authorization", "X-Amzn-Bedrock-AgentCore-Runtime-Custom-*"]}
+            assert result == expected
+            # Should use default headers when no existing ones provided
+            mock_prompt.assert_called_once_with(
+                "Enter allowed request headers (comma-separated)", 
+                default_headers
             )

--- a/tests/operations/runtime/test_configure.py
+++ b/tests/operations/runtime/test_configure.py
@@ -362,6 +362,381 @@ def handler(payload):
         finally:
             os.chdir(original_cwd)
 
+    def test_configure_with_request_header_configuration(
+        self, mock_bedrock_agentcore_app, mock_boto3_clients, mock_container_runtime, tmp_path
+    ):
+        """Test configuration with request_header_configuration parameter."""
+        # Create agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        original_cwd = Path.cwd()
+        import os
+
+        os.chdir(tmp_path)
+
+        try:
+            # Create a mock class that preserves class attributes
+            class MockContainerRuntimeClass:
+                DEFAULT_RUNTIME = "auto"
+                DEFAULT_PLATFORM = "linux/arm64"
+
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                def __new__(cls, *args, **kwargs):
+                    return mock_container_runtime
+
+            with patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.configure.ContainerRuntime",
+                MockContainerRuntimeClass,
+            ):
+                # Test with request header configuration
+                request_header_config = {
+                    "requestHeaderAllowlist": ["Authorization", "X-Custom-Header", "X-Test-Header"]
+                }
+
+                result = configure_bedrock_agentcore(
+                    agent_name="test_agent",
+                    entrypoint_path=agent_file,
+                    execution_role="TestRole",
+                    container_runtime="docker",
+                    request_header_configuration=request_header_config,
+                )
+
+                # Verify result structure
+                assert hasattr(result, "config_path")
+                assert result.runtime == "Docker"
+
+                # Verify config file was created
+                config_path = tmp_path / ".bedrock_agentcore.yaml"
+                assert config_path.exists()
+
+                # Load and verify the configuration contains request headers
+                from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+                loaded_config = load_config(config_path)
+                agent_config = loaded_config.get_agent_config("test_agent")
+                
+                assert agent_config.request_header_configuration is not None
+                assert "requestHeaderAllowlist" in agent_config.request_header_configuration
+                assert agent_config.request_header_configuration["requestHeaderAllowlist"] == [
+                    "Authorization", "X-Custom-Header", "X-Test-Header"
+                ]
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_configure_with_none_request_header_configuration(
+        self, mock_bedrock_agentcore_app, mock_boto3_clients, mock_container_runtime, tmp_path
+    ):
+        """Test configuration with None request_header_configuration parameter."""
+        # Create agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        original_cwd = Path.cwd()
+        import os
+
+        os.chdir(tmp_path)
+
+        try:
+            # Create a mock class that preserves class attributes
+            class MockContainerRuntimeClass:
+                DEFAULT_RUNTIME = "auto"
+                DEFAULT_PLATFORM = "linux/arm64"
+
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                def __new__(cls, *args, **kwargs):
+                    return mock_container_runtime
+
+            with patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.configure.ContainerRuntime",
+                MockContainerRuntimeClass,
+            ):
+                # Test with None request header configuration
+                result = configure_bedrock_agentcore(
+                    agent_name="test_agent",
+                    entrypoint_path=agent_file,
+                    execution_role="TestRole",
+                    request_header_configuration=None,
+                )
+
+                # Verify config file was created
+                config_path = tmp_path / ".bedrock_agentcore.yaml"
+                assert config_path.exists()
+
+                # Load and verify the configuration has None for request headers
+                from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+                loaded_config = load_config(config_path)
+                agent_config = loaded_config.get_agent_config("test_agent")
+                
+                assert agent_config.request_header_configuration is None
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_configure_with_empty_request_header_configuration(
+        self, mock_bedrock_agentcore_app, mock_boto3_clients, mock_container_runtime, tmp_path
+    ):
+        """Test configuration with empty dict request_header_configuration parameter."""
+        # Create agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        original_cwd = Path.cwd()
+        import os
+
+        os.chdir(tmp_path)
+
+        try:
+            # Create a mock class that preserves class attributes
+            class MockContainerRuntimeClass:
+                DEFAULT_RUNTIME = "auto"
+                DEFAULT_PLATFORM = "linux/arm64"
+
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                def __new__(cls, *args, **kwargs):
+                    return mock_container_runtime
+
+            with patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.configure.ContainerRuntime",
+                MockContainerRuntimeClass,
+            ):
+                # Test with empty dict request header configuration
+                result = configure_bedrock_agentcore(
+                    agent_name="test_agent",
+                    entrypoint_path=agent_file,
+                    execution_role="TestRole",
+                    request_header_configuration={},
+                )
+
+                # Verify config file was created
+                config_path = tmp_path / ".bedrock_agentcore.yaml"
+                assert config_path.exists()
+
+                # Load and verify the configuration has empty dict for request headers
+                from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+                loaded_config = load_config(config_path)
+                agent_config = loaded_config.get_agent_config("test_agent")
+                
+                assert agent_config.request_header_configuration == {}
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_configure_verbose_logs_request_header_configuration(
+        self, mock_bedrock_agentcore_app, mock_boto3_clients, mock_container_runtime, tmp_path
+    ):
+        """Test that verbose mode logs request header configuration details."""
+        # Create agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        original_cwd = Path.cwd()
+        import os
+
+        os.chdir(tmp_path)
+
+        try:
+            # Create a mock class that preserves class attributes
+            class MockContainerRuntimeClass:
+                DEFAULT_RUNTIME = "auto"
+                DEFAULT_PLATFORM = "linux/arm64"
+
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                def __new__(cls, *args, **kwargs):
+                    return mock_container_runtime
+
+            with patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.configure.ContainerRuntime",
+                MockContainerRuntimeClass,
+            ):
+                # Mock the logger to capture verbose logging
+                with patch("bedrock_agentcore_starter_toolkit.operations.runtime.configure.log") as mock_log:
+                    request_header_config = {
+                        "requestHeaderAllowlist": ["Authorization", "X-Verbose-Test-Header"]
+                    }
+
+                    result = configure_bedrock_agentcore(
+                        agent_name="test_agent",
+                        entrypoint_path=agent_file,
+                        execution_role="TestRole",
+                        request_header_configuration=request_header_config,
+                        verbose=True,  # Enable verbose mode
+                    )
+
+                    # Verify result structure is correct
+                    assert result.runtime == "Docker"
+
+                    # Verify that verbose logging was enabled
+                    mock_log.setLevel.assert_called_with(10)  # logging.DEBUG = 10
+
+                    # Verify that request header configuration was logged
+                    debug_calls = [call for call in mock_log.debug.call_args_list]
+                    assert len(debug_calls) > 0, "Expected debug log calls when verbose=True"
+                    
+                    # Check that request header configuration appears in one of the debug calls
+                    request_header_logged = any(
+                        "Request header configuration" in str(call) for call in debug_calls
+                    )
+                    assert request_header_logged, "Expected request header configuration to be logged in verbose mode"
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_configure_complex_request_header_configuration(
+        self, mock_bedrock_agentcore_app, mock_boto3_clients, mock_container_runtime, tmp_path
+    ):
+        """Test configuration with complex request_header_configuration structure."""
+        # Create agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        original_cwd = Path.cwd()
+        import os
+
+        os.chdir(tmp_path)
+
+        try:
+            # Create a mock class that preserves class attributes
+            class MockContainerRuntimeClass:
+                DEFAULT_RUNTIME = "auto"
+                DEFAULT_PLATFORM = "linux/arm64"
+
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                def __new__(cls, *args, **kwargs):
+                    return mock_container_runtime
+
+            with patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.configure.ContainerRuntime",
+                MockContainerRuntimeClass,
+            ):
+                # Test with complex nested request header configuration
+                request_header_config = {
+                    "requestHeaderAllowlist": [
+                        "Authorization",
+                        "X-Amzn-Bedrock-AgentCore-Runtime-Custom-*",
+                        "Content-Type",
+                        "User-Agent"
+                    ],
+                    "additionalSettings": {
+                        "maxHeaderSize": 8192,
+                        "caseSensitive": False,
+                        "allowWildcards": True
+                    }
+                }
+
+                result = configure_bedrock_agentcore(
+                    agent_name="test_agent",
+                    entrypoint_path=agent_file,
+                    execution_role="TestRole",
+                    request_header_configuration=request_header_config,
+                )
+
+                # Verify config file was created
+                config_path = tmp_path / ".bedrock_agentcore.yaml"
+                assert config_path.exists()
+
+                # Load and verify the complex configuration is preserved
+                from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+                loaded_config = load_config(config_path)
+                agent_config = loaded_config.get_agent_config("test_agent")
+                
+                assert agent_config.request_header_configuration is not None
+                assert "requestHeaderAllowlist" in agent_config.request_header_configuration
+                assert len(agent_config.request_header_configuration["requestHeaderAllowlist"]) == 4
+                assert "Authorization" in agent_config.request_header_configuration["requestHeaderAllowlist"]
+                assert "X-Amzn-Bedrock-AgentCore-Runtime-Custom-*" in agent_config.request_header_configuration["requestHeaderAllowlist"]
+                
+                # Verify additional settings are preserved
+                assert "additionalSettings" in agent_config.request_header_configuration
+                assert agent_config.request_header_configuration["additionalSettings"]["maxHeaderSize"] == 8192
+                assert agent_config.request_header_configuration["additionalSettings"]["caseSensitive"] is False
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_configure_with_all_authorization_options(
+        self, mock_bedrock_agentcore_app, mock_boto3_clients, mock_container_runtime, tmp_path
+    ):
+        """Test configuration with both authorizer_configuration and request_header_configuration."""
+        # Create agent file
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("# test agent")
+
+        original_cwd = Path.cwd()
+        import os
+
+        os.chdir(tmp_path)
+
+        try:
+            # Create a mock class that preserves class attributes
+            class MockContainerRuntimeClass:
+                DEFAULT_RUNTIME = "auto"
+                DEFAULT_PLATFORM = "linux/arm64"
+
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                def __new__(cls, *args, **kwargs):
+                    return mock_container_runtime
+
+            with patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.configure.ContainerRuntime",
+                MockContainerRuntimeClass,
+            ):
+                # Test with both OAuth authorizer and request headers
+                oauth_config = {
+                    "customJWTAuthorizer": {
+                        "discoveryUrl": "https://example.com/.well-known/openid_configuration",
+                        "allowedClients": ["client1", "client2"],
+                        "allowedAudience": ["aud1", "aud2"]
+                    }
+                }
+                
+                request_header_config = {
+                    "requestHeaderAllowlist": ["Authorization", "X-OAuth-Token", "X-Client-ID"]
+                }
+
+                result = configure_bedrock_agentcore(
+                    agent_name="test_agent",
+                    entrypoint_path=agent_file,
+                    execution_role="TestRole",
+                    authorizer_configuration=oauth_config,
+                    request_header_configuration=request_header_config,
+                )
+
+                # Verify config file was created
+                config_path = tmp_path / ".bedrock_agentcore.yaml"
+                assert config_path.exists()
+
+                # Load and verify both configurations are preserved
+                from bedrock_agentcore_starter_toolkit.utils.runtime.config import load_config
+                loaded_config = load_config(config_path)
+                agent_config = loaded_config.get_agent_config("test_agent")
+                
+                # Verify OAuth configuration
+                assert agent_config.authorizer_configuration is not None
+                assert "customJWTAuthorizer" in agent_config.authorizer_configuration
+                assert agent_config.authorizer_configuration["customJWTAuthorizer"]["discoveryUrl"] == "https://example.com/.well-known/openid_configuration"
+                
+                # Verify request header configuration
+                assert agent_config.request_header_configuration is not None
+                assert agent_config.request_header_configuration["requestHeaderAllowlist"] == [
+                    "Authorization", "X-OAuth-Token", "X-Client-ID"
+                ]
+
+        finally:
+            os.chdir(original_cwd)
+
 
 class TestValidateAgentName:
     """Test class for validate_agent_name function."""

--- a/tests/services/test_runtime.py
+++ b/tests/services/test_runtime.py
@@ -28,6 +28,7 @@ class TestBedrockAgentCoreRuntime:
             agent_name="test-agent",
             image_uri="123456789012.dkr.ecr.us-west-2.amazonaws.com/test:latest",
             execution_role_arn="arn:aws:iam::123456789012:role/TestRole",
+            request_header_config=None,
         )
 
         # Verify create was called
@@ -41,6 +42,7 @@ class TestBedrockAgentCoreRuntime:
             agent_name="test-agent",
             image_uri="123456789012.dkr.ecr.us-west-2.amazonaws.com/test:latest",
             execution_role_arn="arn:aws:iam::123456789012:role/TestRole",
+            request_header_config=None,
         )
 
         # Verify update was called

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -83,7 +83,7 @@ wheels = [
 [[package]]
 name = "bedrock-agentcore"
 version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../bedrock-agentcore-sdk-python" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
@@ -93,9 +93,32 @@ dependencies = [
     { name = "urllib3" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/23/be1672a79632a1c36b049fc29103732f6ca2dd8596ffcc3a59a1d6e59f4c/bedrock_agentcore-0.1.4.tar.gz", hash = "sha256:59c513df840ef66843915c7c229603732a3e7d7e76cb9d618be5663dbe1cc863", size = 229574, upload-time = "2025-09-17T18:29:23.327Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/82/c6ac88e118447c054c28147b3be1577cf9e9fbf5529919c39262ca2d8b50/bedrock_agentcore-0.1.4-py3-none-any.whl", hash = "sha256:d372ca4d522173be6baab5723efd3c27cc2746b73b711ead1329902a98bc9a43", size = 62284, upload-time = "2025-09-17T18:29:21.769Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.40.35" },
+    { name = "botocore", specifier = ">=1.40.35" },
+    { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
+    { name = "starlette", specifier = ">=0.46.2" },
+    { name = "strands-agents", marker = "extra == 'strands-agents'", specifier = ">=1.1.0" },
+    { name = "typing-extensions", specifier = ">=4.13.2,<5.0.0" },
+    { name = "urllib3", specifier = ">=1.26.0" },
+    { name = "uvicorn", specifier = ">=0.34.2" },
+]
+provides-extras = ["strands-agents"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "moto", specifier = ">=5.1.6" },
+    { name = "mypy", specifier = ">=1.16.1" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "ruff", specifier = ">=0.12.0" },
+    { name = "strands-agents", specifier = ">=1.1.0" },
+    { name = "wheel", specifier = ">=0.45.1" },
 ]
 
 [[package]]
@@ -149,9 +172,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "autopep8", specifier = ">=2.3.2" },
-    { name = "bedrock-agentcore", specifier = ">=0.1.4" },
-    { name = "boto3", specifier = ">=1.39.7" },
-    { name = "botocore", specifier = ">=1.39.7" },
+    { name = "bedrock-agentcore", editable = "../bedrock-agentcore-sdk-python" },
+    { name = "boto3", specifier = ">=1.40.35" },
+    { name = "botocore", specifier = ">=1.40.35" },
     { name = "docstring-parser", specifier = ">=0.15,<1.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -193,30 +216,30 @@ dev = [
 
 [[package]]
 name = "boto3"
-version = "1.40.27"
+version = "1.40.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/32/85c4956285aee9f7bc087662738423020b3c40149ea6a6766dbaeb644208/boto3-1.40.27.tar.gz", hash = "sha256:bf1e0f5aa79dbeedff14926dc2eb1b57bc119fa9015a190a24b6cd5bf9a60e9a", size = 111545, upload-time = "2025-09-09T19:23:40.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/d0/9082261eb9afbb88896fa2ce018fa10750f32572ab356f13f659761bc5b5/boto3-1.40.35.tar.gz", hash = "sha256:d718df3591c829bcca4c498abb7b09d64d1eecc4e5a2b6cef14b476501211b8a", size = 111563, upload-time = "2025-09-19T19:41:07.704Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/6a/c19f053781c5970d63e9210cbd044dc9fb9442ff16714bf94a35ba9c0d88/boto3-1.40.27-py3-none-any.whl", hash = "sha256:397d8cde7924f03b25eb553d5ed69293697dbfa1ca29b07369b3fa2df8318eca", size = 139327, upload-time = "2025-09-09T19:23:38.864Z" },
+    { url = "https://files.pythonhosted.org/packages/db/26/08d814db09dc46eab747c7ebe1d4af5b5158b68e1d7de82ecc71d419eab3/boto3-1.40.35-py3-none-any.whl", hash = "sha256:f4c1b01dd61e7733b453bca38b004ce030e26ee36e7a3d4a9e45a730b67bc38d", size = 139346, upload-time = "2025-09-19T19:41:05.929Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.40.27"
+version = "1.40.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/a1/c5c8223cb3ff4d7ada79845ed8f2b17108895e5c9c21ad0de31d1d9f3b16/botocore-1.40.27.tar.gz", hash = "sha256:f7cb28668751d85adc7f17929efa684640d8e2739800a86a05d4bc38f8443d1c", size = 14339872, upload-time = "2025-09-09T19:23:27.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/6f/37f40da07f3cdde367f620874f76b828714409caf8466def65aede6bdf59/botocore-1.40.35.tar.gz", hash = "sha256:67e062752ff579c8cc25f30f9c3a84c72d692516a41a9ee1cf17735767ca78be", size = 14350022, upload-time = "2025-09-19T19:40:56.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/45/736eea55d9a6343bc1dba7826348655acbfceb47987444409276e8d555fc/botocore-1.40.27-py3-none-any.whl", hash = "sha256:47441c94913740f5c24abf3d7f6fa534f12705e4c6669cd2e8443f3b3ca9d7ca", size = 14012750, upload-time = "2025-09-09T19:23:23.284Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f4/9942dfb01a8a849daac34b15d5b7ca994c52ef131db2fa3f6e6995f61e0a/botocore-1.40.35-py3-none-any.whl", hash = "sha256:c545de2cbbce161f54ca589fbb677bae14cdbfac7d5f1a27f6a620cb057c26f4", size = 14020774, upload-time = "2025-09-19T19:40:53.498Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add support for specifying request header allowlist feature which is supported with agent core runtime with the latest release. 

When you configure an agent runtime you can now specify a set of headers which will be passed through to agent runtime at the time of invocation. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [X] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [X] Test coverage remains above 80%
- [X] Manual testing completed

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [X] No hardcoded secrets or credentials
- [X] No new security warnings from bandit
- [X] Dependencies are from trusted sources
- [X] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
