### PR TITLE
Update Direct Code Deploy message to clarify Python-only support

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -613,7 +613,7 @@ def configure(
         # Interactive mode
         if direct_code_deploy_available:
             deployment_options = [
-                ("Direct Code Deploy (recommended) - Simple, serverless, no Docker required", "direct_code_deploy"),
+                ("Direct Code Deploy (recommended) - Python only, no Docker required", "direct_code_deploy"),
                 ("Container - For custom runtimes or complex dependencies", "container"),
             ]
         else:


### PR DESCRIPTION
## Summary
Updated the deployment option message for Direct Code Deploy to better clarify that it supports Python-only runtimes.

## Changes
- Changed message from 'Simple, serverless, no Docker required' to 'Python only, no Docker required'
- This provides clearer guidance to users about the runtime limitations

## Impact
- Improves user experience by setting correct expectations
- Reduces confusion about supported runtimes for Direct Code Deploy option

## Testing
- Message change is cosmetic and doesn't affect functionality
- Verified the text appears correctly in the deployment options