### PR TITLE
Add AWS Marketplace permissions for automatic model subscription

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
@@ -159,6 +159,20 @@
       ]
     },
     {
+      "Sid": "MarketplaceSubscribeOnFirstCall",
+      "Effect": "Allow",
+      "Action": [
+        "aws-marketplace:ViewSubscriptions",
+        "aws-marketplace:Subscribe"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:CalledViaLast": "bedrock.amazonaws.com"
+        }
+      }
+    },
+    {
       "Sid": "BedrockAgentCoreCodeInterpreter",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Description

Adds AWS Marketplace subscription permissions to the auto-generated execution role policy to support automatic subscription for Bedrock models offered through AWS Marketplace.

## Context
Following the Bedrock model access simplification (retirement of Model Access page), certain models like Claude Sonnet 4 are now offered through AWS Marketplace and require subscription before use. 

With these permissions, the execution role can automatically create subscriptions on first model invocation, eliminating manual setup steps for users.

## Changes
- Added `MarketplaceSubscribeOnFirstCall` statement to `execution_role_policy.json.j2`
- Grants `aws-marketplace:ViewSubscriptions` and `aws-marketplace:Subscribe` permissions
- Scoped with condition `aws:CalledViaLast: bedrock.amazonaws.com` for security

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x ] Unit tests pass locally
- [x ] Integration tests pass (if applicable)
- [x ] Test coverage remains above 80%
- [x ] Manual testing completed

## Checklist

- [x ] My code follows the project's style guidelines (ruff/pre-commit)
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x ] Any dependent changes have been merged and published

## Security Checklist

- [x ] No hardcoded secrets or credentials
- [ x] No new security warnings from bandit
- [x ] Dependencies are from trusted sources
- [ x] No sensitive data logged

