### PR TITLE
Add explicit user creation config for Cognito pools

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/gateway/client.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/gateway/client.py
@@ -415,6 +415,10 @@ class GatewayClient:
     def create_oauth_authorizer_with_cognito(self, gateway_name: str) -> Dict[str, Any]:
         """Creates Cognito OAuth authorization server.
 
+        Note: This implementation uses AdminCreateUserOnly mode where only administrators
+        can create user accounts. If modifying this implementation for public clients,
+        review AWS Cognito security best practices regarding user sign-up policies.
+
         :param gateway_name: the name of the gateway being created for use in naming Cognito resources.
         :return: dictionary with details of the authorization server, client id, and client secret.
         """
@@ -425,7 +429,12 @@ class GatewayClient:
         try:
             # 1. Create User Pool
             pool_name = f"agentcore-gateway-{GatewayClient.generate_random_id()}"
-            user_pool_response = cognito_client.create_user_pool(PoolName=pool_name)
+            user_pool_response = cognito_client.create_user_pool(
+                PoolName=pool_name,
+                AdminCreateUserConfig={
+                    "AllowAdminCreateUserOnly": True  # Disables self-registration
+                },
+            )
             user_pool_id = user_pool_response["UserPool"]["Id"]
             self.logger.info("  ✓ Created User Pool: %s", user_pool_id)
 

--- a/tests/operations/gateway/test_gateway_client_init.py
+++ b/tests/operations/gateway/test_gateway_client_init.py
@@ -694,7 +694,9 @@ class TestCreateOAuthAuthorizerWithCognito:
                 result = self.client.create_oauth_authorizer_with_cognito(gateway_name)
 
                 # Verify user pool creation
-                self.mock_cognito_client.create_user_pool.assert_called_once_with(PoolName="agentcore-gateway-12345678")
+                self.mock_cognito_client.create_user_pool.assert_called_once_with(
+                    PoolName="agentcore-gateway-12345678", AdminCreateUserConfig={"AllowAdminCreateUserOnly": True}
+                )
 
                 # Verify domain creation
                 self.mock_cognito_client.create_user_pool_domain.assert_called_once_with(


### PR DESCRIPTION
Updates create_oauth_authorizer_with_cognito to use explicit AdminCreateUserConfig

## Description

This PR updates the default configuration when creating Cognito User Pools
through the toolkit's OAuth helper method.

- Added explicit AdminCreateUserConfig parameter to user pool creation

## Testing
- Verified gateway creation works with updated parameters
- Confirmed existing quickstart continues to function as expected

## Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [X ] Unit tests pass locally
- [X ] Integration tests pass (if applicable)
- [X ] Test coverage remains above 80%
- [X ] Manual testing completed

## Checklist

- [X ] My code follows the project's style guidelines (ruff/pre-commit)
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [X ] No hardcoded secrets or credentials
- [X ] No new security warnings from bandit
- [X ] Dependencies are from trusted sources
- [X ] No sensitive data logged
