### PR TITLE
Add required permission to Agent execution role to decrypt OAuth2 credential provider client secret

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
@@ -121,6 +121,16 @@
       ]
     },
     {
+      "Sid": "BedrockAgentCoreIdentityGetCredentialProviderClientSecret",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:{{ region }}:{{ account_id }}:secret:bedrock-agentcore-identity!default/oauth2/*"
+      ]
+    },
+    {
       "Sid": "BedrockAgentCoreIdentityGetResourceOauth2Token",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Description

The agent execution role needs permission to call `secretsmanager:GetSecretValue` in order to retrieve the OAuth 2.0 client credentials for the credential provider created in Bedrock AgentCore Identity.

This change adds the permission to the policy auto-generated execution role in the starter toolkit. Without this, customer's are required to manually add this permission.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
