### PR TITLE
Fix pyproject.toml installation in subdirectories

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/Dockerfile.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/Dockerfile.j2
@@ -8,7 +8,7 @@ ENV UV_SYSTEM_PYTHON=1 UV_COMPILE_BYTECODE=1
 {% if dependencies_install_path %}
 COPY {{ dependencies_install_path }} {{ dependencies_install_path }}
 # Install from pyproject.toml directory
-RUN uv pip install {{ dependencies_install_path }}
+RUN cd {{ dependencies_install_path }} && uv pip install .
 {% else %}
 COPY {{ dependencies_file }} {{ dependencies_file }}
 # Install from requirements file


### PR DESCRIPTION
## Problem
When using `pyproject.toml` in a subdirectory, the generated Dockerfile incorrectly runs `uv pip install <dirname>` which tries to install package `https://pypi.org/project/<dirname>` from PyPI instead of the local dependencies.

This affects users who organize their agent code in subdirectories, such as:

```
source/agent.py
source/pyproject.toml
```

When running `agentcore configure -e source/agent.py -rf source/pyproject.toml`, the generated Dockerfile would contain:
```dockerfile
RUN uv pip install source
```

This command installs the unrelated source package from PyPI (https://pypi.org/project/source/) instead of installing the dependencies defined in the local source/pyproject.toml.

## Solution

Changed the installation command from `uv pip install {{ dependencies_install_path }}` to `cd {{ dependencies_install_path }} && uv pip install .` to properly install from the local pyproject.toml.

## Impact

**Before:** `RUN uv pip install <dirname>` (installs PyPI package named <dirname> or fails if it doesn't exist)
**After:** `RUN cd <dirname> && uv pip install .` (installs correct local dependencies)

This is a critical bug fix that ensures agents with subdirectory structures work correctly with their intended dependencies rather than accidentally pulling unrelated packages from PyPI.