### PR TITLE
Add ability to invoke runtime with custom headers

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/invoke.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/invoke.py
@@ -23,6 +23,7 @@ def invoke_bedrock_agentcore(
     bearer_token: Optional[str] = None,
     user_id: Optional[str] = None,
     local_mode: Optional[bool] = False,
+    custom_headers: Optional[dict] = None,
 ) -> InvokeResult:
     """Invoke deployed Bedrock AgentCore endpoint."""
     # Load project configuration
@@ -68,7 +69,7 @@ def invoke_bedrock_agentcore(
 
         # TODO: store and read port config of local running container
         client = LocalBedrockAgentCoreClient("http://127.0.0.1:8080")
-        response = client.invoke_endpoint(session_id, payload_str, workload_access_token)
+        response = client.invoke_endpoint(session_id, payload_str, workload_access_token, custom_headers)
 
     else:
         if not agent_arn:
@@ -88,12 +89,13 @@ def invoke_bedrock_agentcore(
                 payload=payload_str,
                 session_id=session_id,
                 bearer_token=bearer_token,
+                custom_headers=custom_headers,
             )
         else:
             # Use existing boto3 client
             bedrock_agentcore_client = BedrockAgentCoreClient(region)
             response = bedrock_agentcore_client.invoke_endpoint(
-                agent_arn=agent_arn, payload=payload_str, session_id=session_id, user_id=user_id
+                agent_arn=agent_arn, payload=payload_str, session_id=session_id, user_id=user_id, custom_headers=custom_headers
             )
 
     return InvokeResult(


### PR DESCRIPTION
## Description

Add support for invoking runtime with headers. These headers will be passed when invoking runtime and will be available in your agent runtime code provided you have configured the runtime with request header allowlist.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [X] Unit tests pass locally
- [X] Integration tests pass (if applicable)
- [X] Test coverage remains above 80%
- [X] Manual testing completed

## Checklist

- [X] My code follows the project's style guidelines (ruff/pre-commit)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [X] No hardcoded secrets or credentials
- [X] No new security warnings from bandit
- [X] Dependencies are from trusted sources
- [X] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes
### Manual testing

1. Runtime with OAuth
      1. Tested with no headers
      2. Tested with one header
      3. Tested with multiple headers
      4. Tested auto append logic
2. Did the same for runtime with SigV4
