### PR TITLE
fix: Deployment type improvements and backwards compatibility

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -1091,7 +1091,7 @@ def launch(
                 f"[bold]Agent Details:[/bold]\n"
                 f"Agent Name: [cyan]{agent_name}[/cyan]\n"
                 f"Agent ARN: [cyan]{result.agent_arn}[/cyan]\n"
-                f"Deployment Type: [cyan]Direct Code Deploy (Lambda-style)[/cyan]\n\n"
+                f"Deployment Type: [cyan]Direct Code Deploy[/cyan]\n\n"
                 f"📦 Code package deployed to Bedrock AgentCore\n\n"
                 f"[bold]Next Steps:[/bold]\n"
                 f"   [cyan]agentcore status[/cyan]\n"
@@ -1596,14 +1596,15 @@ def status(
                     if agent_id:
                         try:
                             endpoint_name = endpoint_data.get("name")
-                            runtime_logs, otel_logs = get_agent_log_paths(agent_id, endpoint_name)
+                            project_config = load_config(config_path)
+                            agent_config = project_config.get_agent_config(agent)
+                            deployment_type = agent_config.deployment_type if agent_config else "container"
+                            runtime_logs, otel_logs = get_agent_log_paths(agent_id, endpoint_name, deployment_type=deployment_type)
                             follow_cmd, since_cmd = get_aws_tail_commands(runtime_logs)
 
                             panel_content += f"📋 [cyan]CloudWatch Logs:[/cyan]\n   {runtime_logs}\n   {otel_logs}\n\n"
 
                             # Only show GenAI Observability Dashboard if OTEL is enabled
-                            project_config = load_config(config_path)
-                            agent_config = project_config.get_agent_config(agent)
                             if agent_config and agent_config.aws.observability.enabled:
                                 panel_content += (
                                     f"🔍 [cyan]GenAI Observability Dashboard:[/cyan]\n"

--- a/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
+++ b/src/bedrock_agentcore_starter_toolkit/notebook/runtime/bedrock_agentcore.py
@@ -60,7 +60,7 @@ class Runtime:
         vpc_security_groups: Optional[List[str]] = None,
         idle_timeout: Optional[int] = None,
         max_lifetime: Optional[int] = None,
-        deployment_type: Literal["direct_code_deploy", "container"] = "direct_code_deploy",
+        deployment_type: Literal["direct_code_deploy", "container"] = "container",
         runtime_type: Optional[str] = None,
     ) -> ConfigureResult:
         """Configure Bedrock AgentCore from notebook using an entrypoint file.

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/destroy.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/destroy.py
@@ -73,8 +73,9 @@ def destroy_bedrock_agentcore(
         # 2. Destroy Bedrock AgentCore agent
         _destroy_agentcore_agent(session, agent_config, result, dry_run)
 
-        # 3. Remove ECR images and optionally the repository
-        _destroy_ecr_images(session, agent_config, result, dry_run, delete_ecr_repo)
+        # 3. Remove ECR images and optionally the repository (only for container deployments)
+        if agent_config.deployment_type == "container":
+            _destroy_ecr_images(session, agent_config, result, dry_run, delete_ecr_repo)
 
         # 4. Remove CodeBuild project (only for container deployments)
         if agent_config.deployment_type == "container":

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/logs.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/logs.py
@@ -39,7 +39,7 @@ def get_agent_log_paths(
     if deployment_type == "direct_code_deploy":
         if session_id:
             # Specific session logs
-            log_stream_prefix = f"runtime-logs-{session_id}]"
+            log_stream_prefix = "runtime-logs"
         else:
             # All session logs (incomplete prefix to match all)
             log_stream_prefix = "runtime-logs"

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/package.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/package.py
@@ -577,7 +577,6 @@ class CodeZipPackager:
 
         step_start = time.time()
         bucket = codebuild.ensure_source_bucket(account_id)
-        log.info("  ⏱️  S3 ensure bucket: %.2fs", time.time() - step_start)
 
         s3_key = f"{agent_name}/deployment.zip"
         s3 = session.client("s3")
@@ -585,6 +584,5 @@ class CodeZipPackager:
         log.info("Uploading to s3://%s/%s...", bucket, s3_key)
         step_start = time.time()
         s3.upload_file(str(deployment_zip), bucket, s3_key, ExtraArgs={"ExpectedBucketOwner": account_id})
-        log.info("  ⏱️  S3 upload_file: %.2fs", time.time() - step_start)
 
         return f"s3://{bucket}/{s3_key}"

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/schema.py
@@ -195,7 +195,7 @@ class BedrockAgentCoreAgentSchema(BaseModel):
     name: str = Field(..., description="Name of the Bedrock AgentCore application")
     entrypoint: str = Field(..., description="Entrypoint file path (e.g., 'agent.py' or 'agent.py:handler')")
     deployment_type: Literal["container", "direct_code_deploy"] = Field(
-        default="direct_code_deploy", description="Deployment artifact type: container (Docker) or direct_code_deploy (Lambda-style)"
+        default="container", description="Deployment artifact type: container (Docker) or direct_code_deploy"
     )
     runtime_type: Optional[str] = Field(
         default=None, description="Managed runtime version for direct_code_deploy (e.g., 'PYTHON_3_10', 'PYTHON_3_11')"


### PR DESCRIPTION
## Summary

Multiple deployment type improvements and backwards compatibility fixes:

## Changes
- Remove stopwatch timing logs (⏱️) for cleaner output
- Fix memory creation console.print error by using log.info instead
- Remove 'Lambda-style' text from deployment type display
- Skip ECR cleanup warning for direct_code_deploy deployments
- Use shorter log stream prefix without full session ID
- Fix status command log stream prefix for direct_code_deploy
- Change default deployment_type to 'container' for backwards compatibility

## Testing
- Verified memory creation no longer crashes with NoneType error
```
⠸ Launching Bedrock AgentCore...Creating new memory with LTM strategies...
⏳ Creating memory resource (this may take 30-180 seconds)...
⠇ Launching Bedrock AgentCore...Created memory: agentcore_starter_strands_mem-xCy8m02JNF
Created memory agentcore_starter_strands_mem-xCy8m02JNF, waiting for ACTIVE status...
Waiting for memory agentcore_starter_strands_mem-xCy8m02JNF to return to ACTIVE state and strategies to reach terminal states...
⠙ Launching Bedrock AgentCore...[22:06:50]    ⏳ Memory: CREATING, Strategies: 0/3 active (10s elapsed)                                               manager.py:1017
⠙ Launching Bedrock AgentCore...[22:07:01]    ⏳ Memory: CREATING, Strategies: 0/3 active (20s elapsed)  

Memory agentcore_starter_strands_mem-xCy8m02JNF is ACTIVE and all strategies are in terminal states (took 166 seconds)
              ✅ Memory is ACTIVE (took 166s)  

agentcore status
✅ MemoryManager initialized for region: us-west-2
🔎 Retrieving memory resource with ID: agentcore_starter_strands_mem-xCy8m02JNF...
  Found memory: agentcore_starter_strands_mem-xCy8m02JNF
╭───────────────────────────────────────────── Agent Status: agentcore_starter_strands ─────────────────────────────────────────────╮
│ Ready - Agent deployed and endpoint available                                                                                     │
│                                                                                                                                   │
│ Agent Details:                                                                                                                    │
│ Agent Name: agentcore_starter_strands                                                                                             │
│ Agent ARN: arn:aws:bedrock-agentcore:us-west-2:924833783899:runtime/agentcore_starter_strands-eKJsFlGK5e                          │
│ Endpoint: DEFAULT (READY)                                                                                                         │
│ Region: us-west-2 | Account: 924833783899                                  

agentcore invoke '{"prompt": "Hello"}'


Response:
Hello! I'm your AI assistant with code execution capabilities. I can help you with various tasks like:

- Running Python, JavaScript, or TypeScript code
- Data analysis and visualization
- Executing shell commands
- File operations in a sandbox environment
- And much more!

Is there something specific you'd like me to help you with today? I can write and execute code to solve problems, create 
visualizations, analyze data, or assist with any coding-related tasks you might have. 
```

- Verified `agentcore destroy`

```
agentcore destroy
⚠️  About to destroy resources for agent 'djsodjpsodjsopd'

Current deployment:
  • Agent ARN: arn:aws:bedrock-agentcore:us-west-2:924833783899:runtime/djsodjpsodjsopd-f1xwFg7bI9
  • Agent ID: djsodjpsodjsopd-f1xwFg7bI9
  • Execution Role: arn:aws:iam::924833783899:role/AmazonBedrockAgentCoreSDKRuntime-us-west-2-c9ab38a182

This will permanently delete AWS resources and cannot be undone!
Are you sure you want to destroy the agent 'djsodjpsodjsopd' and all its resources? [y/N]: y
Starting destroy operation for agent: djsodjpsodjsopd (dry_run=False, delete_ecr_repo=False)
⠹ Destroying Bedrock AgentCore resources...DEFAULT endpoint will be automatically deleted with agent
⠦ Destroying Bedrock AgentCore resources...Deleted AgentCore agent: arn:aws:bedrock-agentcore:us-west-2:924833783899:runtime/djsodjpsodjsopd-f1xwFg7bI9
Skipping CodeBuild cleanup for direct_code_deploy deployment
⠇ Destroying Bedrock AgentCore resources...Deleted S3 artifact: djsodjpsodjsopd/deployment.zip
Deleted S3 artifact: djsodjpsodjsopd/source.zip
Skipping CodeBuild IAM role cleanup for direct_code_deploy deployment
⠋ Destroying Bedrock AgentCore resources...Deleted IAM role: AmazonBedrockAgentCoreSDKRuntime-us-west-2-c9ab38a182
Removed agent configuration: djsodjpsodjsopd
Updated default agent from 'djsodjpsodjsopd' to 'test_ecr_test_again'
Updated configuration file
Destroy operation completed. Resources removed: 6, Warnings: 0, Errors: 0
✅ Successfully destroyed resources for agent 'djsodjpsodjsopd'

╭──────────────────────────────────────────────── Resources Successfully Destroyed ─────────────────────────────────────────────────╮
│   ✓ AgentCore agent: arn:aws:bedrock-agentcore:us-west-2:924833783899:runtime/djsodjpsodjsopd-f1xwFg7bI9                          │
│   ✓ S3 artifact: s3://bedrock-agentcore-codebuild-sources-924833783899-us-west-2/djsodjpsodjsopd/deployment.zip                   │
│   ✓ S3 artifact: s3://bedrock-agentcore-codebuild-sources-924833783899-us-west-2/djsodjpsodjsopd/source.zip                       │
│   ✓ IAM execution role: AmazonBedrockAgentCoreSDKRuntime-us-west-2-c9ab38a182                                                     │
│   ✓ Agent configuration: djsodjpsodjsopd                                                                                          │
│   ✓ Default agent updated to: test_ecr_test_again                                                                                 │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

Next steps:
  • Run 'agentcore configure --entrypoint <file>' to set up a new agent
  • Run 'agentcore launch' to deploy to Bedrock AgentCore
```

- Validated default deployment type

```
python notebook.py

response = agentcore_runtime.configure(
    entrypoint="strands_claude.py",
    auto_create_execution_role=True,
    auto_create_ecr=True,
    requirements_file="requirements.txt",
    region=region,
    agent_name=agent_name
)

Bedrock AgentCore configured: /Users/aravadha/Repositories/zip-starter-toolkit/aravadha-notebook-two/.bedrock_agentcore.yaml
```