### PR TITLE
feat: Add A2A protocol support to AgentCore Runtime toolkit

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -5,7 +5,7 @@ import typer
 from ..cli.gateway.commands import create_mcp_gateway, create_mcp_gateway_target, gateway_app
 from ..utils.logging_config import setup_toolkit_logging
 from .import_agent.commands import import_agent
-from .runtime.commands import configure_app, destroy, invoke, launch, status
+from .runtime.commands import configure_app, destroy, get_agent_card_command, invoke, launch, status
 
 app = typer.Typer(name="agentcore", help="BedrockAgentCore CLI", add_completion=False, rich_markup_mode="rich")
 
@@ -18,6 +18,7 @@ app.command("status")(status)
 app.command("launch")(launch)
 app.command("import-agent")(import_agent)
 app.command("destroy")(destroy)
+app.command("get-agent-card")(get_agent_card_command)
 app.add_typer(configure_app)
 
 # gateway

--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -683,6 +683,7 @@ def invoke(
         if config.aws.protocol_configuration.server_protocol == "A2A":
             if not session_id or len(session_id) < 33:
                 import uuid
+
                 session_id = f"agentcore_session_{uuid.uuid4().hex}"
                 console.print(f"[dim]Generated A2A-compliant session ID: {session_id}[/dim]")
 
@@ -1154,10 +1155,9 @@ def destroy(
     except Exception as e:
         _handle_error(f"Destruction failed: {e}", e)
 
+
 def get_agent_card_command(
-    agent: Optional[str] = typer.Option(
-        None, "--agent", "-a", help="Agent name"
-    ),
+    agent: Optional[str] = typer.Option(None, "--agent", "-a", help="Agent name"),
     bearer_token: Optional[str] = typer.Option(
         None, "--bearer-token", "-bt", help="Bearer token for OAuth authentication"
     ),
@@ -1177,11 +1177,12 @@ def get_agent_card_command(
 
         if json_output:
             import json
+
             console.print(json.dumps(result.agent_card, indent=2))
         else:
             # Pretty formatted output
             agent_card = result.agent_card
-            
+
             panel_lines = [
                 f"[bold]Agent:[/bold] [cyan]{agent_card.get('name', 'Unknown')}[/cyan]",
                 f"[bold]Description:[/bold] {agent_card.get('description', 'N/A')}",

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/__init__.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/__init__.py
@@ -2,6 +2,7 @@
 
 from .configure import configure_bedrock_agentcore, validate_agent_name
 from .destroy import destroy_bedrock_agentcore
+from .get_agent_card import get_agent_card
 from .invoke import invoke_bedrock_agentcore
 from .launch import launch_bedrock_agentcore
 from .models import (
@@ -9,6 +10,7 @@ from .models import (
     DestroyResult,
     InvokeResult,
     LaunchResult,
+    GetAgentCardResult,
     StatusConfigInfo,
     StatusResult,
 )
@@ -17,12 +19,14 @@ from .status import get_status
 __all__ = [
     "configure_bedrock_agentcore",
     "destroy_bedrock_agentcore",
+    "get_agent_card",
     "validate_agent_name",
     "launch_bedrock_agentcore",
     "invoke_bedrock_agentcore",
     "get_status",
     "ConfigureResult",
     "DestroyResult",
+    "GetAgentCardResult",
     "InvokeResult",
     "LaunchResult",
     "StatusResult",

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/__init__.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/__init__.py
@@ -8,9 +8,9 @@ from .launch import launch_bedrock_agentcore
 from .models import (
     ConfigureResult,
     DestroyResult,
+    GetAgentCardResult,
     InvokeResult,
     LaunchResult,
-    GetAgentCardResult,
     StatusConfigInfo,
     StatusResult,
 )

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
@@ -59,7 +59,7 @@ def configure_bedrock_agentcore(
         request_header_configuration: Request header configuration dictionary
         verbose: Whether to provide verbose output during configuration
         region: AWS region for deployment
-        protocol: agent server protocol, must be either HTTP or MCP
+        protocol: agent server protocol, must be either HTTP or MCP or A2A
         non_interactive: Skip interactive prompts and use defaults
 
     Returns:
@@ -205,6 +205,7 @@ def configure_bedrock_agentcore(
         requirements_file,
         memory_id,
         memory_name,
+        protocol,
     )
 
     # Check if .dockerignore was created

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/get_agent_card.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/get_agent_card.py
@@ -1,0 +1,79 @@
+"""Get agent card operation - retrieves A2A agent card from deployed agent."""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from ...services.runtime import BedrockAgentCoreClient, HttpBedrockAgentCoreClient
+from ...utils.runtime.config import load_config
+from .models import GetAgentCardResult
+
+log = logging.getLogger(__name__)
+
+
+def get_agent_card(
+    config_path: Path,
+    agent_name: Optional[str] = None,
+    bearer_token: Optional[str] = None,
+) -> GetAgentCardResult:
+    """Retrieve agent card from deployed A2A agent.
+
+    Args:
+        config_path: Path to configuration file
+        agent_name: Name of agent (optional, uses default if not provided)
+        bearer_token: OAuth bearer token for authentication (if agent uses OAuth)
+
+    Returns:
+        GetAgentCardResult with agent card JSON
+
+    Raises:
+        ValueError: If agent not configured or not deployed
+        RuntimeError: If GetAgentCard API call fails
+    """
+    # Load configuration
+    project_config = load_config(config_path)
+    agent_config = project_config.get_agent_config(agent_name)
+
+    log.debug("Retrieving agent card for agent: %s", agent_config.name)
+
+    # Check if agent is deployed
+    if not agent_config.bedrock_agentcore or not agent_config.bedrock_agentcore.agent_arn:
+        raise ValueError(
+            f"Agent '{agent_config.name}' is not deployed. Run 'agentcore launch' first."
+        )
+
+    agent_arn = agent_config.bedrock_agentcore.agent_arn
+    region = agent_config.aws.region
+
+    if not region:
+        raise ValueError("Region not found in configuration")
+
+    # Determine if we need OAuth or SigV4
+    if bearer_token:
+        # Use HTTP client with bearer token
+        from ...services.runtime import HttpBedrockAgentCoreClient
+        
+        client = HttpBedrockAgentCoreClient(region)
+        
+        try:
+            agent_card = client.get_agent_card(
+                agent_arn=agent_arn,
+                bearer_token=bearer_token,
+            )
+        except Exception as e:
+            log.error("Failed to get agent card with OAuth: %s", e)
+            raise RuntimeError(f"GetAgentCard failed: {e}") from e
+    else:
+        # Use SigV4 client
+        client = BedrockAgentCoreClient(region)
+        
+        try:
+            agent_card = client.get_agent_card(agent_arn=agent_arn)
+        except Exception as e:
+            log.error("Failed to get agent card with SigV4: %s", e)
+            raise RuntimeError(f"GetAgentCard failed: {e}") from e
+
+    return GetAgentCardResult(
+        agent_card=agent_card,
+        agent_name=agent_config.name,
+    )

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/get_agent_card.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/get_agent_card.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from ...services.runtime import BedrockAgentCoreClient, HttpBedrockAgentCoreClient
+from ...services.runtime import BedrockAgentCoreClient
 from ...utils.runtime.config import load_config
 from .models import GetAgentCardResult
 
@@ -38,9 +38,7 @@ def get_agent_card(
 
     # Check if agent is deployed
     if not agent_config.bedrock_agentcore or not agent_config.bedrock_agentcore.agent_arn:
-        raise ValueError(
-            f"Agent '{agent_config.name}' is not deployed. Run 'agentcore launch' first."
-        )
+        raise ValueError(f"Agent '{agent_config.name}' is not deployed. Run 'agentcore launch' first.")
 
     agent_arn = agent_config.bedrock_agentcore.agent_arn
     region = agent_config.aws.region
@@ -52,9 +50,9 @@ def get_agent_card(
     if bearer_token:
         # Use HTTP client with bearer token
         from ...services.runtime import HttpBedrockAgentCoreClient
-        
+
         client = HttpBedrockAgentCoreClient(region)
-        
+
         try:
             agent_card = client.get_agent_card(
                 agent_arn=agent_arn,
@@ -66,7 +64,7 @@ def get_agent_card(
     else:
         # Use SigV4 client
         client = BedrockAgentCoreClient(region)
-        
+
         try:
             agent_card = client.get_agent_card(agent_arn=agent_arn)
         except Exception as e:

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/models.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/models.py
@@ -94,3 +94,9 @@ class DestroyResult(BaseModel):
     warnings: List[str] = Field(default_factory=list, description="List of warnings during destruction")
     errors: List[str] = Field(default_factory=list, description="List of errors during destruction")
     dry_run: bool = Field(default=False, description="Whether this was a dry run")
+
+class GetAgentCardResult(BaseModel):
+    """Result from get_agent_card operation."""
+
+    agent_card: dict = Field(..., description="Agent card JSON document")
+    agent_name: str = Field(..., description="Name of the agent")

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/models.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/models.py
@@ -95,6 +95,7 @@ class DestroyResult(BaseModel):
     errors: List[str] = Field(default_factory=list, description="List of errors during destruction")
     dry_run: bool = Field(default=False, description="Whether this was a dry run")
 
+
 class GetAgentCardResult(BaseModel):
     """Result from get_agent_card operation."""
 

--- a/src/bedrock_agentcore_starter_toolkit/services/runtime.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/runtime.py
@@ -497,10 +497,10 @@ class BedrockAgentCoreClient:
 
         # URL-encode the ARN
         escaped_arn = urllib.parse.quote(agent_arn, safe="")
-        
+
         # Construct the GetAgentCard URL
         url = f"{self.dp_endpoint}/runtimes/{escaped_arn}/invocations/.well-known/agent-card.json"
-        
+
         if qualifier and qualifier != "DEFAULT":
             url += f"?qualifier={qualifier}"
 
@@ -508,21 +508,24 @@ class BedrockAgentCoreClient:
 
         try:
             import requests
-            
+
             # Use requests with SigV4 signing
             from botocore.auth import SigV4Auth
             from botocore.awsrequest import AWSRequest
-            
+
             request = AWSRequest(method="GET", url=url)
-            SigV4Auth(self.dataplane_client._request_signer._credentials, "bedrock-agentcore", self.region).add_auth(request)
-            
+            SigV4Auth(self.dataplane_client._request_signer._credentials, "bedrock-agentcore", self.region).add_auth(
+                request
+            )
+
             response = requests.get(url, headers=dict(request.headers))
             response.raise_for_status()
-            
+
             return response.json()
         except Exception as e:
             self.logger.error("Failed to get agent card: %s", e)
             raise
+
 
 class HttpBedrockAgentCoreClient:
     """Bedrock AgentCore client for agent management using HTTP requests with bearer token."""
@@ -625,7 +628,7 @@ class HttpBedrockAgentCoreClient:
 
         # Build URL
         url = f"{self.dp_endpoint}/runtimes/{escaped_arn}/invocations/.well-known/agent-card.json"
-        
+
         if qualifier and qualifier != "DEFAULT":
             url += f"?qualifier={qualifier}"
 
@@ -643,6 +646,7 @@ class HttpBedrockAgentCoreClient:
         except requests.exceptions.RequestException as e:
             self.logger.error("Failed to get agent card: %s", str(e))
             raise
+
 
 class LocalBedrockAgentCoreClient:
     """Local Bedrock AgentCore client for invoking endpoints."""

--- a/src/bedrock_agentcore_starter_toolkit/services/runtime.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/runtime.py
@@ -98,6 +98,8 @@ class BedrockAgentCoreClient:
         control_plane_url = get_control_plane_endpoint(region)
         data_plane_url = get_data_plane_endpoint(region)
 
+        self.dp_endpoint = data_plane_url
+
         self.logger.debug("Initializing Bedrock AgentCore client for region: %s", region)
         self.logger.debug("Control plane: %s", control_plane_url)
         self.logger.debug("Data plane: %s", data_plane_url)
@@ -481,6 +483,46 @@ class BedrockAgentCoreClient:
                     "before-sign.bedrock-agentcore.InvokeAgentRuntime", handler_id
                 )
 
+    def get_agent_card(self, agent_arn: str, qualifier: str = "DEFAULT") -> dict:
+        """Get agent card from deployed A2A agent.
+
+        Args:
+            agent_arn: Agent ARN
+            qualifier: Endpoint qualifier (default: "DEFAULT")
+
+        Returns:
+            Agent card JSON document
+        """
+        import urllib.parse
+
+        # URL-encode the ARN
+        escaped_arn = urllib.parse.quote(agent_arn, safe="")
+        
+        # Construct the GetAgentCard URL
+        url = f"{self.dp_endpoint}/runtimes/{escaped_arn}/invocations/.well-known/agent-card.json"
+        
+        if qualifier and qualifier != "DEFAULT":
+            url += f"?qualifier={qualifier}"
+
+        self.logger.debug("Getting agent card from: %s", url)
+
+        try:
+            import requests
+            
+            # Use requests with SigV4 signing
+            from botocore.auth import SigV4Auth
+            from botocore.awsrequest import AWSRequest
+            
+            request = AWSRequest(method="GET", url=url)
+            SigV4Auth(self.dataplane_client._request_signer._credentials, "bedrock-agentcore", self.region).add_auth(request)
+            
+            response = requests.get(url, headers=dict(request.headers))
+            response.raise_for_status()
+            
+            return response.json()
+        except Exception as e:
+            self.logger.error("Failed to get agent card: %s", e)
+            raise
 
 class HttpBedrockAgentCoreClient:
     """Bedrock AgentCore client for agent management using HTTP requests with bearer token."""
@@ -560,6 +602,47 @@ class HttpBedrockAgentCoreClient:
             self.logger.error("Failed to invoke agent endpoint: %s", str(e))
             raise
 
+    def get_agent_card(
+        self,
+        agent_arn: str,
+        bearer_token: str,
+        qualifier: str = "DEFAULT",
+    ) -> dict:
+        """Get agent card using OAuth bearer token.
+
+        Args:
+            agent_arn: Agent ARN
+            bearer_token: OAuth bearer token
+            qualifier: Endpoint qualifier (default: "DEFAULT")
+
+        Returns:
+            Agent card JSON document
+        """
+        import urllib.parse
+
+        # Escape agent ARN for URL
+        escaped_arn = urllib.parse.quote(agent_arn, safe="")
+
+        # Build URL
+        url = f"{self.dp_endpoint}/runtimes/{escaped_arn}/invocations/.well-known/agent-card.json"
+        
+        if qualifier and qualifier != "DEFAULT":
+            url += f"?qualifier={qualifier}"
+
+        # Headers
+        headers = {
+            "Authorization": f"Bearer {bearer_token}",
+            "Accept": "application/json",
+        }
+
+        try:
+            # Make request
+            response = requests.get(url, headers=headers, timeout=30)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            self.logger.error("Failed to get agent card: %s", str(e))
+            raise
 
 class LocalBedrockAgentCoreClient:
     """Local Bedrock AgentCore client for invoking endpoints."""

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
@@ -110,6 +110,7 @@ class ContainerRuntime:
         requirements_file: Optional[str] = None,
         memory_id: Optional[str] = None,
         memory_name: Optional[str] = None,
+        protocol: Optional[str] = None,
     ) -> Path:
         """Generate Dockerfile from template."""
         current_platform = self._get_current_platform()
@@ -168,6 +169,7 @@ class ContainerRuntime:
             "observability_enabled": enable_observability,
             "memory_id": memory_id,
             "memory_name": memory_name,
+            "protocol": protocol or "HTTP",
         }
 
         dockerfile_path = output_dir / "Dockerfile"

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
@@ -43,7 +43,16 @@ class NetworkConfiguration(BaseModel):
 class ProtocolConfiguration(BaseModel):
     """Protocol configuration for BedrockAgentCore deployment."""
 
-    server_protocol: str = Field(default="HTTP", description="Server protocol for deployment, either HTTP or MCP")
+    server_protocol: str = Field(default="HTTP", description="Server protocol for deployment, either HTTP or MCP or A2A")
+
+    @field_validator("server_protocol")
+    @classmethod
+    def validate_protocol(cls, v: str) -> str:
+        """Validate protocol is one of the supported types."""
+        allowed = ["HTTP", "MCP", "A2A"]
+        if v.upper() not in allowed:
+            raise ValueError(f"Protocol must be one of {allowed}, got: {v}")
+        return v.upper()
 
     def to_aws_dict(self) -> dict:
         """Convert to AWS API format with camelCase keys."""

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
@@ -43,7 +43,9 @@ class NetworkConfiguration(BaseModel):
 class ProtocolConfiguration(BaseModel):
     """Protocol configuration for BedrockAgentCore deployment."""
 
-    server_protocol: str = Field(default="HTTP", description="Server protocol for deployment, either HTTP or MCP or A2A")
+    server_protocol: str = Field(
+        default="HTTP", description="Server protocol for deployment, either HTTP or MCP or A2A"
+    )
 
     @field_validator("server_protocol")
     @classmethod

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/Dockerfile.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/Dockerfile.j2
@@ -40,8 +40,14 @@ ENV DOCKER_CONTAINER=1
 RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore
 
-EXPOSE 8080
+# Expose port based on protocol
+{% if protocol == "A2A" %}
+EXPOSE 9000
+{% elif protocol == "MCP" %}
 EXPOSE 8000
+{% else %}
+EXPOSE 8080
+{% endif %}
 
 # Copy entire project (respecting .dockerignore)
 COPY . .

--- a/tests/cli/runtime/test_commands.py
+++ b/tests/cli/runtime/test_commands.py
@@ -185,7 +185,7 @@ def handler(payload):
                 self.runner.invoke(app, ["configure", "--entrypoint", str(agent_file), "--protocol", "HTTPS"])
             except typer.Exit:
                 pass
-            mock_error.assert_called_once_with("Error: --protocol must be either HTTP or MCP")
+            mock_error.assert_called_once_with("Error: --protocol must be either HTTP or MCP or A2A")
 
     @pytest.mark.skip(reason="Skipping due to Typer CLI issues with YAML parsing")
     def test_launch_command_local(self, tmp_path):

--- a/tests/operations/runtime/test_get_agent_card.py
+++ b/tests/operations/runtime/test_get_agent_card.py
@@ -1,0 +1,232 @@
+"""Tests for get_agent_card operation."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from bedrock_agentcore_starter_toolkit.operations.runtime.get_agent_card import get_agent_card
+from bedrock_agentcore_starter_toolkit.operations.runtime.models import GetAgentCardResult
+
+
+class TestGetAgentCard:
+    """Test get_agent_card functionality."""
+
+
+    def test_get_agent_card_with_oauth(self, tmp_path):
+        """Test retrieving agent card using OAuth bearer token."""
+        config_content = """
+default_agent: test_agent
+agents:
+  test_agent:
+    name: test_agent
+    entrypoint: test_agent.py
+    platform: linux/arm64
+    container_runtime: docker
+    aws:
+      region: us-west-2
+      account: '123456789012'
+      execution_role: arn:aws:iam::123456789012:role/TestRole
+      ecr_repository: test-repo
+      ecr_auto_create: false
+      network_configuration:
+        network_mode: PUBLIC
+      protocol_configuration:
+        server_protocol: A2A
+      observability:
+        enabled: true
+    bedrock_agentcore:
+      agent_id: test-agent-id
+      agent_arn: arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/test-agent
+      agent_session_id: null
+    codebuild:
+      project_name: null
+      execution_role: null
+      source_bucket: null
+    memory:
+      mode: STM_ONLY
+      memory_id: null
+      memory_arn: null
+      memory_name: null
+      event_expiry_days: 30
+      first_invoke_memory_check_done: false
+    authorizer_configuration:
+      customJWTAuthorizer:
+        discoveryUrl: https://example.com/.well-known/openid-configuration
+        allowedClients:
+          - test-client-id
+    request_header_configuration: null
+    oauth_configuration: null
+"""
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        config_path.write_text(config_content)
+
+        mock_agent_card = {"name": "OAuth Agent", "url": "https://example.com/oauth-agent"}
+
+        # Patch the dynamically imported HttpBedrockAgentCoreClient
+        with patch(
+            "bedrock_agentcore_starter_toolkit.services.runtime.HttpBedrockAgentCoreClient"
+        ) as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_agent_card.return_value = mock_agent_card
+            mock_client_class.return_value = mock_client
+
+            result = get_agent_card(config_path=config_path, agent_name="test_agent", bearer_token="test-token")
+
+            assert isinstance(result, GetAgentCardResult)
+            assert result.agent_name == "test_agent"
+            assert result.agent_card == mock_agent_card
+
+    def test_get_agent_card_agent_not_deployed(self, tmp_path):
+        """Test error when agent is not deployed."""
+        config_content = """
+default_agent: test_agent
+agents:
+  test_agent:
+    name: test_agent
+    entrypoint: test_agent.py
+    platform: linux/arm64
+    container_runtime: docker
+    aws:
+      region: us-west-2
+      account: '123456789012'
+      execution_role: arn:aws:iam::123456789012:role/TestRole
+      ecr_repository: test-repo
+      ecr_auto_create: false
+      network_configuration:
+        network_mode: PUBLIC
+      protocol_configuration:
+        server_protocol: A2A
+      observability:
+        enabled: true
+    bedrock_agentcore:
+      agent_id: null
+      agent_arn: null
+      agent_session_id: null
+    codebuild:
+      project_name: null
+      execution_role: null
+      source_bucket: null
+    memory:
+      mode: STM_ONLY
+      memory_id: null
+      memory_arn: null
+      memory_name: null
+      event_expiry_days: 30
+      first_invoke_memory_check_done: false
+    authorizer_configuration: null
+    request_header_configuration: null
+    oauth_configuration: null
+"""
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        config_path.write_text(config_content)
+
+        with pytest.raises(ValueError) as exc_info:
+            get_agent_card(config_path=config_path, agent_name="test_agent")
+
+        assert "not deployed" in str(exc_info.value)
+
+    def test_get_agent_card_config_not_found(self, tmp_path):
+        """Test error when configuration file doesn't exist."""
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+
+        with pytest.raises(FileNotFoundError):
+            get_agent_card(config_path=config_path, agent_name="test_agent")
+
+    def test_get_agent_card_agent_not_in_config(self, tmp_path):
+        """Test error when specified agent doesn't exist in config."""
+        config_content = """
+default_agent: test_agent
+agents:
+  test_agent:
+    name: test_agent
+    entrypoint: test_agent.py
+    platform: linux/arm64
+    container_runtime: docker
+    aws:
+      region: us-west-2
+      account: '123456789012'
+      execution_role: arn:aws:iam::123456789012:role/TestRole
+      ecr_repository: test-repo
+      ecr_auto_create: false
+      network_configuration:
+        network_mode: PUBLIC
+      protocol_configuration:
+        server_protocol: A2A
+      observability:
+        enabled: true
+    bedrock_agentcore:
+      agent_id: test-agent-id
+      agent_arn: arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/test-agent
+      agent_session_id: null
+    codebuild:
+      project_name: null
+      execution_role: null
+      source_bucket: null
+    memory:
+      mode: STM_ONLY
+      memory_id: null
+      memory_arn: null
+      memory_name: null
+      event_expiry_days: 30
+      first_invoke_memory_check_done: false
+    authorizer_configuration: null
+    request_header_configuration: null
+    oauth_configuration: null
+"""
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        config_path.write_text(config_content)
+
+        with pytest.raises(ValueError) as exc_info:
+            get_agent_card(config_path=config_path, agent_name="nonexistent_agent")
+
+        assert "not found" in str(exc_info.value)
+
+    def test_get_agent_card_missing_region(self, tmp_path):
+        """Test error when region is missing from configuration."""
+        config_content = """
+default_agent: test_agent
+agents:
+  test_agent:
+    name: test_agent
+    entrypoint: test_agent.py
+    platform: linux/arm64
+    container_runtime: docker
+    aws:
+      region: null
+      account: '123456789012'
+      execution_role: arn:aws:iam::123456789012:role/TestRole
+      ecr_repository: test-repo
+      ecr_auto_create: false
+      network_configuration:
+        network_mode: PUBLIC
+      protocol_configuration:
+        server_protocol: A2A
+      observability:
+        enabled: true
+    bedrock_agentcore:
+      agent_id: test-agent-id
+      agent_arn: arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/test-agent
+      agent_session_id: null
+    codebuild:
+      project_name: null
+      execution_role: null
+      source_bucket: null
+    memory:
+      mode: STM_ONLY
+      memory_id: null
+      memory_arn: null
+      memory_name: null
+      event_expiry_days: 30
+      first_invoke_memory_check_done: false
+    authorizer_configuration: null
+    request_header_configuration: null
+    oauth_configuration: null
+"""
+        config_path = tmp_path / ".bedrock_agentcore.yaml"
+        config_path.write_text(config_content)
+
+        with pytest.raises(ValueError) as exc_info:
+            get_agent_card(config_path=config_path, agent_name="test_agent")
+
+        assert "Region not found" in str(exc_info.value)


### PR DESCRIPTION
## Description

Adds A2A (Agent-to-Agent) protocol support to the Bedrock AgentCore Runtime toolkit, enabling deployment and invocation of A2A servers with OAuth

## Changes

### Protocol Support
- Added "A2A" to allowed protocols in schema validation
- Updated Dockerfile template to expose port 9000 for A2A (vs 8080 for HTTP)
- Protocol parameter properly threaded through configure → launch pipeline

### Agent Card Operations
- New `agentcore get-agent-card` command to retrieve agent metadata
- Supports both SigV4 and OAuth authentication
- Returns agent card JSON with capabilities, skills, and discovery information

### OAuth Support
- `--bearer-token` flag in invoke command for OAuth-authenticated agents
- Bearer token properly passed to Runtime API Authorization header
- Session ID auto-generation compliant with A2A spec (33+ characters)

### Environment Variables
- Existing `--env` flag in launch works correctly for A2A agents
- Enables passing SEARCH_AGENT_URL, BEARER_TOKEN, etc. to containers
- Critical for multi-agent A2A systems

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [X ] Unit tests pass locally
- [x ] Integration tests pass (if applicable)
- [x ] Test coverage remains above 80%
- [ x] Manual testing completed

## Checklist

- [x ] My code follows the project's style guidelines (ruff/pre-commit)
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published

## Security Checklist

- [x ] No hardcoded secrets or credentials
- [x ] No new security warnings from bandit
- [x ] Dependencies are from trusted sources
- [x ] No sensitive data logged

## Breaking Changes
None. All changes are backward compatible with existing HTTP/MCP workflows.


## Dependencies
- Requires Runtime service A2A protocol support (GA release)
- No new Python dependencies added
