### PR TITLE
add a2a and vpc documentation on agentcore

### DIFF
--- a/documentation/docs/user-guide/runtime/a2a.md
+++ b/documentation/docs/user-guide/runtime/a2a.md
@@ -1,0 +1,508 @@
+# Deploy A2A servers in AgentCore Runtime
+
+Amazon Bedrock AgentCore AgentCore Runtime lets you deploy and run Agent-to-Agent (A2A)
+servers in the AgentCore Runtime. This guide walks you through creating, testing, and deploying your
+first A2A server.
+
+In this section, you learn:
+
+* How
+  Amazon Bedrock AgentCore supports A2A
+* How to create an A2A server with agent capabilities
+* How to test your server locally
+* How to deploy your server to AWS
+* How to invoke your deployed server
+* How to retrieve agent cards for discovery
+
+###### Topics
+
+* [How
+  Amazon Bedrock AgentCore supports A2A](#runtime-a2a-how-agentcore-supports "#runtime-a2a-how-agentcore-supports")
+* [Using A2A with AgentCore Runtime](#runtime-a2a-steps "#runtime-a2a-steps")
+* [Appendix](#runtime-a2a-appendix "#runtime-a2a-appendix")
+
+## How Amazon Bedrock AgentCore supports A2A
+
+Amazon Bedrock AgentCore's A2A protocol support enables seamless integration with
+A2A servers by acting as a transparent proxy layer. When configured for A2A,
+Amazon Bedrock AgentCore expects containers to run stateless, streamable HTTP servers on port
+`9000` at the root path (`0.0.0.0:9000/`), which aligns with the default A2A server
+configuration.
+
+The service provides enterprise-grade session isolation while maintaining protocol
+transparency - JSON-RPC payloads from the [InvokeAgentRuntime](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_InvokeAgentRuntime.html "https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_InvokeAgentRuntime.html") API are passed
+through directly to the A2A container without modification. This architecture preserves
+the standard A2A protocol features like built-in agent discovery through Agent Cards at
+`/.well-known/agent-card.json` and JSON-RPC communication, while adding enterprise
+authentication (SigV4/OAuth 2.0) and scalability.
+
+The key differentiators from other protocols are the port (9000 vs 8080 for HTTP),
+mount path (`/` vs `/invocations`), and the standardized agent discovery mechanism, making
+Amazon Bedrock AgentCore an ideal deployment platform for A2A agents in production
+environments.
+
+Key differences from other
+protocols:
+
+**Port**
+:   A2A servers run on port 9000 (vs 8080 for HTTP, 8000 for MCP)
+
+**Path**
+:   A2A servers are mounted at `/` (vs
+    `/invocations` for HTTP, `/mcp` for
+    MCP)
+
+**Agent Cards**
+:   A2A provides built-in agent discovery through Agent Cards at
+    `/.well-known/agent-card.json`
+
+**Protocol**
+:   Uses JSON-RPC for agent-to-agent communication
+
+**Authentication**
+:   Supports both SigV4 and OAuth 2.0 authentication schemes
+
+For more information, see [https://a2a-protocol.org/](https://a2a-protocol.org/ "https://a2a-protocol.org/").
+
+## Using A2A with AgentCore Runtime
+
+In this tutorial you create, test, and deploy an A2A server.
+
+###### Topics
+
+* [Prerequisites](#runtime-a2a-prerequisites "#runtime-a2a-prerequisites")
+* [Step 1: Create your A2A server](#runtime-a2a-create-server "#runtime-a2a-create-server")
+* [Step 2: Test your A2A server locally](#runtime-a2a-test-locally "#runtime-a2a-test-locally")
+* [Step 3: Deploy your A2A server to Bedrock
+  AgentCore Runtime](#runtime-a2a-deploy "#runtime-a2a-deploy")
+* [Step 4: Get the agent card](#runtime-a2a-step-4 "#runtime-a2a-step-4")
+* [Step 5: Invoke your deployed A2A server](#runtime-a2a-step-5 "#runtime-a2a-step-5")
+
+### Prerequisites
+
+* Python 3.10 or higher installed and basic understanding of Python
+* An AWS account with appropriate permissions and local credentials
+  configured
+* Understanding of the A2A protocol and agent-to-agent communication
+  concepts
+
+### Step 1: Create your A2A server
+
+We are showing an example with strands, but you can use other ways to build with
+A2A.
+
+#### Install required packages
+
+First, install the required packages for A2A:
+
+```
+pip install strands-agents[a2a]  
+pip install bedrock-agentcore  
+pip install strands-agents-tools
+```
+
+#### Create your first A2A server
+
+Create a new file called `my_a2a_server.py`:
+
+```
+
+import logging  
+import os  
+from strands_tools.calculator import calculator  
+from strands import Agent  
+from strands.multiagent.a2a import A2AServer  
+import uvicorn  
+from fastapi import FastAPI  
+
+logging.basicConfig(level=logging.INFO)  
+
+# Use the complete runtime URL from environment variable, fallback to local  
+runtime_url = os.environ.get('AGENTCORE_RUNTIME_URL', 'http://127.0.0.1:9000/')  
+
+logging.info(f"Runtime URL: {runtime_url}")  
+
+strands_agent = Agent(  
+    name="Calculator Agent",  
+    description="A calculator agent that can perform basic arithmetic operations.",  
+    tools=[calculator],  
+    callback_handler=None  
+)  
+
+host, port = "0.0.0.0", 9000  
+
+# Pass runtime_url to http_url parameter AND use serve_at_root=True  
+a2a_server = A2AServer(  
+    agent=strands_agent,  
+    http_url=runtime_url,  
+    serve_at_root=True  # Serves locally at root (/) regardless of remote URL path complexity  
+)  
+
+app = FastAPI()  
+
+@app.get("/ping")  
+def ping():  
+    return {"status": "healthy"}  
+
+app.mount("/", a2a_server.to_fastapi_app())  
+
+if __name__ == "__main__":  
+    uvicorn.run(app, host=host, port=port)
+                
+```
+
+#### Understanding the code
+
+**Strands Agent**
+:   Creates an agent with specific tools and capabilities
+
+**A2AServer**
+:   Wraps the agent to provide A2A protocol compatibility
+
+**Agent Card URL**
+:   Dynamically constructs the correct URL based on deployment context
+    using the `AGENTCORE_RUNTIME_URL` environment
+    variable
+
+**Port 9000**
+:   A2A servers run on port 9000 by default in AgentCore Runtime
+
+### Step 2: Test your A2A server locally
+
+Run and test your A2A server in a local development environment.
+
+#### Start your A2A server
+
+Run your A2A server locally:
+
+```
+python my_a2a_server.py
+```
+
+You should see output indicating the server is running on port
+`9000`.
+
+#### Invoke agent
+
+```
+curl -X POST http://0.0.0.0:9000 \\
+-H "Content-Type: application/json" \\
+-d '{  
+  "jsonrpc": "2.0",  
+  "id": "req-001",  
+  "method": "message/send",  
+  "params": {  
+    "message": {  
+      "role": "user",  
+      "parts": [  
+        {  
+          "kind": "text",  
+          "text": "what is 101 * 11?"  
+        }  
+      ],  
+      "messageId": "12345678-1234-1234-1234-123456789012"  
+    }  
+  } 
+}' | jq . 
+```
+
+#### Test agent card retrieval
+
+You can test the agent card endpoint locally:
+
+```
+curl http://localhost:9000/.well-known/agent-card.json | jq .
+```
+
+You can also test your deployed server using the A2A Inspector as described in
+[Remote testing with A2A inspector](https://github.com/a2aproject/a2a-inspector "https://github.com/a2aproject/a2a-inspector").
+
+### Step 3: Deploy your A2A server to Bedrock AgentCore Runtime
+
+Deploy your A2A server to AWS using the Amazon Bedrock AgentCore starter toolkit.
+
+#### Install deployment tools
+
+Install the Amazon Bedrock AgentCore starter toolkit:
+
+```
+pip install bedrock-agentcore-starter-toolkit 
+```
+
+Start by creating a project folder with the following structure:
+
+```
+## Project Folder Structure  
+your_project_directory/  
+├── a2a_server.py          # Your main agent code  
+├── requirements.txt       # Dependencies for your agent
+```
+
+Create a new file called `requirements.txt`, add the
+following to it:
+
+```
+strands-agents[a2a]  
+bedrock-agentcore  
+strands-agents-tools 
+```
+
+#### Set up Cognito user pool for authentication
+
+Configure authentication for secure access to your deployed
+server. For detailed Cognito setup instructions, see [Set up Cognito user
+pool for authentication](./runtime-mcp.html#runtime-mcp-appendix-a "./runtime-mcp.html#runtime-mcp-appendix-a"). This provides the OAuth tokens required for
+secure access to your deployed server.
+
+#### Configure your A2A server for deployment
+
+After setting up authentication, create the deployment configuration:
+
+```
+agentcore configure -e my_a2a_server.py --protocol A2A
+```
+
+* Select protocol as A2A
+* Configure with OAuth configuration as setup in the previous
+  step
+
+#### Deploy to AWS
+
+Deploy your agent:
+
+```
+agentcore launch
+```
+
+After deployment, you'll receive an agent runtime ARN that looks like:
+
+```
+arn:aws:bedrock-agentcore:us-west-2:accountId:runtime/my_a2a_server-xyz123
+```
+
+### Step 4: Get the agent card
+
+Agent Cards are JSON metadata documents that describe an A2A server's identity, capabilities, skills, service endpoint, and authentication requirements. They enable automatic agent discovery in the A2A ecosystem.
+
+#### Set up environment variables
+
+Set up environment variables
+
+1. Export bearer token as an environment variable. For bearer token setup, see [Bearer token setup](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-mcp.html#runtime-mcp-appendix "https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-mcp.html#runtime-mcp-appendix").
+
+   ```
+   export BEARER_TOKEN="<BEARER_TOKEN>"
+   ```
+2. Export the agent ARN.
+
+   ```
+   export AGENT_ARN="arn:aws:bedrock-agentcore:us-west-2:accountId:runtime/my_a2a_server-xyz123"
+   ```
+
+#### Retrieve agent card
+
+```
+import os
+import json
+import requests
+from uuid import uuid4
+from urllib.parse import quote
+
+def fetch_agent_card():
+    # Get environment variables
+    agent_arn = os.environ.get('AGENT_ARN')
+    bearer_token = os.environ.get('BEARER_TOKEN')
+
+    if not agent_arn:
+        print("Error: AGENT_ARN environment variable not set")
+        return
+
+    if not bearer_token:
+        print("Error: BEARER_TOKEN environment variable not set")
+        return
+
+    # URL encode the agent ARN
+    escaped_agent_arn = quote(agent_arn, safe='')
+
+    # Construct the URL
+    url = f"https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/{escaped_agent_arn}/invocations/.well-known/agent-card.json"
+
+    # Generate a unique session ID
+    session_id = str(uuid4())
+    print(f"Generated session ID: {session_id}")
+
+    # Set headers
+    headers = {
+        'Accept': '*/*',
+        'Authorization': f'Bearer {bearer_token}',
+        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': session_id
+    }
+
+    try:
+        # Make the request
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+
+        # Parse and pretty print JSON
+        agent_card = response.json()
+        print(json.dumps(agent_card, indent=2))
+
+        return agent_card
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching agent card: {e}")
+        return None
+
+if __name__ == "__main__":
+    fetch_agent_card()
+```
+
+After you get the URL from the Agent Card, export `AGENTCORE_RUNTIME_URL` as an environment variable:
+
+```
+export AGENTCORE_RUNTIME_URL="https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/<ARN>/invocations/"
+```
+
+### Step 5: Invoke your deployed A2A server
+
+Create client code to invoke your deployed Amazon Bedrock AgentCore A2A server and send
+messages to test the functionality.
+
+Create a new file `my_a2a_client_remote.py` to invoke your deployed A2A server:
+
+```
+
+import asyncio
+import logging
+import os
+from uuid import uuid4
+
+import httpx
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.types import Message, Part, Role, TextPart
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 300  # set request timeout to 5 minutes
+
+def create_message(*, role: Role = Role.user, text: str) -> Message:
+    return Message(
+        kind="message",
+        role=role,
+        parts=[Part(TextPart(kind="text", text=text))],
+        message_id=uuid4().hex,
+    )
+
+async def send_sync_message(message: str):
+    # Get runtime URL from environment variable
+    runtime_url = os.environ.get('AGENTCORE_RUNTIME_URL')
+    
+    # Generate a unique session ID
+    session_id = str(uuid4())
+    print(f"Generated session ID: {session_id}")
+
+    # Add authentication headers for Amazon Bedrock AgentCore
+    headers = {"Authorization": f"Bearer {os.environ.get('BEARER_TOKEN')}",
+        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': session_id}
+        
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT, headers=headers) as httpx_client:
+        # Get agent card from the runtime URL
+        resolver = A2ACardResolver(httpx_client=httpx_client, base_url=runtime_url)
+        agent_card = await resolver.get_agent_card()
+
+        # Agent card contains the correct URL (same as runtime_url in this case)
+        # No manual override needed - this is the path-based mounting pattern
+
+        # Create client using factory
+        config = ClientConfig(
+            httpx_client=httpx_client,
+            streaming=False,  # Use non-streaming mode for sync response
+        )
+        factory = ClientFactory(config)
+        client = factory.create(agent_card)
+
+        # Create and send message
+        msg = create_message(text=message)
+
+        # With streaming=False, this will yield exactly one result
+        async for event in client.send_message(msg):
+            if isinstance(event, Message):
+                logger.info(event.model_dump_json(exclude_none=True, indent=2))
+                return event
+            elif isinstance(event, tuple) and len(event) == 2:
+                # (Task, UpdateEvent) tuple
+                task, update_event = event
+                logger.info(f"Task: {task.model_dump_json(exclude_none=True, indent=2)}")
+                if update_event:
+                    logger.info(f"Update: {update_event.model_dump_json(exclude_none=True, indent=2)}")
+                return task
+            else:
+                # Fallback for other response types
+                logger.info(f"Response: {str(event)}")
+                return event
+
+# Usage - Uses AGENTCORE_RUNTIME_URL environment variable
+asyncio.run(send_sync_message("what is 101 * 11"))
+    
+```
+
+## Appendix
+
+###### Topics
+
+* [Set up Cognito user pool for
+  authentication](#runtime-a2a-setup-cognito-appendix "#runtime-a2a-setup-cognito-appendix")
+* [Remote testing with A2A
+  inspector](#runtime-a2a-remote-testing "#runtime-a2a-remote-testing")
+* [Troubleshooting](#runtime-a2a-troubleshooting "#runtime-a2a-troubleshooting")
+
+### Set up Cognito user pool for authentication
+
+For detailed Cognito setup instructions, see Set up
+[Cognito user pool for authentication](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-mcp.html#set-up-cognito-user-pool-for-authentication "https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-mcp.html#set-up-cognito-user-pool-for-authentication")
+in the MCP documentation.
+
+### Remote testing with A2A inspector
+
+See [https://github.com/a2aproject/a2a-inspector](https://github.com/a2aproject/a2a-inspector "https://github.com/a2aproject/a2a-inspector").
+
+### Troubleshooting
+
+###### Common A2A-specific issues
+
+The following are common issues you might encounter:
+
+Port conflicts
+:   A2A servers must run on port 9000 in the AgentCore Runtime environment
+
+JSON-RPC errors
+:   Check that your client is sending properly formatted JSON-RPC 2.0
+    messages
+
+Authorization method mismatch
+:   Make sure your request uses the same authentication method (OAuth or
+    SigV4) that the agent was configured with
+
+###### Exception handling
+
+A2A specifications for Error handling: [https://a2a-protocol.org/latest/specification/#81-standard-json-rpc-errors](https://a2a-protocol.org/latest/specification/#81-standard-json-rpc-errors "https://a2a-protocol.org/latest/specification/#81-standard-json-rpc-errors")
+
+A2A servers return errors as standard JSON-RPC error responses with HTTP 200
+status codes. Internal Runtime errors are automatically translated to JSON-RPC
+internal errors to maintain protocol compliance.
+
+The service now provides proper A2A-compliant error responses with standardized
+JSON-RPC error codes:
+
+JSON-RPC Error Codes
+
+| JSON-RPC Error Code | Runtime Exception | HTTP Error Code | JSON-RPC Error Message |
+| --- | --- | --- | --- |
+| N/A | `AccessDeniedException` | 403 | N/A |
+| -32501 | `ResourceNotFoundException` | 404 | Resource not found – Requested resource does not exist |
+| -32502 | `ValidationException` | 400 | Validation error – Invalid request data |
+| -32503 | `ThrottlingException` | 429 | Rate limit exceeded – Too many requests |
+| -32503 | `ServiceQuotaExceededException` | 429 | Rate limit exceeded – Too many requests |
+| -32504 | `ResourceConflictException` | 409 | Resource conflict – Resource already exists |
+| -32505 | `RuntimeClientError` | 424 | Runtime client error – Check your CloudWatch logs for more information. |

--- a/documentation/docs/user-guide/security/agentcore-vpc.md
+++ b/documentation/docs/user-guide/security/agentcore-vpc.md
@@ -1,0 +1,433 @@
+# Configure Amazon Bedrock AgentCore Runtime and tools for VPC
+
+You can configure Amazon Bedrock AgentCore Runtime and built-in tools (Code Interpreter and Browser Tool) to connect to resources in your Amazon Virtual Private Cloud (VPC). By configuring VPC connectivity, you enable secure access to private resources such as databases, internal APIs, and services within your VPC.
+
+## VPC connectivity for Amazon Bedrock AgentCore Runtime and tools
+
+To enable Amazon Bedrock AgentCore Runtime and built-in tools to securely access resources in your private VPC, Amazon Bedrock AgentCore provides VPC connectivity capabilities. This feature allows your runtime and tools to:
+
+* Connect to private resources without exposing them to the internet
+* Maintain secure communications within your organization's network boundaries
+* Access enterprise data stores and internal services while preserving security
+
+When you configure VPC connectivity for Amazon Bedrock AgentCore Runtime and tools:
+
+* Amazon Bedrock creates elastic network interfaces (ENIs) in your VPC using the service-linked role
+  `AWSServiceRoleForBedrockAgentCoreNetwork`
+* These ENIs enable your Amazon Bedrock AgentCore Runtime and tools to securely communicate with resources in your VPC
+* Each ENI is assigned a private IP address from the subnets you specify
+* Security groups attached to the ENIs control which resources your runtime and tools can communicate with
+
+###### Note
+
+VPC connectivity impacts only outbound network traffic from the runtime or tool. Inbound
+requests to the runtime (such as invocations) are not routed through the VPC and are unaffected
+by this configuration.
+
+## Prerequisites
+
+Before configuring Amazon Bedrock AgentCore Runtime and tools for VPC access, ensure you have:
+
+* An Amazon VPC with appropriate subnets for your runtime and tool requirements. For example, to configure your subnets to have internet access, see [Internet access considerations](#agentcore-internet-access "#agentcore-internet-access").
+* Subnets located in supported Availability Zones for your region. For information about supported Availability Zones, see [Supported Availability Zones](#agentcore-supported-azs "#agentcore-supported-azs").
+* Appropriate security groups defined in your VPC for runtime and tool access patterns. For example, to configure your security groups to connect to Amazon RDS, see [Example: Connecting to an Amazon RDS database](#agentcore-security-groups-example "#agentcore-security-groups-example").
+* Required IAM permissions to create and manage the service-linked role (already included in the
+  AWS managed policy [BedrockAgentCoreFullAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/BedrockAgentCoreFullAccess.html "https://docs.aws.amazon.com/aws-managed-policy/latest/reference/BedrockAgentCoreFullAccess.html")). For information about required permissions, see [IAM permissions](#agentcore-iam-permissions "#agentcore-iam-permissions").
+* Required VPC endpoints if your VPC doesn't have internet access. For example, to configure your VPC endpoints, see [VPC endpoint configuration](#agentcore-vpc-endpoints "#agentcore-vpc-endpoints").
+* Understanding of your runtime and tool network requirements (databases, APIs, web resources). If you need to use Browser tool which requires internet access, then your VPC should have internet access through
+  NAT Gateway. For example, see [Security group considerations](#agentcore-security-groups "#agentcore-security-groups").
+
+###### Important
+
+Amazon Bedrock AgentCore creates a network interface in your account with a private IP address. Using a public subnet does not provide internet connectivity.
+To enable internet access, place it in private subnets with a route to a NAT Gateway.
+
+## Supported Availability Zones
+
+Amazon Bedrock AgentCore supports VPC connectivity in specific Availability Zones within each supported region. When configuring subnets for your Amazon Bedrock AgentCore Runtime and built-in tools, ensure that your subnets are located in the supported Availability Zones for your region.
+
+The following table shows the supported Availability Zone IDs for each region:
+
+| Region | Region Code | Supported Availability Zones |
+| --- | --- | --- |
+| US East (N. Virginia) | us-east-1 | * use1-az1 * use1-az2 * use1-az4 |
+| US East (Ohio) | us-east-2 | * use2-az1 * use2-az2 * use2-az3 |
+| US West (Oregon) | us-west-2 | * usw2-az1 * usw2-az2 * usw2-az3 |
+| Asia Pacific (Sydney) | ap-southeast-2 | * apse2-az1 * apse2-az2 * apse2-az3 |
+| Asia Pacific (Mumbai) | ap-south-1 | * aps1-az1 * aps1-az2 * aps1-az3 |
+| Asia Pacific (Singapore) | ap-southeast-1 | * apse1-az1 * apse1-az2 * apse1-az3 |
+| Asia Pacific (Tokyo) | ap-northeast-1 | * apne1-az1 * apne1-az2 * apne1-az4 |
+| Europe (Ireland) | eu-west-1 | * euw1-az1 * euw1-az2 * euw1-az3 |
+| Europe (Frankfurt) | eu-central-1 | * euc1-az1 * euc1-az2 * euc1-az3 |
+
+###### Important
+
+Subnets must be located in the supported Availability Zones listed above. If you specify subnets in unsupported Availability Zones, the configuration will fail during resource creation.
+
+To identify the Availability Zone ID of your subnets, you can use the following CLI command:
+
+```
+aws ec2 describe-subnets --subnet-ids subnet-12345678 --query 'Subnets[0].AvailabilityZoneId'
+```
+
+## IAM permissions
+
+Amazon Bedrock AgentCore uses the service-linked role `AWSServiceRoleForBedrockAgentCoreNetwork`
+to create and manage network interfaces in your VPC. This role is automatically created when you first
+configure Amazon Bedrock AgentCore Runtime or AgentCore built-in tools to use VPC connectivity.
+
+If you need to create this role manually, your IAM entity needs the following permissions:
+
+```
+{
+    "Action": "iam:CreateServiceLinkedRole",
+    "Effect": "Allow",
+    "Resource": "arn:aws:iam::*:role/aws-service-role/network.bedrock-agentcore.amazonaws.com/AWSServiceRoleForBedrockAgentCoreNetwork",
+    "Condition": {
+        "StringLike": {
+            "iam:AWSServiceName": "network.bedrock-agentcore.amazonaws.com"
+        }
+    }
+}
+```
+
+This permission is already included in the AWS managed policy
+[BedrockAgentCoreFullAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/BedrockAgentCoreFullAccess.html "https://docs.aws.amazon.com/aws-managed-policy/latest/reference/BedrockAgentCoreFullAccess.html").
+
+## Best practices
+
+For optimal performance and security with VPC-connected Amazon Bedrock AgentCore Runtime and built-in tools:
+
+* **High Availability**:
+
+  + Configure at least two private subnets in different Availability Zones. For a list of supported Availability
+    Zones, see [Supported Availability Zones](#agentcore-supported-azs "#agentcore-supported-azs").
+  + Deploy dependent resources (such as databases or caches) with multi-AZ support to avoid single points of failure.
+* **Network Performance**:
+
+  + Place Amazon Bedrock AgentCore Runtime or built-in tools subnets in the same Availability Zones as the resources they connect to. This reduces cross-AZ latency and data transfer costs.
+  + Use VPC endpoints for AWS services whenever possible. Endpoints provide lower latency, higher reliability, and avoid NAT gateway charges for supported services.
+* **Security**:
+
+  + Apply the principle of least privilege when creating security group rules.
+  + Enable VPC Flow Logs for auditing and monitoring. Review logs regularly to identify unexpected traffic patterns.
+* **Internet Access**:
+
+  + To provide internet access from Amazon Bedrock AgentCore Runtime or built-in tools inside a VPC, configure a NAT gateway in a public subnet. Update the route table for private subnets to send outbound traffic (0.0.0.0/0) to the NAT gateway.
+  + We recommend using VPC endpoints for AWS services instead of internet routing to improve security and reduce costs.
+
+## Configuring VPC access for runtime and tools
+
+You can configure VPC access for Amazon Bedrock AgentCore Runtime and built-in tools using the AWS Management Console, AWS CLI, or AWS SDKs.
+
+### Runtime configuration
+
+AWS Management Console
+:   1. Open the AgentCore console at [https://console.aws.amazon.com/bedrock-agentcore/home#](https://console.aws.amazon.com/bedrock-agentcore/home# "https://console.aws.amazon.com/bedrock-agentcore/home#").
+    2. Navigate to the AgentCore section
+    3. Select or create an Amazon Bedrock AgentCore Runtime configuration
+    4. Choose your ECR image
+    5. Under the Network configuration section, choose **VPC**
+    6. Select your VPC from the dropdown list
+    7. Select the appropriate subnets for your application needs
+    8. Select one or more security groups to apply to the ENIs
+    9. Save your configuration
+
+AWS CLI
+:   ```
+    aws bedrock-agentcore create-runtime \
+      --runtime-name "MyAgentRuntime" \
+      --network-configuration '{
+          "networkMode": "VPC",
+          "networkModeConfig": {
+            "subnets": ["subnet-0123456789abcdef0", "subnet-0123456789abcdef1"],
+            "securityGroups": ["sg-0123456789abcdef0"]
+          }
+        }'
+    ```
+
+AWS SDK (Python)
+:   ```
+    import boto3
+
+    client = boto3.client('bedrock-agentcore')
+
+    response = client.create_runtime(
+        runtimeName='MyAgentRuntime',
+        networkConfiguration={
+            'networkMode': 'VPC',
+            'networkModeConfig': {
+                'subnets': ['subnet-0123456789abcdef0', 'subnet-0123456789abcdef1'],
+                'securityGroups': ['sg-0123456789abcdef0']
+            }
+        }
+    )
+    ```
+
+### Code Interpreter configuration
+
+AWS Management Console
+:   1. Open the AgentCore console at [https://console.aws.amazon.com/bedrock-agentcore/home#](https://console.aws.amazon.com/bedrock-agentcore/home# "https://console.aws.amazon.com/bedrock-agentcore/home#").
+    2. Navigate to AgentCore → Built-in Tools → Code Interpreter
+    3. Select **Create Code Interpreter** or modify existing configuration
+    4. Provide a tool name (optional)
+    5. Configure execution role with necessary permissions
+    6. Under Network configuration, choose **VPC**
+    7. Select your VPC from the dropdown
+    8. Choose appropriate subnets (recommend private subnets across multiple AZs with NAT gateway)
+    9. Select security groups for ENI access control
+    10. Configure execution role with necessary permissions
+    11. Save your configuration
+
+AWS CLI
+:   ```
+    aws bedrock-agentcore-control create-code-interpreter \
+      --region <Region> \
+      --name "my-code-interpreter" \
+      --description "My Code Interpreter with VPC mode for data analysis" \
+      --execution-role-arn "arn:aws:iam::123456789012:role/my-execution-role" \
+      --network-configuration '{
+        "networkMode": "VPC",
+        "networkModeConfig": {
+          "subnets": ["subnet-0123456789abcdef0", "subnet-0123456789abcdef1"],
+          "securityGroups": ["sg-0123456789abcdef0"]
+        }
+      }'
+    ```
+
+AWS SDK (Python)
+:   ```
+    import boto3
+
+    # Initialize the boto3 client
+    cp_client = boto3.client(
+        'bedrock-agentcore-control', 
+        region_name="<Region>",
+        endpoint_url="https://bedrock-agentcore-control.<Region>.amazonaws.com"
+    )
+
+    # Create a Code Interpreter
+    response = cp_client.create_code_interpreter(
+        name="myTestVpcCodeInterpreter",
+        description="Test code sandbox for development",
+        executionRoleArn="arn:aws:iam::123456789012:role/my-execution-role",
+        networkConfiguration={
+            'networkMode': 'VPC',
+            'networkModeConfig': {
+                'subnets': ['subnet-0123456789abcdef0', 'subnet-0123456789abcdef1'],
+                'securityGroups': ['sg-0123456789abcdef0']
+            }
+        }
+    )
+
+    # Print the Code Interpreter ID
+    code_interpreter_id = response["codeInterpreterId"]
+    print(f"Code Interpreter ID: {code_interpreter_id}")
+    ```
+
+### Browser Tool configuration
+
+AWS Management Console
+:   1. Open the AgentCore console at [https://console.aws.amazon.com/bedrock-agentcore/home#](https://console.aws.amazon.com/bedrock-agentcore/home# "https://console.aws.amazon.com/bedrock-agentcore/home#").
+    2. In the navigation pane, choose **Built-in tools**
+    3. Choose **Create Browser tool**
+    4. Provide a tool name (optional) and description (optional)
+    5. Set execution role permissions
+    6. Under the Network configuration section, choose **VPC** mode
+    7. Select your VPC and subnets
+    8. Configure security groups for web access requirements
+    9. Set execution role permissions
+    10. Save your configuration
+
+AWS CLI
+:   ```
+    aws bedrock-agentcore-control create-browser \
+      --region <Region> \
+      --name "my-browser" \
+      --description "My browser for web interaction" \
+      --network-configuration '{
+        "networkMode": "VPC",
+        "networkModeConfig": {
+          "subnets": ["subnet-0123456789abcdef0", "subnet-0123456789abcdef1"],
+          "securityGroups": ["sg-0123456789abcdef0"]
+        }
+      }' \
+      --recording '{ 
+        "enabled": true, 
+        "s3Location": { 
+          "bucket": "my-bucket-name", 
+          "prefix": "sessionreplay" 
+        } 
+      }' \
+      --execution-role-arn "arn:aws:iam::123456789012:role/my-execution-role"
+    ```
+
+AWS SDK (Python)
+:   ```
+    import boto3
+
+    # Initialize the boto3 client
+    cp_client = boto3.client(
+        'bedrock-agentcore-control', 
+        region_name="<Region>",
+        endpoint_url="https://bedrock-agentcore-control.<Region>.amazonaws.com"
+    )
+
+    # Create a Browser
+    response = cp_client.create_browser(
+        name="myTestVpcBrowser",
+        description="Test browser with VPC mode for development",
+        networkConfiguration={
+            'networkMode': 'VPC',
+            'networkModeConfig': {
+                'subnets': ['subnet-0123456789abcdef0', 'subnet-0123456789abcdef1'],
+                'securityGroups': ['sg-0123456789abcdef0']
+            }
+        },
+        executionRoleArn="arn:aws:iam::123456789012:role/Sessionreplay",
+        recording={
+            "enabled": True,
+            "s3Location": {
+                "bucket": "session-record-123456789012",
+                "prefix": "replay-data"
+            } 
+        }
+    )
+    ```
+
+## Security group considerations
+
+Security groups act as virtual firewalls for your Amazon Bedrock AgentCore Runtime or built-in tool when connected to a VPC. They control inbound and outbound traffic at the instance level. To configure security groups for your runtime:
+
+* **Outbound rules** – Define outbound rules to allow your Amazon Bedrock AgentCore Runtime to connect to required VPC resources.
+* **Inbound rules** – Ensure that the target resource's security group allows inbound connections from the security group associated with your Amazon Bedrock AgentCore Runtime.
+* **Least privilege** – Apply the principle of least privilege by allowing only the minimum required traffic.
+
+### Example: Connecting to an Amazon RDS database
+
+When your Amazon Bedrock AgentCore Runtime connects to an Amazon RDS database, configure the security groups as follows:
+
+###### Amazon Bedrock AgentCore Runtime security group
+
+* **Outbound** – Allow TCP traffic to the RDS database's security group on port 3306 (MySQL).
+* **Inbound** – Not required. The runtime only initiates outbound connections.
+
+###### Amazon RDS database security group
+
+* **Inbound** – Allow TCP traffic from the Amazon Bedrock AgentCore Runtime security group on port 3306.
+* **Outbound** – Not required. Return traffic is automatically allowed because security groups are stateful.
+
+## VPC endpoint configuration
+
+When running Amazon Bedrock AgentCore Runtime in a private VPC without internet access, you must configure
+the following VPC endpoints to ensure proper functionality:
+
+### Required VPC endpoints
+
+* **Amazon ECR Requirements**:
+
+  + Docker endpoint: `com.amazonaws.region.ecr.dkr`
+  + ECR API endpoint: `com.amazonaws.region.ecr.api`
+* **Amazon S3 Requirements**:
+
+  + Gateway endpoint for ECR docker layer storage: `com.amazonaws.region.s3`
+* **CloudWatch Requirements**:
+
+  + Logs endpoint: `com.amazonaws.region.logs`
+
+###### Note
+
+Be sure to replace `region` with your specific region if different.
+
+### Internet access considerations
+
+When you connect Amazon Bedrock AgentCore Runtime or a built-in tool to a Virtual Private Cloud (VPC), it does not have internet access by default. By default, these resources can communicate only with resources inside the same VPC. If your runtime or tool requires access to both VPC resources and the internet, you must configure your VPC accordingly.
+
+#### Internet access architecture
+
+To enable internet access for your VPC-connected Amazon Bedrock AgentCore Runtime or built-in tool, configure your VPC with the following components:
+
+* **Private subnets** – Place the Amazon Bedrock AgentCore Runtime or tool's network interfaces in private subnets.
+* **Public subnets with a NAT gateway** – Deploy a NAT gateway in one or more public subnets to provide outbound internet access for private resources.
+* **Internet gateway (IGW)** – Attach an internet gateway to your VPC to enable communication between the NAT gateway and the internet.
+
+#### Routing configuration
+
+Update your subnet route tables as follows:
+
+* **Private subnet route table** – Add a default route (0.0.0.0/0) that points to the NAT gateway. This allows outbound traffic from the runtime or tool to reach the internet.
+* **Public subnet route table** – Add a default route (0.0.0.0/0) that points to the internet gateway. This allows the NAT gateway to communicate with the internet.
+
+###### Important
+
+Connecting Amazon Bedrock AgentCore Runtime and built-in tools to public subnets does not provide internet access.
+Always use private subnets with NAT gateways for internet connectivity.
+
+## Monitoring and troubleshooting
+
+To monitor and troubleshoot your VPC-connected Amazon Bedrock AgentCore Runtime and tools:
+
+### CloudWatch Logs
+
+Enable CloudWatch Logs for your Amazon Bedrock AgentCore Runtime to identify any connectivity issues:
+
+* Check error messages related to VPC connectivity
+* Look for timeout errors when connecting to VPC resources
+* Monitor initialization times (VPC connectivity may increase session startup times)
+
+### Common issues and solutions
+
+* **Connection timeouts**:
+
+  + Verify security group rules are correct
+  + Ensure route tables are properly configured
+  + Check that the target resource is running and accepting connections
+* **DNS resolution failures**:
+
+  + Ensure that DNS resolution is enabled in your VPC
+  + Verify that your DHCP options are configured correctly
+* **Missing ENIs**:
+
+  + Check the IAM permissions to ensure the service-linked role has appropriate permissions
+  + Look for any service quotas that may have been reached
+
+### Code Interpreter issues
+
+* **Code Interpreter invoke call timeouts when trying to call a public endpoint**:
+
+  + Verify that VPC is configured with NAT gateway for internet access
+* **Invoke calls for a Code Interpreter with private VPC endpoints throw "AccessDenied" errors**:
+
+  + Make sure the execution role passed during Code Interpreter creation has the right permissions for AWS service for which VPC endpoint was configured
+* **Invoke calls for a Code Interpreter with some private VPC endpoints show "Unable to locate Credentials" error**:
+
+  + Check that the execution role has been provided while creating the code interpreter
+
+### Browser Tool issues
+
+* **Live-View/Connection Stream is unable to load webpages and fails with connection timeouts**:
+
+  + Check if the browser was created with Private Subnet with NAT Gateway
+
+### Testing VPC connectivity
+
+To verify that your Amazon Bedrock AgentCore Runtime and tools have proper VPC connectivity, you can test connections to your private resources and verify that network interfaces are created correctly in your specified subnets.
+
+To verify that your Amazon Bedrock AgentCore tool has internet access, you can configure a Code Interpreter with your VPC configuration and use the `Invoke` API with `executeCommand` that attempts to connect to a public API or website using `curl` command and check the response. If the connection times out, review your VPC configuration, particularly your route tables and NAT gateway setup.
+
+```
+# Using awscurl
+awscurl -X POST \
+  "https://bedrock-agentcore.<Region>.amazonaws.com/code-interpreters/<code_interpreter_id>/tools/invoke" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "x-amzn-code-interpreter-session-id: your-session-id" \
+  --service bedrock-agentcore \
+  --region <Region> \
+  -d '{ 
+    "name": "executeCommand", 
+    "arguments": { 
+      "command": "curl amazon.com" 
+    } 
+  }'
+```

--- a/documentation/docs/user-guide/security/security-vpc-condition.md
+++ b/documentation/docs/user-guide/security/security-vpc-condition.md
@@ -1,0 +1,153 @@
+# Use IAM condition keys with AgentCore Runtime and built-in tools VPC settings
+
+You can use Amazon Bedrock AgentCore-specific condition keys for VPC settings to
+provide additional permission controls for your AgentCore Runtime and
+built-in tools. For example, you can require that all runtimes in your organization are connected
+to a VPC. You can also specify the subnets and security groups that users of the AgentCore Runtime can and
+can't use.
+
+AgentCore supports the following condition keys in IAM
+policies:
+
+* **bedrock-agentcore:subnets** – Allow or deny one or more
+  subnets.
+* **bedrock-agentcore:securityGroups** – Allow or deny one or
+  more security groups.
+
+The AgentCore Control Plane API operations
+`CreateAgentRuntime`, `UpdateAgentRuntime`,
+`CreateCodeInterpreter`, and `CreateBrowser` support these condition keys.
+For more information about using condition keys in IAM policies, see [IAM JSON Policy Elements: Condition](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html") in the IAM User Guide.
+
+## Example policies with condition keys for VPC settings
+
+The following examples demonstrate how to use condition keys for VPC settings. After you
+create a policy statement with the desired restrictions, attach the policy statement to the
+target user or role.
+
+### Require that users deploy only VPC-connected runtimes and tools
+
+To require that all users deploy only VPC-connected AgentCore Runtime and built-in tools, you can
+deny runtime and tool create and update operations that don't include valid subnets and
+security groups.
+
+```
+{
+  "Version": "2012-10-17"		 	 	 ,
+  "Statement": [
+    {
+      "Sid": "EnforceVPCRuntime",
+      "Action": [
+        "bedrock-agentcore:CreateAgentRuntime",
+        "bedrock-agentcore:UpdateAgentRuntime",
+        "bedrock-agentcore:CreateCodeInterpreter",
+        "bedrock-agentcore:CreateBrowser"
+      ],
+      "Effect": "Deny",
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "bedrock-agentcore:Subnets": "true",
+          "bedrock-agentcore:SecurityGroups": "true"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Deny users access to specific subnets or security groups
+
+To deny users access to specific subnets, use `StringEquals` to check the value
+of the `bedrock-agentcore:subnets` condition. The following example denies users
+access to `subnet-1` and `subnet-2`.
+
+```
+{
+  "Sid": "EnforceOutOfSubnet",
+  "Action": [
+    "bedrock-agentcore:CreateAgentRuntime",
+    "bedrock-agentcore:UpdateAgentRuntime",
+    "bedrock-agentcore:CreateCodeInterpreter",
+    "bedrock-agentcore:CreateBrowser"
+  ],
+  "Effect": "Deny",
+  "Resource": "*",
+  "Condition": {
+    "ForAnyValue:StringEquals": {
+      "bedrock-agentcore:subnets": ["subnet-1", "subnet-2"]
+    }
+  }
+}
+```
+
+To deny users access to specific security groups, use `StringEquals` to check
+the value of the `bedrock-agentcore:securityGroups` condition. The following example
+denies users access to `sg-1` and `sg-2`.
+
+```
+{
+  "Sid": "EnforceOutOfSecurityGroups",
+  "Action": [
+    "bedrock-agentcore:CreateAgentRuntime",
+    "bedrock-agentcore:UpdateAgentRuntime",
+    "bedrock-agentcore:CreateCodeInterpreter",
+    "bedrock-agentcore:CreateBrowser"
+  ],
+  "Effect": "Deny",
+  "Resource": "*",
+  "Condition": {
+    "ForAnyValue:StringEquals": {
+      "bedrock-agentcore:securityGroups": ["sg-1", "sg-2"]
+    }
+  }
+}
+```
+
+### Allow users to create and update AgentCore Runtimes and tools with specific VPC settings
+
+To allow users to access specific subnets, use `StringEquals` to check the
+value of the `bedrock-agentcore:subnets` condition. The following example allows
+users to access `subnet-1` and `subnet-2`.
+
+```
+{
+  "Sid": "EnforceStayInSpecificSubnets",
+  "Action": [
+    "bedrock-agentcore:CreateAgentRuntime",
+    "bedrock-agentcore:UpdateAgentRuntime",
+    "bedrock-agentcore:CreateCodeInterpreter",
+    "bedrock-agentcore:CreateBrowser"
+  ],
+  "Effect": "Allow",
+  "Resource": "*",
+  "Condition": {
+    "ForAllValues:StringEquals": {
+      "bedrock-agentcore:subnets": ["subnet-1", "subnet-2"]
+    }
+  }
+}
+```
+
+To allow users to access specific security groups, use `StringEquals` to check
+the value of the `bedrock-agentcore:SecurityGroups` condition. The following example
+allows users to access `sg-1` and `sg-2`.
+
+```
+{
+  "Sid": "EnforceStayInSpecificSecurityGroups",
+  "Action": [
+    "bedrock-agentcore:CreateAgentRuntime",
+    "bedrock-agentcore:UpdateAgentRuntime",
+    "bedrock-agentcore:CreateCodeInterpreter",
+    "bedrock-agentcore:CreateBrowser"
+  ],
+  "Effect": "Allow",
+  "Resource": "*",
+  "Condition": {
+    "ForAllValues:StringEquals": {
+      "bedrock-agentcore:SecurityGroups": ["sg-1", "sg-2"]
+    }
+  }
+}
+```

--- a/documentation/docs/user-guide/security/vpc-interface-endpoints.md
+++ b/documentation/docs/user-guide/security/vpc-interface-endpoints.md
@@ -1,0 +1,311 @@
+# Use interface VPC endpoints (AWS PrivateLink) to create a private connection between your VPC and your AgentCore resources
+
+You can use AWS PrivateLink to create a private connection between your VPC and
+Amazon Bedrock AgentCore. You can access AgentCore as if it were in your VPC, without the use of an
+internet gateway, NAT device, VPN connection, or AWS Direct Connect connection. Instances in your VPC
+don't need public IP addresses to access AgentCore.
+
+You establish this private connection by creating an *interface
+endpoint*, powered by AWS PrivateLink. We create an endpoint network interface
+in each subnet that you enable for the interface endpoint. These are requester-managed
+network interfaces that serve as the entry point for traffic destined for AgentCore.
+
+For more information, see [Access AWS services
+through AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-access-aws-services.html "https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-access-aws-services.html") in the
+*AWS PrivateLink Guide*.
+
+## Considerations for AgentCore
+
+Before you set up an interface endpoint for AgentCore, review [Considerations](https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html#considerations-interface-endpoints "https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html#considerations-interface-endpoints") in the *AWS PrivateLink Guide*.
+
+AgentCore supports the following through interface endpoints:
+
+* Data plane operations (runtime APIs)
+* Invoking gateways
+
+###### Note
+
+AWS PrivateLink is currently not supported for Amazon Bedrock AgentCore control plane endpoints.
+
+AgentCore interface endpoints are available in the following AWS Regions:
+
+* US East (N. Virginia)
+* US West (Oregon)
+* Europe (Frankfurt)
+* Asia Pacific (Sydney)
+
+###### Authorization considerations for data plane APIs
+
+The data plane APIs support both AWS Signature Version 4 (SigV4) headers for
+authentication and Bearer Token (OAuth) authentication. VPC endpoint policies can
+only restrict callers based on IAM principals and not OAuth users. For OAuth-based
+requests to succeed through the VPC endpoint, the principal must be set to
+`*` in the endpoint policy. Otherwise, only SigV4 allowlisted callers
+can make successful calls over the VPC endpoint.
+
+AWS IAM global condition context keys are supported. By default, full access to
+AgentCore is allowed through the interface endpoint. You can control access by attaching
+an endpoint policy to the interface endpoint or by associating a security group with the
+endpoint network interfaces.
+
+## Create an interface endpoint for AgentCore
+
+You can create an interface endpoint for AgentCore using either the Amazon VPC console or
+the AWS Command Line Interface (AWS CLI). For more information, see [Create an interface endpoint](https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html#create-interface-endpoint-aws "https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html#create-interface-endpoint-aws") in the
+*AWS PrivateLink Guide*.
+
+Create an interface endpoint for AgentCore using the following service name
+format:
+
+* Data plane operations:
+  `com.amazonaws.region.bedrock-agentcore`
+* For AgentCore Gateway:
+  `com.amazonaws.region.bedrock-agentcore.gateway`
+
+If you enable private DNS for the interface endpoint, you can make API requests to
+AgentCore using its default Regional DNS name. For example,
+`bedrock-agentcore.us-east-1.amazonaws.com`.
+
+## Create an endpoint policy for your interface endpoint
+
+An endpoint policy is an IAM resource that you can attach to an interface endpoint.
+The default endpoint policy allows full access to AgentCore through the interface
+endpoint. To control the access allowed to AgentCore from your VPC, attach a custom
+endpoint policy to the interface endpoint.
+
+An endpoint policy specifies the following information:
+
+* The principals that can perform actions (AWS accounts, IAM users, and
+  IAM roles).
+
+  + For AgentCore Gateway, if your gateway ingress isn't [AWS
+    Signature Version 4 (SigV4)](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html "https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html")-based (for example, if you use
+    OAuth instead), you must specify the `Principal` field as the
+    wildcard `*`. SigV4 -based authentication allows you to
+    define the `Principal` as a specific AWS identity.
+* The actions that can be performed.
+* The resources on which the actions can be performed.
+
+For more information, see [Control access to services using endpoint policies](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-access.html "https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-access.html") in the
+*AWS PrivateLink Guide*.
+
+###### Endpoint policies for various primitives
+
+The following examples show endpoint policies for different AgentCore components:
+
+Runtime
+:   The following endpoint policy allows specific IAM principals to invoke agent runtime resources.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": {
+                "AWS": "arn:aws::iam::ACCOUNT_ID:user/USERNAME"
+             },
+             "Action": [
+                "bedrock-agentcore:InvokeAgentRuntime"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1:ACCOUNT_ID:runtime/RUNTIME_ID"
+          }
+       ]
+    }
+    ```
+
+    ###### Mixed IAM and OAuth authentication
+
+    The `InvokeAgentRuntime` API supports two modes of VPC endpoint authorization. The following example policy allows both IAM principals and OAuth callers to access different agent runtime resources.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": {
+                "AWS": "arn:aws::iam::ACCOUNT_ID:root"
+             },
+             "Action": [
+                "bedrock-agentcore:InvokeAgentRuntime"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1:ACCOUNT_ID:runtime/customAgent1"
+          },
+          {
+             "Effect": "Allow",
+             "Principal": "*",
+             "Action": [
+                "bedrock-agentcore:InvokeAgentRuntime"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1:ACCOUNT_ID:runtime/customAgent2"
+          }
+       ]
+    }
+    ```
+
+    The above policy allows only the IAM principal to make `InvokeAgentRuntime` calls to `customAgent1`. It also allows both IAM principals and OAuth callers to make `InvokeAgentRuntime` calls to `customAgent2`.
+
+Code Interpreter
+:   The following endpoint policy allows specific IAM principals to invoke Code Interpreter resources.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": {
+                "AWS": "arn:aws::iam::ACCOUNT_ID:root"
+             },
+             "Action": [
+                "bedrock-agentcore:InvokeCodeInterpreter"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1:ACCOUNT_ID:code-interpreter/CODE_INTERPRETER_ID"
+          }
+       ]
+    }
+    ```
+
+Memory
+:   ###### All data plane operations
+
+    The following endpoint policy allows specific IAM principals to access us-east-1 data plane operations
+    for a specific AgentCore Memory.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": {
+                "AWS": "arn:aws::iam::ACCOUNT_ID:root"
+             },
+             "Action": [
+                "bedrock-agentcore:CreateEvent",
+                "bedrock-agentcore:DeleteEvent",
+                "bedrock-agentcore:GetEvent",
+                "bedrock-agentcore:ListEvents",
+                "bedrock-agentcore:DeleteMemoryRecord",
+                "bedrock-agentcore:GetMemoryRecord",
+                "bedrock-agentcore:ListMemoryRecords",
+                "bedrock-agentcore:RetrieveMemoryRecords",
+                "bedrock-agentcore:ListActors",
+                "bedrock-agentcore:ListSessions",
+                "bedrock-agentcore:BatchCreateMemoryRecords",
+                "bedrock-agentcore:BatchDeleteMemoryRecords",
+                "bedrock-agentcore:BatchUpdateMemoryRecords"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1:ACCOUNT_ID:memory/MEMORY_ID"
+          }
+       ]
+    }
+    ```
+
+    ###### Access to all memories
+
+    The following endpoint policy allows specific IAM principals access to all memories.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": {
+                "AWS": "arn:aws::iam::ACCOUNT_ID:root"
+             },
+             "Action": [
+                "bedrock-agentcore:CreateEvent",
+                "bedrock-agentcore:DeleteEvent",
+                "bedrock-agentcore:GetEvent",
+                "bedrock-agentcore:ListEvents",
+                "bedrock-agentcore:DeleteMemoryRecord",
+                "bedrock-agentcore:GetMemoryRecord",
+                "bedrock-agentcore:ListMemoryRecords",
+                "bedrock-agentcore:RetrieveMemoryRecords",
+                "bedrock-agentcore:ListActors",
+                "bedrock-agentcore:ListSessions",
+                "bedrock-agentcore:BatchCreateMemoryRecords",
+                "bedrock-agentcore:BatchDeleteMemoryRecords",
+                "bedrock-agentcore:BatchUpdateMemoryRecords"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1:ACCOUNT_ID:memory/*"
+          }
+       ]
+    }
+    ```
+
+    ###### Access restriction by APIs
+
+    The following endpoint policy grants permission for a specific IAM principal to create events in a
+    specific AgentCore Memory resource.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": {
+                "AWS": "arn:aws::iam::ACCOUNT_ID:root"
+             },
+             "Action": [
+                "bedrock-agentcore:CreateEvent"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1:ACCOUNT_ID:memory/MEMORY_ID"
+          }
+       ]
+    }
+    ```
+
+Browser Tool
+:   The following endpoint policy allows specific IAM principals to connect to Browser Tool resources.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": {
+                "AWS": "arn:aws::iam::ACCOUNT_ID:root"
+             },
+             "Action": [
+                "bedrock-agentcore:ConnectBrowserAutomationStream"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1:ACCOUNT_ID:browser/BROWSER_ID"
+          }
+       ]
+    }
+    ```
+
+Gateway
+:   The following is an example of a custom endpoint policy. When you attach this policy to your interface endpoint, it allows all principals to invoke the gateway specified in the `Resource` field.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": "*",
+             "Action": [
+                "bedrock:InvokeGateway"
+             ],
+             "Resource": "arn:aws::bedrock-agentcore:us-east-1::gateway/my-gateway"
+          }
+       ]
+    }
+    ```
+
+Identity
+:   The following endpoint policy allows access to Identity resources.
+
+    ```
+    {
+       "Statement": [
+          {
+             "Effect": "Allow",
+             "Principal": "*",
+             "Action": [
+                "*"
+             ],
+             "Resource": "arn:aws:bedrock-agentcore:us-east-1:ACCOUNT_ID:workload-identity-directory/default/workload-identity/WORKLOAD_IDENTITY_ID"
+          }
+       ]
+    }
+    ```

--- a/documentation/mkdocs.yaml
+++ b/documentation/mkdocs.yaml
@@ -77,6 +77,7 @@ nav:
       - Runtime Permissions: user-guide/runtime/permissions.md
       - Runtime Async Processing: user-guide/runtime/async.md
       - Runtime Notebook: user-guide/runtime/notebook.md
+      - Runtime A2A Server Deployment: user-guide/runtime/a2a.md
     - Gateway:
       - Gateway Quickstart: user-guide/gateway/quickstart.md
     - Memory:
@@ -86,6 +87,10 @@ nav:
     - Built-in Tools:
       - Quickstart Browser Tool: user-guide/builtin-tools/quickstart-browser.md
       - Quickstart Code Interpreter: user-guide/builtin-tools/quickstart-code-interpreter.md
+    - Security:
+      - VPC Interface Endpoints: user-guide/security/vpc-interface-endpoints.md
+      - AgentCore VPC Configuration: user-guide/security/agentcore-vpc.md
+      - VPC Condition Keys: user-guide/security/security-vpc-condition.md
     - Observability:
       - Observability Quickstart: user-guide/observability/quickstart.md
     - Import Agent:
@@ -141,11 +146,15 @@ plugins:
           - "user-guide/runtime/permissions.md": "Runtime permissions guide"
           - "user-guide/runtime/async.md": "Runtime async processing"
           - "user-guide/runtime/notebook.md": "Runtime notebook integration"
+          - "user-guide/runtime/a2a.md": "A2A server deployment guide"
           - "user-guide/gateway/quickstart.md": "Gateway quickstart guide"
           - "user-guide/memory/quickstart.md": "Memory quickstart guide"
           - "user-guide/identity/quickstart.md": "Identity quickstart guide"
           - "user-guide/builtin-tools/quickstart-browser.md": "Browser tool quickstart"
           - "user-guide/builtin-tools/quickstart-code-interpreter.md": "Code interpreter quickstart"
+          - "user-guide/security/vpc-interface-endpoints.md": "VPC interface endpoints configuration"
+          - "user-guide/security/agentcore-vpc.md": "AgentCore VPC configuration guide"
+          - "user-guide/security/security-vpc-condition.md": "VPC condition keys for IAM policies"
           - "user-guide/observability/quickstart.md": "Observability quickstart guide"
           - "user-guide/import-agent/quickstart.md": "Import agent quickstart"
           - "user-guide/import-agent/overview.md": "Import agent overview"


### PR DESCRIPTION
## Description

This pr adds 4 documents to the agentcore documentation, from aws.docs. The first is deploying a2a servers on agentcore runtime. The other 3 are configuring VPC with agentcore. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [x] Manual testing completed

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [ ] Dependencies are from trusted sources
- [ ] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
