### PR TITLE
fix: don't fail validation for empty namespaces for during get_or_create when strategy defaults server side

### DIFF
--- a/tests_integ/memory/memory-manager.ipynb
+++ b/tests_integ/memory/memory-manager.ipynb
@@ -13,12 +13,8 @@
    "source": [
     "from bedrock_agentcore_starter_toolkit.operations.memory.manager import Memory, MemoryManager\n",
     "from bedrock_agentcore_starter_toolkit.operations.memory.models.strategies import (\n",
-    "    ConsolidationConfig,\n",
-    "    CustomSemanticStrategy,\n",
-    "    CustomSummaryStrategy,\n",
-    "    CustomUserPreferenceStrategy,\n",
-    "    ExtractionConfig,\n",
-    "    SummaryStrategy,\n",
+    "    SemanticStrategy, SummaryStrategy, CustomSemanticStrategy, CustomSummaryStrategy, CustomUserPreferenceStrategy,\n",
+    "    ExtractionConfig, ConsolidationConfig\n",
     ")"
    ]
   },
@@ -41,52 +37,127 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "🔎 Retrieving memory resource with ID: DemoLongTermMemory2-ZsKBvw2Oqs...\n",
-      "  ✅ Found memory: DemoLongTermMemory2-ZsKBvw2Oqs\n",
-      "🔎 Retrieving memory resource with ID: DemoLongTermMemory3-EQGD6pFqrh...\n",
-      "  ✅ Found memory: DemoLongTermMemory3-EQGD6pFqrh\n",
-      "🔎 Retrieving memory resource with ID: LargeDemoLongTermMemory-wKcX9pCmQV...\n"
+      "Deleted memory: CustomerSupportSemantic10-j28CWNGRR7\n",
+      "🔎 Retrieving memory resource with ID: CustomerSupportSemantic10-j28CWNGRR7...\n",
+      "  ✅ Found memory: CustomerSupportSemantic10-j28CWNGRR7\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🔍 DEBUG: Memory status ACTIVE\n",
-      "🔍 DEBUG: Memory status ACTIVE\n"
+      "🔍 DEBUG: Memory status DELETING\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  ✅ Found memory: LargeDemoLongTermMemory-wKcX9pCmQV\n"
+      "Deleted memory: DemoLongTermMemory1-mIRDJI3wdV\n",
+      "🔎 Retrieving memory resource with ID: DemoLongTermMemory1-mIRDJI3wdV...\n",
+      "  ✅ Found memory: DemoLongTermMemory1-mIRDJI3wdV\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🔍 DEBUG: Memory status ACTIVE\n"
+      "🔍 DEBUG: Memory status DELETING\n"
      ]
     }
    ],
    "source": [
     "for memory in manager.list_memories():\n",
     "    try:\n",
-    "        # manager.delete_memory(memory_id=memory.id)\n",
+    "        manager.delete_memory(memory_id=memory.id)\n",
     "        pass\n",
-    "    except Exception:\n",
+    "    except Exception as e:\n",
     "        pass\n",
-    "    status = manager.get_memory(memory_id=memory.id).status\n",
+    "    try:\n",
+    "        status = manager.get_memory(memory_id=memory.id).status\n",
+    "    except Exception as e:\n",
+    "        status = \"DELETED\"\n",
     "    print(f\"🔍 DEBUG: Memory status {status}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Memory already exists. Using existing memory ID: qDemoMemory-RQOZg27WYc\n",
+      "🔎 Retrieving memory resource with ID: qDemoMemory-RQOZg27WYc...\n",
+      "  ✅ Found memory: qDemoMemory-RQOZg27WYc\n",
+      "Existing {'type': 'SEMANTIC', 'name': 'SemanticStrategy', 'description': None, 'namespaces': ['/strategies/{memoryStrategyId}/actors/{actorId}']}\n",
+      "Requested {'type': 'SEMANTIC', 'name': 'SemanticStrategya', 'description': None, 'namespaces': []}\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "Strategy mismatch for memory 'qDemoMemory'. Strategy 1 mismatch: name: value mismatch ('SemanticStrategy' vs 'SemanticStrategya') Cannot use existing memory with different strategy configuration.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m memory \u001b[38;5;241m=\u001b[39m \u001b[43mmanager\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_or_create_memory\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m    \u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mqDemoMemory\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m    \u001b[49m\u001b[43mstrategies\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m[\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[43m        \u001b[49m\u001b[43mSemanticStrategy\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      5\u001b[0m \u001b[43m            \u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mSemanticStrategya\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m      6\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;66;43;03m# namespaces=['/strategies/{memoryStrategyId}/actors/{actorId}'],\u001b[39;49;00m\n\u001b[1;32m      7\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      8\u001b[0m \u001b[43m    \u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m      9\u001b[0m \u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/PersonalWorkspace/bedrock-agentcore-starter-toolkit/src/bedrock_agentcore_starter_toolkit/operations/memory/manager.py:436\u001b[0m, in \u001b[0;36mMemoryManager.get_or_create_memory\u001b[0;34m(self, name, strategies, description, event_expiry_days, memory_execution_role_arn, encryption_key_arn)\u001b[0m\n\u001b[1;32m    434\u001b[0m             existing_strategies \u001b[38;5;241m=\u001b[39m memory\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstrategies\u001b[39m\u001b[38;5;124m\"\u001b[39m, memory\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmemoryStrategies\u001b[39m\u001b[38;5;124m\"\u001b[39m, []))\n\u001b[1;32m    435\u001b[0m             memory_name \u001b[38;5;241m=\u001b[39m memory\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mname\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 436\u001b[0m             \u001b[43mvalidate_existing_memory_strategies\u001b[49m\u001b[43m(\u001b[49m\u001b[43mexisting_strategies\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstrategies\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmemory_name\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    438\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m memory\n\u001b[1;32m    439\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m ClientError \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[1;32m    440\u001b[0m     \u001b[38;5;66;03m# Failed to create memory\u001b[39;00m\n",
+      "File \u001b[0;32m~/PersonalWorkspace/bedrock-agentcore-starter-toolkit/src/bedrock_agentcore_starter_toolkit/operations/memory/strategy_validator.py:397\u001b[0m, in \u001b[0;36mvalidate_existing_memory_strategies\u001b[0;34m(memory_strategies, requested_strategies, memory_name)\u001b[0m\n\u001b[1;32m    394\u001b[0m matches, error_message \u001b[38;5;241m=\u001b[39m StrategyComparator\u001b[38;5;241m.\u001b[39mcompare_strategies(memory_strategies, requested_strategies)\n\u001b[1;32m    396\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m matches:\n\u001b[0;32m--> 397\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[1;32m    398\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mStrategy mismatch for memory \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmemory_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m. \u001b[39m\u001b[38;5;132;01m{\u001b[39;00merror_message\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    399\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCannot use existing memory with different strategy configuration.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    400\u001b[0m     )\n\u001b[1;32m    402\u001b[0m \u001b[38;5;66;03m# Log successful validation\u001b[39;00m\n\u001b[1;32m    403\u001b[0m strategy_types \u001b[38;5;241m=\u001b[39m [s\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtype\u001b[39m\u001b[38;5;124m\"\u001b[39m, s\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmemoryStrategyType\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124munknown\u001b[39m\u001b[38;5;124m\"\u001b[39m)) \u001b[38;5;28;01mfor\u001b[39;00m s \u001b[38;5;129;01min\u001b[39;00m memory_strategies]\n",
+      "\u001b[0;31mValueError\u001b[0m: Strategy mismatch for memory 'qDemoMemory'. Strategy 1 mismatch: name: value mismatch ('SemanticStrategy' vs 'SemanticStrategya') Cannot use existing memory with different strategy configuration."
+     ]
+    }
+   ],
+   "source": [
+    "memory = manager.get_or_create_memory(\n",
+    "    name=\"qDemoMemory\",\n",
+    "    strategies=[\n",
+    "        SemanticStrategy(\n",
+    "            name=\"SemanticStrategy\",\n",
+    "            namespaces=['/strategies/{memoryStrategyId}/actors/{actorId}'],\n",
+    "        )\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Updated memory strategies for: DemoMemory-zon5lHECjS\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'arn': 'arn:aws:bedrock-agentcore:us-east-1:328307993871:memory/DemoMemory-zon5lHECjS', 'id': 'DemoMemory-zon5lHECjS', 'name': 'DemoMemory', 'eventExpiryDuration': 90, 'status': 'ACTIVE', 'createdAt': datetime.datetime(2025, 9, 30, 22, 36, 26, 183000, tzinfo=tzlocal()), 'updatedAt': datetime.datetime(2025, 9, 30, 22, 36, 28, 864000, tzinfo=tzlocal()), 'strategies': [{'strategyId': 'SemanticStrategy-wEMM9fABMq', 'name': 'SemanticStrategy', 'description': 'Brief description', 'type': 'SUMMARIZATION', 'namespaces': ['/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}'], 'createdAt': datetime.datetime(2025, 9, 30, 22, 36, 29, 33000, tzinfo=tzlocal()), 'updatedAt': datetime.datetime(2025, 9, 30, 22, 36, 29, 33000, tzinfo=tzlocal()), 'status': 'CREATING'}]}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "manager.add_summary_strategy(\n",
+    "    memory_id=memory.id,\n",
+    "    name=\"SemanticStrategy\",\n",
+    "    description=\"Brief description\",\n",
+    ")"
    ]
   },
   {
@@ -148,10 +219,12 @@
     "            name=\"SemanticStrategy\",\n",
     "            description=\"A strategy for semantic understanding.\",\n",
     "            extraction_config=ExtractionConfig(\n",
-    "                append_to_prompt=\"Extract insights\", model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
+    "                append_to_prompt=\"Extract insights\",\n",
+    "                model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
     "            ),\n",
     "            consolidation_config=ConsolidationConfig(\n",
-    "                append_to_prompt=\"Consolidate semantic insights\", model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
+    "                append_to_prompt=\"Consolidate semantic insights\",\n",
+    "                model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
     "            ),\n",
     "            namespaces=[\"support/user/{actorId}/{sessionId}\"],\n",
     "        ),\n",
@@ -159,7 +232,8 @@
     "            name=\"SummaryStrategy\",\n",
     "            description=\"A strategy for summarizing the conversation.\",\n",
     "            consolidation_config=ConsolidationConfig(\n",
-    "                append_to_prompt=\"Summarize conversation highlights\", model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
+    "                append_to_prompt=\"Summarize conversation highlights\",\n",
+    "                model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
     "            ),\n",
     "            namespaces=[\"support/user/{actorId}/{sessionId}\"],\n",
     "        ),\n",
@@ -167,13 +241,15 @@
     "            name=\"UserPreferenceStrategy\",\n",
     "            description=\"A strategy for user preference.\",\n",
     "            extraction_config=ExtractionConfig(\n",
-    "                append_to_prompt=\"Extract insights\", model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
+    "                append_to_prompt=\"Extract insights\",\n",
+    "                model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
     "            ),\n",
     "            consolidation_config=ConsolidationConfig(\n",
-    "                append_to_prompt=\"Consolidate user preferences\", model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
+    "                append_to_prompt=\"Consolidate user preferences\",\n",
+    "                model_id=\"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
     "            ),\n",
-    "            namespaces=[\"/strategies/{memoryStrategyId}/actors/{actorId}\"],\n",
-    "        ),\n",
+    "            namespaces=['/strategies/{memoryStrategyId}/actors/{actorId}']\n",
+    "        )\n",
     "    ],\n",
     ")\n",
     "print(\"🔍 DEBUG: long-term memory created successfully\")\n",
@@ -285,7 +361,7 @@
     "        UserPreferenceStrategy(\n",
     "            name=\"UserPreferenceStrategy\",\n",
     "            description=\"A strategy for user preference.\",\n",
-    "            namespaces=[\"/strategies/{memoryStrategyId}/actors/{actorId}\"],\n",
+    "            namespaces=['/strategies/{memoryStrategyId}/actors/{actorId}']\n",
     "        )\n",
     "    ],\n",
     ")\n",
@@ -631,7 +707,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "data_science",
    "language": "python",
    "name": "python3"
   },
@@ -645,7 +721,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
fix: don't fail validation for empty namespaces for during get_or_create when strategy defaults server side

## Description
Since AgentCoreMemory provides default namespaces for strategies, the call the `get_or_create_memory` fails with a mismatch exception on the second call if the initial call didn't provide a namespace on the strategy. 
This fix makes it so that, the validation only fails if the provided namespace is not empty.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Checklist

- [ ] No hardcoded secrets or credentials
- [ ] No new security warnings from bandit
- [ ] Dependencies are from trusted sources
- [ ] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
