### PR TITLE
chore: remove workload access permissions from runtime execution policy

### DIFF
--- a/documentation/docs/user-guide/runtime/permissions.md
+++ b/documentation/docs/user-guide/runtime/permissions.md
@@ -61,121 +61,131 @@ Attach the following policy to your IAM user or role:
 
 ```json
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "IAMRoleManagement",
-			"Effect": "Allow",
-			"Action": [
-				"iam:CreateRole",
-				"iam:DeleteRole",
-				"iam:GetRole",
-				"iam:PutRolePolicy",
-				"iam:DeleteRolePolicy",
-				"iam:AttachRolePolicy",
-				"iam:DetachRolePolicy",
-				"iam:TagRole",
-				"iam:ListRolePolicies",
-				"iam:ListAttachedRolePolicies"
-			],
-			"Resource": [
-				"arn:aws:iam::*:role/*BedrockAgentCore*",
-				"arn:aws:iam::*:role/service-role/*BedrockAgentCore*"
-			]
-		},
-		{
-			"Sid": "CodeBuildProjectAccess",
-			"Effect": "Allow",
-			"Action": [
-				"codebuild:StartBuild",
-				"codebuild:BatchGetBuilds",
-				"codebuild:ListBuildsForProject",
-				"codebuild:CreateProject",
-				"codebuild:UpdateProject",
-				"codebuild:BatchGetProjects"
-			],
-			"Resource": [
-				"arn:aws:codebuild:*:*:project/bedrock-agentcore-*",
-				"arn:aws:codebuild:*:*:build/bedrock-agentcore-*"
-			]
-		},
-		{
-			"Sid": "CodeBuildListAccess",
-			"Effect": "Allow",
-			"Action": [
-				"codebuild:ListProjects"
-			],
-			"Resource": "*"
-		},
-		{
-			"Sid": "IAMPassRoleAccess",
-			"Effect": "Allow",
-			"Action": [
-				"iam:PassRole"
-			],
-			"Resource": [
-				"arn:aws:iam::*:role/AmazonBedrockAgentCore*",
-				"arn:aws:iam::*:role/service-role/AmazonBedrockAgentCore*"
-			]
-		},
-		{
-			"Sid": "CloudWatchLogsAccess",
-			"Effect": "Allow",
-			"Action": [
-				"logs:GetLogEvents",
-				"logs:DescribeLogGroups",
-				"logs:DescribeLogStreams"
-			],
-			"Resource": [
-				"arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/*",
-				"arn:aws:logs:*:*:log-group:/aws/codebuild/*"
-			]
-		},
-		{
-			"Sid": "S3Access",
-			"Effect": "Allow",
-			"Action": [
-				"s3:GetObject",
-				"s3:PutObject",
-				"s3:ListBucket",
-				"s3:CreateBucket",
-				"s3:PutLifecycleConfiguration"
-			],
-			"Resource": [
-				"arn:aws:s3:::bedrock-agentcore-*",
-				"arn:aws:s3:::bedrock-agentcore-*/*"
-			]
-		},
-		{
-			"Sid": "ECRRepositoryAccess",
-			"Effect": "Allow",
-			"Action": [
-				"ecr:CreateRepository",
-				"ecr:DescribeRepositories",
-				"ecr:GetRepositoryPolicy",
-				"ecr:InitiateLayerUpload",
-				"ecr:CompleteLayerUpload",
-				"ecr:PutImage",
-				"ecr:UploadLayerPart",
-				"ecr:BatchCheckLayerAvailability",
-				"ecr:GetDownloadUrlForLayer",
-				"ecr:BatchGetImage",
-				"ecr:ListImages",
-				"ecr:TagResource"
-			],
-			"Resource": [
-				"arn:aws:ecr:*:*:repository/bedrock-agentcore-*"
-			]
-		},
-		{
-			"Sid": "ECRAuthorizationAccess",
-			"Effect": "Allow",
-			"Action": [
-				"ecr:GetAuthorizationToken"
-			],
-			"Resource": "*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [{
+      "Sid": "IAMRoleManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:TagRole",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/*BedrockAgentCore*",
+        "arn:aws:iam::*:role/service-role/*BedrockAgentCore*"
+      ]
+    },
+    {
+      "Sid": "CodeBuildProjectAccess",
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:StartBuild",
+        "codebuild:BatchGetBuilds",
+        "codebuild:ListBuildsForProject",
+        "codebuild:CreateProject",
+        "codebuild:UpdateProject",
+        "codebuild:BatchGetProjects"
+      ],
+      "Resource": [
+        "arn:aws:codebuild:*:*:project/bedrock-agentcore-*",
+        "arn:aws:codebuild:*:*:build/bedrock-agentcore-*"
+      ]
+    },
+    {
+      "Sid": "CodeBuildListAccess",
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:ListProjects"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IAMPassRoleAccess",
+      "Effect": "Allow",
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/AmazonBedrockAgentCore*",
+        "arn:aws:iam::*:role/service-role/AmazonBedrockAgentCore*"
+      ]
+    },
+    {
+      "Sid": "CloudWatchLogsAccess",
+      "Effect": "Allow",
+      "Action": [
+        "logs:GetLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:log-group:/aws/bedrock-agentcore/*",
+        "arn:aws:logs:*:*:log-group:/aws/codebuild/*"
+      ]
+    },
+    {
+      "Sid": "S3Access",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListBucket",
+        "s3:CreateBucket",
+        "s3:PutLifecycleConfiguration"
+      ],
+      "Resource": [
+        "arn:aws:s3:::bedrock-agentcore-*",
+        "arn:aws:s3:::bedrock-agentcore-*/*"
+      ]
+    },
+    {
+      "Sid": "ECRRepositoryAccess",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:CreateRepository",
+        "ecr:DescribeRepositories",
+        "ecr:GetRepositoryPolicy",
+        "ecr:InitiateLayerUpload",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage",
+        "ecr:UploadLayerPart",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:ListImages",
+        "ecr:TagResource"
+      ],
+      "Resource": [
+        "arn:aws:ecr:*:*:repository/bedrock-agentcore-*"
+      ]
+    },
+    {
+      "Sid": "ECRAuthorizationAccess",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "BedrockAgentCoreRuntimeIdentityServiceLinkedRolePermissions",
+      "Effect": "Allow",
+      "Action": "iam:CreateServiceLinkedRole",
+      "Resource": "arn:aws:iam::*:role/aws-service-role/runtime-identity.bedrock-agentcore.amazonaws.com/AWSServiceRoleForBedrockAgentCoreRuntimeIdentity",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": "runtime-identity.bedrock-agentcore.amazonaws.com"
+        }
+      }
+    }
+  ]
 }
 ```
 
@@ -315,19 +325,6 @@ The Runtime Execution Role is an IAM role that AgentCore Runtime assumes to run 
                     "cloudwatch:namespace": "bedrock-agentcore"
                 }
             }
-        },
-        {
-            "Sid": "GetAgentAccessToken",
-            "Effect": "Allow",
-            "Action": [
-                "bedrock-agentcore:GetWorkloadAccessToken",
-                "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
-                "bedrock-agentcore:GetWorkloadAccessTokenForUserId"
-            ],
-            "Resource": [
-                "arn:aws:bedrock-agentcore:region:accountId:workload-identity-directory/default",
-                "arn:aws:bedrock-agentcore:region:accountId:workload-identity-directory/default/workload-identity/agentName-*"
-            ]
         },
         {
             "Sid": "BedrockModelInvocation",

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
@@ -144,19 +144,6 @@
       ]
     },
     {
-      "Sid": "BedrockAgentCoreIdentityGetWorkloadAccessToken",
-      "Effect": "Allow",
-      "Action": [
-        "bedrock-agentcore:GetWorkloadAccessToken",
-        "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
-        "bedrock-agentcore:GetWorkloadAccessTokenForUserId"
-      ],
-      "Resource": [
-        "arn:aws:bedrock-agentcore:{{ region }}:{{ account_id }}:workload-identity-directory/default",
-        "arn:aws:bedrock-agentcore:{{ region }}:{{ account_id }}:workload-identity-directory/default/workload-identity/{{ agent_name }}-*"
-      ]
-    },
-    {
       "Sid": "BedrockModelInvocation",
       "Effect": "Allow",
       "Action": [

--- a/tests/utils/runtime/test_policy_template.py
+++ b/tests/utils/runtime/test_policy_template.py
@@ -129,9 +129,6 @@ class TestPolicyTemplate:
             "xray:GetSamplingRules",
             "xray:GetSamplingTargets",
             "cloudwatch:PutMetricData",
-            "bedrock-agentcore:GetWorkloadAccessToken",
-            "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
-            "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
             "bedrock:InvokeModel",
             "bedrock:InvokeModelWithResponseStream",
         ]


### PR DESCRIPTION
## Description

Starting `October 13, 2025`, Amazon Bedrock AgentCore uses a Service-Linked Role (SLR) for workload identity permissions instead of requiring manual IAM policy configuration for new/updated agents.

The Service-Linked Role details:

- **Name**: `AWSServiceRoleForBedrockAgentCoreRuntimeIdentity`
- **Service Principal**: `runtime-identity.bedrock-agentcore.amazonaws.com`
- **Purpose**: Manages workload identity access tokens and OAuth credentials
- **Benefit**: The Service-Linked Role automatically provides the necessary permissions for workload identity access without requiring manual policy configuration.
- **Docs**: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/service-linked-roles.html#identity-service-linked-role

Tested with account allowlisted for SLR use.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [x] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

N/A
