### PR TITLE
Closes 251: print response only in invoke command

### DIFF
--- a/documentation/docs/api-reference/cli.md
+++ b/documentation/docs/api-reference/cli.md
@@ -99,6 +99,8 @@ Options:
 
 - `--user-id, -u TEXT`: User ID for authorization flows
 
+- `--response-only, -ro`: Return only the JSON payload response without metadata
+
 **Example Output:**
 
 - Session and Request IDs displayed in panel header
@@ -229,6 +231,9 @@ agentcore invoke '{"prompt": "Secure request"}' --bearer-token eyJhbGciOiJIUzI1N
 
 # Invoke local agent
 agentcore invoke '{"prompt": "Test locally"}' --local
+
+# Invoke with response-only flag (returns only the JSON payload)
+agentcore invoke '{"prompt": "Get raw response"}' --response-only
 ```
 
 ### Check Status

--- a/tests/cli/runtime/test_commands.py
+++ b/tests/cli/runtime/test_commands.py
@@ -3087,3 +3087,74 @@ agents:
                 assert call_args.kwargs["custom_headers"] == expected_headers
             finally:
                 os.chdir(original_cwd)
+                
+    def test_invoke_with_response_only_flag(self, tmp_path):
+        """Test invoke command with response_only flag."""
+        config_file = tmp_path / ".bedrock_agentcore.yaml"
+        config_content = """
+default_agent: test-agent
+agents:
+  test-agent:
+    name: test-agent
+    entrypoint: test.py
+"""
+        config_file.write_text(config_content.strip())
+
+        with (
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.load_config") as mock_load_config,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.invoke_bedrock_agentcore") as mock_invoke,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.console.print") as mock_print,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands._show_invoke_info_panel") as mock_show_panel,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands._show_success_response") as mock_show_response,
+        ):
+            # Mock project config and agent config
+            mock_project_config = Mock()
+            mock_agent_config = Mock()
+            mock_agent_config.authorizer_configuration = None
+            mock_project_config.get_agent_config.return_value = mock_agent_config
+            mock_load_config.return_value = mock_project_config
+
+            # Create a response with nested structure
+            mock_result = Mock()
+            mock_result.response = {"response": "This is the raw response"}
+            mock_result.session_id = "test-session"
+            mock_invoke.return_value = mock_result
+
+            original_cwd = Path.cwd()
+            os.chdir(tmp_path)
+
+            try:
+                # Test with response_only flag
+                result = self.runner.invoke(
+                    app, ["invoke", '{"message": "hello"}', "--response-only"]
+                )
+
+                assert result.exit_code == 0
+                
+                # Verify response_only was passed to invoke_bedrock_agentcore
+                call_args = mock_invoke.call_args
+                
+                # Verify the info panel was not shown when response_only is True
+                mock_show_panel.assert_not_called()
+                mock_show_response.assert_not_called()
+                
+                # Verify console.print was called directly with the content
+                mock_print.assert_any_call("This is the raw response")
+                
+                # Test without response_only flag
+                mock_show_panel.reset_mock()
+                mock_show_response.reset_mock()
+                mock_print.reset_mock()
+                
+                result = self.runner.invoke(
+                    app, ["invoke", '{"message": "hello"}']
+                )
+                
+                assert result.exit_code == 0
+                
+                # Verify the info panel was shown when response_only is False
+                mock_show_panel.assert_called_once()
+                mock_show_response.assert_called_once()
+                
+            finally:
+                os.chdir(original_cwd)


### PR DESCRIPTION
## Description

Added functionality to only print the json response of the invoke command 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

