### PR TITLE
Fix: Integration test hanging due to missing non-interactive flag

### DIFF
--- a/tests_integ/cli/runtime/test_simple_agent.py
+++ b/tests_integ/cli/runtime/test_simple_agent.py
@@ -55,8 +55,9 @@ class TestSimpleAgent(BaseCLIRuntimeTest):
                 TEST_ECR,
                 "--requirements-file",
                 self.requirements_file,
+                "--non-interactive",
             ],
-            user_input=["no", "no"],  # oauth config, request header allowlist
+            user_input=[],
             validator=lambda result: self.validate_configure(result),
         )
 


### PR DESCRIPTION
## Description

### Problem
The `test_simple_agent` integration test was hanging indefinitely after the recent addition of the `--non-interactive` flag to the CLI configure command.

### Solution
Added `--non-interactive` flag to the configure command in the integration test and removed the now-unnecessary `user_input` array.

### Changes
- Added `--non-interactive` flag to skip interactive prompts in automated testing
- Removed `user_input=["no", "no"]` as it's no longer needed

This ensures the integration test runs without waiting for user input, aligning with the CLI's new non-interactive mode behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [ ] Manual testing completed

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [ ] No hardcoded secrets or credentials
- [ ] No new security warnings from bandit
- [ ] Dependencies are from trusted sources
- [ ] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
