### PR TITLE
docs: Remove duplicate --non-interactive option in CLI reference

### DIFF
--- a/documentation/docs/api-reference/cli.md
+++ b/documentation/docs/api-reference/cli.md
@@ -61,8 +61,6 @@ Options:
 
 - `--non-interactive, -ni`: Skip prompts; use defaults unless overridden
 
-- `--non-interactive, -ni`: Skip prompts; use defaults unless overridden
-
 - `--vpc`: Enable VPC networking mode for secure access to private resources
 
 - `--subnets TEXT`: Comma-separated list of subnet IDs (required when --vpc is enabled)


### PR DESCRIPTION
## Summary

Removes duplicate `--non-interactive, -ni` option from CLI documentation.

## Changes
- Fixed duplicate entry in `documentation/docs/api-reference/cli.md`