### PR TITLE
refactor: rename 'launch' command to 'deploy'

### DIFF
--- a/documentation/docs/api-reference/cli.md
+++ b/documentation/docs/api-reference/cli.md
@@ -144,12 +144,12 @@ agentcore configure --entrypoint agent.py \
   --max-lifetime 7200      # 2 hours max regardless of activity
 ```
 
-### Launch
+### Deploy
 
 Deploy agents to AWS or run locally.
 
 ```bash
-agentcore launch [OPTIONS]
+agentcore deploy [OPTIONS]
 ```
 
 Options:
@@ -168,21 +168,21 @@ Options:
 
 ```bash
 # CodeBuild (default) - Cloud build, no Docker required
-agentcore launch
+agentcore deploy
 
 # Local mode - Build and run locally
-agentcore launch --local
+agentcore deploy --local
 
 # Local build mode - Build locally, deploy to cloud
-agentcore launch --local-build
+agentcore deploy --local-build
 ```
 
 **Memory Provisioning:**
 
-During launch, if memory is enabled:
+During deploy, if memory is enabled:
 
 - Memory resources are created and provisioned
-- Launch waits for memory to become ACTIVE before proceeding
+- Deploy waits for memory to become ACTIVE before proceeding
 - STM provisioning: ~30-90 seconds
 - LTM provisioning: ~120-180 seconds
 - Progress updates displayed during wait
@@ -461,7 +461,7 @@ https://cognito-idp.us-west-2.amazonaws.com/us-west-2_xxxxx/.well-known/openid-c
 
 - Creates the credential provider in AgentCore Identity
 - Adds provider configuration to `.bedrock_agentcore.yaml`
-- IAM permissions added automatically during `agentcore launch`
+- IAM permissions added automatically during `agentcore deploy`
 
 **Note:** After creating a provider, you must register the returned `callbackUrl` in your OAuth provider’s settings (except for Cognito, which is auto-configured with `--cognito-pool-id`).
 
@@ -615,7 +615,7 @@ agentcore identity create-workload-identity \
   --name my-agent-workload
 
 # 6. Deploy agent
-agentcore launch
+agentcore deploy
 
 # 7. Get bearer token for Runtime auth
 TOKEN=$(agentcore identity get-cognito-inbound-token)
@@ -978,19 +978,19 @@ agentcore configure set-default my_agent
 
 ```bash
 # Deploy to AWS (default - uses CodeBuild)
-agentcore launch
+agentcore deploy
 
 # Run locally
-agentcore launch --local
+agentcore deploy --local
 
 # Build locally, deploy to cloud
-agentcore launch --local-build
+agentcore deploy --local-build
 
-# Launch with environment variables
-agentcore launch --env API_KEY=abc123 --env DEBUG=true
+# Deploy with environment variables
+agentcore deploy --env API_KEY=abc123 --env DEBUG=true
 
 # Auto-update if agent exists
-agentcore launch --auto-update-on-conflict
+agentcore deploy --auto-update-on-conflict
 ```
 
 ### Invoke Agents

--- a/documentation/docs/examples/agentcore-quickstart-example.md
+++ b/documentation/docs/examples/agentcore-quickstart-example.md
@@ -147,7 +147,7 @@ agentcore configure -e agentcore_starter_strands.py
 Launch your agent to the AgentCore runtime environment:
 
 ```bash
-agentcore launch
+agentcore deploy
 
 # This performs:
 #   1. Memory resource provisioning (STM + LTM strategies)
@@ -159,7 +159,7 @@ agentcore launch
 ```
 
 **Expected output:**
-During launch, you'll see memory creation progress with elapsed time indicators. Memory provisioning may take around 2-5 minutes to activate:
+During Deploy, you'll see memory creation progress with elapsed time indicators. Memory provisioning may take around 2-5 minutes to activate:
 
 ```text
 Creating memory resource for agent: agentcore_starter_strands

--- a/documentation/docs/examples/memory_gateway_agent.md
+++ b/documentation/docs/examples/memory_gateway_agent.md
@@ -469,7 +469,7 @@ agentcore configure -e agent_with_gateway.py
 
 # Deploy with short-term memory
 export MEMORY_ID=<your-stm-id>  # Use the STM ID from the setup_memory.py output
-agentcore launch
+agentcore deploy
 ```
 
 AgentCore CLI will handle:
@@ -514,7 +514,7 @@ Now, let's deploy with long-term memory and test cross-session memory:
 ```bash
 # Update deployment with long-term memory
 export MEMORY_ID=<your-ltm-id>  # Use the LTM ID from setup_memory.py output
-agentcore launch
+agentcore deploy
 
 # Tell agent your preferences in one session
 SESSION1="first-session-12345678901234567890123456"

--- a/documentation/docs/examples/runtime-framework-agents.md
+++ b/documentation/docs/examples/runtime-framework-agents.md
@@ -77,7 +77,7 @@ langgraph" > requirements.txt
 
 # Configure and deploy
 agentcore configure --entrypoint langgraph_agent.py
-agentcore launch
+agentcore deploy
 
 # Test
 agentcore invoke '{"prompt": "Explain LangGraph in one sentence"}'
@@ -152,7 +152,7 @@ crewai-tools" > requirements.txt
 
 # Configure and deploy
 agentcore configure --entrypoint crewai_agent.py
-agentcore launch
+agentcore deploy
 
 # Test
 agentcore invoke '{"prompt": "What are the benefits of using CrewAI?"}'
@@ -215,7 +215,7 @@ def invoke(payload):
 Then set the environment variable during deployment:
 
 ```bash
-agentcore launch --env MY_API_KEY=your-key-here
+agentcore deploy --env MY_API_KEY=your-key-here
 ```
 
 ## Troubleshooting

--- a/documentation/docs/examples/session-management.md
+++ b/documentation/docs/examples/session-management.md
@@ -47,7 +47,7 @@ app.run()
 ### CLI
 ```bash
 agentcore configure --entrypoint handler.py
-agentcore launch
+agentcore deploy
 
 # Start conversation
 agentcore invoke '{"message": "Hello"}' --session-id conv1

--- a/documentation/docs/mcp/agentcore_runtime_deployment.md
+++ b/documentation/docs/mcp/agentcore_runtime_deployment.md
@@ -39,7 +39,7 @@ Refer to https://aws.github.io/bedrock-agentcore-starter-toolkit/api-reference/c
 2. **Configuration**: Use AgentCore CLI to configure your agent for deployment.
     ```agentcore configure --entrypoint converted_agentcore_file.py --non-interactive```
 3. **Deployment**: Launch your agent to AWS with automatic resource creation.
-    ```agentcore launch```
+    ```agentcore deploy```
 4. **Invocation**: agentcore invoke '{"prompt": "Hello"}' Test your deployed agent using the CLI or API calls
 
 #### Step 4: Troubleshooting & Enhancement

--- a/documentation/docs/user-guide/identity/quickstart-with-cli.md
+++ b/documentation/docs/user-guide/identity/quickstart-with-cli.md
@@ -213,7 +213,7 @@ agentcore identity create-credential-provider \
 
 - Creates OAuth credential provider in Identity service
 - Saves provider configuration to `.bedrock_agentcore.yaml`
-- IAM permissions will be added automatically during `launch`
+- IAM permissions will be added automatically during `deploy`
 
 ## Step 6: Create Workload Identity
 
@@ -230,7 +230,7 @@ agentcore identity create-workload-identity \
 ## Step 7: Deploy Agent
 
 ```bash
-agentcore launch
+agentcore deploy
 ```
 
 **What happens during launch:**

--- a/documentation/docs/user-guide/identity/quickstart.md
+++ b/documentation/docs/user-guide/identity/quickstart.md
@@ -298,7 +298,7 @@ if __name__ == "__main__":
 
 We will host this agent on AgentCore Runtime. We can do this easily with the AgentCore SDK we installed earlier.
 
-From your terminal, run `agentcore configure -e agentcoreidentityquickstart.py` and `agentcore launch` . The deployment will work with the defaults set by `agentcore configure`, but you may customize them. Ensure that you select "No" for the `Configure OAuth authorizer instead` step. We want to use IAM authorization for this guide.
+From your terminal, run `agentcore configure -e agentcoreidentityquickstart.py` and `agentcore deploy` . The deployment will work with the defaults set by `agentcore configure`, but you may customize them. Ensure that you select "No" for the `Configure OAuth authorizer instead` step. We want to use IAM authorization for this guide.
 
 ### Update the IAM policy of the agent to be able to access the token vault, and client secret
 
@@ -376,7 +376,7 @@ Note that if you interrupt an invocation without completing authorization, you m
 
 ### Debugging
 
-Should you encounter any errors or unexpected behaviors, the output of the agent is captured in CloudWatch logs. A log tailing command is provided after you run `agentcore launch`
+Should you encounter any errors or unexpected behaviors, the output of the agent is captured in CloudWatch logs. A log tailing command is provided after you run `agentcore deploy`
 
 ## Clean Up
 

--- a/documentation/docs/user-guide/runtime/a2a.md
+++ b/documentation/docs/user-guide/runtime/a2a.md
@@ -271,7 +271,7 @@ agentcore configure -e my_a2a_server.py --protocol A2A
 Deploy your agent:
 
 ```
-agentcore launch
+agentcore deploy
 ```
 
 After deployment, you'll receive an agent runtime ARN that looks like:

--- a/documentation/docs/user-guide/runtime/async.md
+++ b/documentation/docs/user-guide/runtime/async.md
@@ -227,7 +227,7 @@ curl http://localhost:8080/ping
 ```bash
 # Configure and test locally
 agentcore configure -e my_async_agent.py
-agentcore launch -l
+agentcore deploy -l
 
 # Test in another terminal
 agentcore invoke '{"prompt": "start processing"}' -l

--- a/documentation/docs/user-guide/runtime/overview.md
+++ b/documentation/docs/user-guide/runtime/overview.md
@@ -20,7 +20,7 @@ if __name__ == "__main__":
 ```bash
 # Configure and deploy your agent
 agentcore configure --entrypoint my_agent.py --non-interactive
-agentcore launch
+agentcore deploy
 agentcore invoke '{"name": "Alice"}'
 ```
 
@@ -45,20 +45,20 @@ The Runtime SDK is a comprehensive Python framework that bridges the gap between
 ### 🚀 Direct Code Deploy Deployment (DEFAULT & RECOMMENDED)
 ```bash
 agentcore configure --entrypoint my_agent.py
-agentcore launch                    # Uses CodeBuild for containers, .zip archive for direct deploy
+agentcore deploy                    # Uses CodeBuild for containers, .zip archive for direct deploy
 ```
 - **Works everywhere** - SageMaker Notebooks, Cloud9, laptops
 - **Production-ready** - managed Python runtime environment
 
 ### 💻 Local Development
 ```bash
-agentcore launch --local           # Build and run locally
+agentcore deploy --local           # Build and run locally
 ```
 - **Fast iteration** - immediate feedback and debugging
 
 ### 🔧 Hybrid Build
 ```bash
-agentcore launch --local-build     # Build locally, deploy to cloud
+agentcore deploy --local-build     # Build locally, deploy to cloud
 ```
 - **For complex scenarios** - large apps, system dependencies
 - **Requires:** Docker for local development
@@ -251,14 +251,14 @@ if __name__ == "__main__":
 agentcore configure --entrypoint my_agent.py
 
 # 2. Develop locally
-agentcore launch --local
+agentcore deploy --local
 
 # 3. Test
 agentcore invoke '{"prompt": "Hello"}'
 agentcore invoke '{"prompt": "Remember this"}' --session-id "test"
 
 # 4. Deploy to cloud
-agentcore launch
+agentcore deploy
 
 # 5. Monitor
 agentcore status

--- a/documentation/docs/user-guide/runtime/permissions.md
+++ b/documentation/docs/user-guide/runtime/permissions.md
@@ -46,7 +46,7 @@ agentcore configure -e my_agent.py
 ```bash
 # Uses CodeBuild by default
 agentcore configure -e my_agent.py
-agentcore launch
+agentcore deploy
 ```
 
 ## Developer/Caller Permissions

--- a/documentation/docs/user-guide/runtime/quickstart.md
+++ b/documentation/docs/user-guide/runtime/quickstart.md
@@ -135,7 +135,7 @@ agentcore configure -e my_agent.py -r us-east-1
 Host your agent in AgentCore Runtime:
 
 ```bash
-agentcore launch
+agentcore deploy
 ```
 
 This command:
@@ -146,7 +146,7 @@ This command:
 - Creates memory resources if you configured memory during the setup
 - Configures CloudWatch logging
 
-In the output from `agentcore launch` note the following:
+In the output from `agentcore deploy` note the following:
 
 - The Amazon Resource Name (ARN) of the agent. You need it to invoke the agent with the InvokeAgentRuntime operation.
 - The location of the logs in Amazon CloudWatch Logs
@@ -330,7 +330,7 @@ Choose the right deployment approach for your needs:
 Suitable for most use cases, no Docker required:
 
 ```bash
-agentcore launch  # Uses CodeBuild for containers, .zip archive for direct deploy
+agentcore deploy  # Uses CodeBuild for containers, .zip archive for direct deploy
 ```
 
 **Local Development**
@@ -338,7 +338,7 @@ agentcore launch  # Uses CodeBuild for containers, .zip archive for direct deplo
 Suitable for development, rapid iteration, debugging:
 
 ```bash
-agentcore launch --local  # Build and run locally (requires Docker/Finch/Podman)
+agentcore deploy --local  # Build and run locally (requires Docker/Finch/Podman)
 ```
 
 **Hybrid: Local Build + Cloud Runtime**
@@ -346,7 +346,7 @@ agentcore launch --local  # Build and run locally (requires Docker/Finch/Podman)
 Suitable for teams with Docker expertise needing build customization:
 
 ```bash
-agentcore launch --local-build  # Build locally, deploy to cloud (requires Docker/Finch/Podman)
+agentcore deploy --local-build  # Build locally, deploy to cloud (requires Docker/Finch/Podman)
 ```
 
 > Note: Docker is only required for `--local` and `--local-build` modes. The default mode uses AWS CodeBuild.

--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -14,9 +14,9 @@ from .identity.commands import identity_app
 from .import_agent.commands import import_agent
 from .runtime.commands import (
     configure_app,
+    deploy,
     destroy,
     invoke,
-    launch,
     status,
     stop_session,
 )
@@ -29,7 +29,7 @@ setup_toolkit_logging(mode="cli")
 # runtime
 app.command("invoke")(invoke)
 app.command("status")(status)
-app.command("launch")(launch)
+app.command("deploy")(deploy)
 app.command("import-agent")(import_agent)
 app.command("destroy")(destroy)
 app.command("stop-session")(stop_session)

--- a/src/bedrock_agentcore_starter_toolkit/cli/identity/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/identity/commands.py
@@ -132,7 +132,7 @@ us-west-2_xxx/.well-known/openid-configuration \
                 f"[bold]Next Steps:[/bold]\n"
                 f"   1. Ensure callback URL is registered with your IdP\n"
                 f"   2. Create/update workload identity with your app's callback URLs\n"
-                f"   3. [cyan]agentcore launch[/cyan]  # Permissions auto-added",
+                f"   3. [cyan]agentcore deploy[/cyan]  # Permissions auto-added",
                 title="✅ Success",
                 border_style="green",
             )

--- a/src/bedrock_agentcore_starter_toolkit/cli/import_agent/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/import_agent/commands.py
@@ -425,7 +425,7 @@ def import_agent(
 
                 configure_cmd = f"agentcore configure --entrypoint {output_path} --requirements-file {requirements_path} --ecr auto -n '{agent_name}'"  # noqa: E501
                 set_default_cmd = f"agentcore configure set-default '{agent_name}'"
-                launch_cmd = f"agentcore launch {env_injection_code}"
+                launch_cmd = f"agentcore deploy {env_injection_code}"
 
                 os.system(f"cd {output_dir} && {configure_cmd} && {set_default_cmd} && {launch_cmd}")  # nosec
 

--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -43,7 +43,7 @@ def _show_configuration_not_found_panel():
             "No agent configuration found in this directory.\n\n"
             "[bold]Get Started:[/bold]\n"
             "   [cyan]agentcore configure --entrypoint your_agent.py[/cyan]\n"
-            "   [cyan]agentcore launch[/cyan]\n"
+            "   [cyan]agentcore deploy[/cyan]\n"
             '   [cyan]agentcore invoke \'{"prompt": "Hello"}\'[/cyan]',
             title="⚠️ Setup Required",
             border_style="bright_blue",
@@ -830,7 +830,7 @@ def configure(
                 f"{lifecycle_info}\n"
                 f"📄 Config saved to: [dim]{result.config_path}[/dim]\n\n"
                 f"[bold]Next Steps:[/bold]\n"
-                f"   [cyan]agentcore launch[/cyan]",
+                f"   [cyan]agentcore deploy[/cyan]",
                 title="Configuration Success",
                 border_style="bright_blue",
             )
@@ -843,7 +843,7 @@ def configure(
         _handle_error(f"Configuration failed: {e}", e)
 
 
-def launch(
+def deploy(
     agent: Optional[str] = typer.Option(
         None, "--agent", "-a", help="Agent name (use 'agentcore configure list' to see available agents)"
     ),
@@ -876,7 +876,7 @@ def launch(
         hidden=True,
     ),
 ):
-    """Launch Bedrock AgentCore with three deployment modes.
+    """Deploy Bedrock AgentCore with three deployment modes.
 
     🚀 DEFAULT (no flags): Cloud runtime (RECOMMENDED)
        - direct_code_deploy deployment: Direct deploy Python code to runtime
@@ -897,15 +897,15 @@ def launch(
        - Use when you need custom build control but want cloud deployment
 
     MIGRATION GUIDE:
-    - OLD: agentcore launch --code-build  →  NEW: agentcore launch
-    - OLD: agentcore launch --local       →  NEW: agentcore launch --local (unchanged)
-    - NEW: agentcore launch --local-build (build locally + deploy to cloud)
+    - OLD: agentcore launch --code-build  →  NEW: agentcore deploy
+    - OLD: agentcore launch --local       →  NEW: agentcore deploy --local (unchanged)
+    - NEW: agentcore deploy --local-build (build locally + deploy to cloud)
     """
     # Handle deprecated --code-build flag
     if code_build:
         console.print("[yellow]⚠️  DEPRECATION WARNING: --code-build flag is deprecated[/yellow]")
         console.print("[yellow]   CodeBuild is now the default deployment method[/yellow]")
-        console.print("[yellow]   MIGRATION: Simply use 'agentcore launch' (no flags needed)[/yellow]")
+        console.print("[yellow]   MIGRATION: Simply use 'agentcore deploy' (no flags needed)[/yellow]")
         console.print("[yellow]   This flag will be removed in a future version[/yellow]\n")
 
     # Validate mutually exclusive options
@@ -925,8 +925,8 @@ def launch(
             _handle_error(
                 "Error: --local-build is only supported for container deployment type.\n"
                 "For direct_code_deploy deployment, use:\n"
-                "  • 'agentcore launch' (default)\n"
-                "  • 'agentcore launch --local' (local execution)"
+                "  • 'agentcore deploy' (default)\n"
+                "  • 'agentcore deploy --local' (local execution)"
             )
 
         if force_rebuild_deps and deployment_type != "direct_code_deploy":
@@ -975,10 +975,10 @@ def launch(
             # Show deployment options hint for first-time users
             console.print("[dim]💡 Deployment options:[/dim]")
             mode_name = "CodeBuild" if deployment_type == "container" else "Cloud"
-            console.print(f"[dim]   • agentcore launch                → {mode_name} (current)[/dim]")
-            console.print("[dim]   • agentcore launch --local        → Local development[/dim]")
+            console.print(f"[dim]   • agentcore deploy                → {mode_name} (current)[/dim]")
+            console.print("[dim]   • agentcore deploy --local        → Local development[/dim]")
             if deployment_type == "container":
-                console.print("[dim]   • agentcore launch --local-build  → Local build + cloud deploy[/dim]")
+                console.print("[dim]   • agentcore deploy --local-build  → Local build + cloud deploy[/dim]")
             console.print()
 
         # Use the operations module
@@ -1426,7 +1426,7 @@ def invoke(
             agent_config = None
         _show_invoke_info_panel(agent_display, invoke_result=None, config=agent_config)
         if "not deployed" in str(e):
-            _show_error_response("Agent not deployed - run 'agentcore launch' to deploy")
+            _show_error_response("Agent not deployed - run 'agentcore deploy' to deploy")
         else:
             _show_error_response(f"Invocation failed: {str(e)}")
         raise typer.Exit(1) from e
@@ -1502,7 +1502,7 @@ def status(
                             f"ECR Repository: [dim]{status_json['config']['ecr_repository']}[/dim]\n\n"
                             f"Your agent is configured but not yet launched.\n\n"
                             f"[bold]Next Steps:[/bold]\n"
-                            f"   [cyan]agentcore launch[/cyan]",
+                            f"   [cyan]agentcore deploy[/cyan]",
                             title=f"Agent Status: {status_json['config']['name']}",
                             border_style="bright_blue",
                         )
@@ -1669,7 +1669,7 @@ def status(
                 f"Error: {str(e)}\n\n"
                 f"[bold]Next Steps:[/bold]\n"
                 f"   [cyan]agentcore configure --entrypoint your_agent.py[/cyan]\n"
-                f"   [cyan]agentcore launch[/cyan]",
+                f"   [cyan]agentcore deploy[/cyan]",
                 title="❌ Status Error",
                 border_style="bright_blue",
             )
@@ -1682,7 +1682,7 @@ def status(
                 f"Unexpected error: {str(e)}\n\n"
                 f"[bold]Next Steps:[/bold]\n"
                 f"   [cyan]agentcore configure --entrypoint your_agent.py[/cyan]\n"
-                f"   [cyan]agentcore launch[/cyan]",
+                f"   [cyan]agentcore deploy[/cyan]",
                 title="❌ Status Error",
                 border_style="bright_blue",
             )
@@ -1916,7 +1916,7 @@ def destroy(
         if not dry_run and not result.errors:
             console.print("\n[dim]Next steps:[/dim]")
             console.print("  • Run 'agentcore configure --entrypoint <file>' to set up a new agent")
-            console.print("  • Run 'agentcore launch' to deploy to Bedrock AgentCore")
+            console.print("  • Run 'agentcore deploy' to deploy to Bedrock AgentCore")
         elif dry_run:
             console.print("\n[dim]To actually destroy these resources, run:[/dim]")
             destroy_cmd = f"  agentcore destroy{f' --agent {actual_agent_name}' if agent else ''}"
@@ -1928,7 +1928,7 @@ def destroy(
         console.print("[red].bedrock_agentcore.yaml not found[/red]")
         console.print("Run the following commands to get started:")
         console.print("  1. agentcore configure --entrypoint your_agent.py")
-        console.print("  2. agentcore launch")
+        console.print("  2. agentcore deploy")
         console.print('  3. agentcore invoke \'{"message": "Hello"}\'')
         raise typer.Exit(1) from None
     except ValueError as e:

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -803,7 +803,7 @@ def launch_bedrock_agentcore(
         raise RuntimeError(
             "Cannot run locally - no container runtime available\n"
             "💡 Recommendation: Use CodeBuild for cloud deployment\n"
-            "💡 Run 'agentcore launch' (without --local) for CodeBuild deployment\n"
+            "💡 Run 'agentcore deploy' (without --local) for CodeBuild deployment\n"
             "💡 For local runs, please install Docker, Finch, or Podman"
         )
 
@@ -812,7 +812,7 @@ def launch_bedrock_agentcore(
         raise RuntimeError(
             "Cannot build locally - no container runtime available\n"
             "💡 Recommendation: Use CodeBuild for cloud deployment (no Docker needed)\n"
-            "💡 Run 'agentcore launch' (without --local-build) for CodeBuild deployment\n"
+            "💡 Run 'agentcore deploy' (without --local-build) for CodeBuild deployment\n"
             "💡 For local builds, please install Docker, Finch, or Podman"
         )
 
@@ -843,7 +843,7 @@ def launch_bedrock_agentcore(
             raise RuntimeError(
                 f"Build failed: {error_message}\n"
                 "💡 Recommendation: Use CodeBuild for building containers in the cloud\n"
-                "💡 Run 'agentcore launch' (default) for CodeBuild deployment"
+                "💡 Run 'agentcore deploy' (default) for CodeBuild deployment"
             )
         else:
             raise RuntimeError(f"Build failed: {error_message}")

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/stop_session.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/stop_session.py
@@ -42,7 +42,7 @@ def stop_runtime_session(
     # Check if agent is deployed
     if not agent_config.bedrock_agentcore.agent_arn:
         raise ValueError(
-            f"Agent '{agent_config.name}' is not deployed. Run 'agentcore launch' to deploy the agent first."
+            f"Agent '{agent_config.name}' is not deployed. Run 'agentcore deploy' to deploy the agent first."
         )
 
     # Determine session ID to stop

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/container.py
@@ -76,7 +76,7 @@ class ContainerRuntime:
                     "• Finch: https://github.com/runfinch/finch\n"
                     "• Podman: https://podman.io/getting-started/installation\n\n"
                     "Alternative: Use CodeBuild for cloud-based building (no container engine needed):\n"
-                    "  agentcore launch  # Uses CodeBuild (default)"
+                    "  agentcore deploy  # Uses CodeBuild (default)"
                 )
             else:
                 raise ValueError(f"Unsupported runtime: {runtime_type}")
@@ -282,7 +282,7 @@ class ContainerRuntime:
             return False, [
                 "No container runtime available for local build",
                 "💡 Recommendation: Use CodeBuild for building containers in the cloud",
-                "💡 Run 'agentcore launch' (default) for CodeBuild deployment",
+                "💡 Run 'agentcore deploy' (default) for CodeBuild deployment",
                 "💡 For local builds, please install Docker, Finch, or Podman",
             ]
 
@@ -324,7 +324,7 @@ class ContainerRuntime:
             raise RuntimeError(
                 "No container runtime available for local run\n"
                 "💡 Recommendation: Use CodeBuild for building containers in the cloud\n"
-                "💡 Run 'agentcore launch' (default) for CodeBuild deployment\n"
+                "💡 Run 'agentcore deploy' (default) for CodeBuild deployment\n"
                 "💡 For local runs, please install Docker, Finch, or Podman"
             )
 

--- a/tests/cli/runtime/test_commands.py
+++ b/tests/cli/runtime/test_commands.py
@@ -315,7 +315,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                result = self.runner.invoke(app, ["launch", "--local"], catch_exceptions=False)
+                result = self.runner.invoke(app, ["deploy", "--local"], catch_exceptions=False)
                 # Just check exit code
                 assert result.exit_code == 0 or result.exit_code == 2
                 # Verify the core function was called correctly
@@ -600,7 +600,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                result = self.runner.invoke(app, ["launch"], catch_exceptions=False)
+                result = self.runner.invoke(app, ["deploy"], catch_exceptions=False)
                 # Just check exit code
                 assert result.exit_code == 0 or result.exit_code == 2
                 # Verify the core function was called correctly
@@ -758,7 +758,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                self.runner.invoke(app, ["launch"])
+                self.runner.invoke(app, ["deploy"])
 
                 # If launch was called and threw exception, _handle_error should be called
                 if mock_launch.called:
@@ -796,7 +796,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                self.runner.invoke(app, ["launch"])
+                self.runner.invoke(app, ["deploy"])
 
                 # If launch was called and threw exception, _handle_error should be called
                 if mock_launch.called:
@@ -826,8 +826,8 @@ agents:
                 result = self.runner.invoke(app, ["invoke", '{"message": "hello"}'])
 
                 assert result.exit_code == 1
-                assert "Agent not deployed - run 'agentcore launch' to deploy" in result.stdout
-                assert "agentcore launch" in result.stdout
+                assert "Agent not deployed - run 'agentcore deploy' to deploy" in result.stdout
+                assert "agentcore deploy" in result.stdout
             finally:
                 os.chdir(original_cwd)
 
@@ -1142,7 +1142,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                result = self.runner.invoke(app, ["launch", "--code-build"])
+                result = self.runner.invoke(app, ["deploy", "--code-build"])
                 # Just check that the deprecation warning appears
                 assert "DEPRECATION WARNING" in result.stdout
                 assert "--code-build flag is deprecated" in result.stdout
@@ -1495,7 +1495,7 @@ agents:
         os.chdir(tmp_path)  # Directory without .bedrock_agentcore.yaml
 
         try:
-            result = self.runner.invoke(app, ["launch"])
+            result = self.runner.invoke(app, ["deploy"])
             assert result.exit_code == 1
             # Error might be in stdout or stderr, or in the exception output
             error_output = result.stdout + result.stderr + str(result.exception) if result.exception else ""
@@ -1547,7 +1547,7 @@ agents:
     def test_launch_command_mutually_exclusive_options(self):
         """Test launch command with mutually exclusive options."""
         # Test local and local-build together (not allowed)
-        result = self.runner.invoke(app, ["launch", "--local", "--local-build"])
+        result = self.runner.invoke(app, ["deploy", "--local", "--local-build"])
         assert result.exit_code == 1
         assert "cannot be used together" in result.stdout
 
@@ -1577,7 +1577,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                result = self.runner.invoke(app, ["launch", "--local-build"])
+                result = self.runner.invoke(app, ["deploy", "--local-build"])
                 # Test expects failure due to CLI validation
                 assert result.exit_code == 0  # Should work with container deployment
                 assert "Local Build Success" in result.stdout or "agentcore status" in result.stdout
@@ -1622,7 +1622,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                result = self.runner.invoke(app, ["launch"])
+                result = self.runner.invoke(app, ["deploy"])
                 assert result.exit_code == 0
                 assert "Deployment Success" in result.stdout
                 assert "ARM64 container deployed" in result.stdout
@@ -1646,7 +1646,7 @@ agents:
 
     def test_launch_help_text_updated(self):
         """Test that help text reflects the three simplified launch modes."""
-        result = self.runner.invoke(app, ["launch", "--help"])
+        result = self.runner.invoke(app, ["deploy", "--help"])
         assert result.exit_code == 0
 
         # Check that old flags are no longer in help text
@@ -1673,7 +1673,7 @@ agents:
 
         try:
             # We only verify the exit code here, not the content
-            result = self.runner.invoke(app, ["launch"])
+            result = self.runner.invoke(app, ["deploy"])
             assert result.exit_code == 1
 
             # Skip checking for output text since it's not captured properly
@@ -2181,7 +2181,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                result = self.runner.invoke(app, ["launch", "--local", "--env", "KEY1=value1", "--env", "KEY2=value2"])
+                result = self.runner.invoke(app, ["deploy", "--local", "--env", "KEY1=value1", "--env", "KEY2=value2"])
                 assert result.exit_code == 0
 
                 # Verify environment variables were parsed correctly
@@ -2254,7 +2254,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                result = self.runner.invoke(app, ["launch"])
+                result = self.runner.invoke(app, ["deploy"])
                 assert result.exit_code == 0
                 assert "Deployment Success" in result.stdout
                 assert "arn:aws:bedrock:us-west-2:123456789012:agent-runtime/AGENT123" in result.stdout
@@ -3987,7 +3987,7 @@ test-agent:
 
                 assert result.exit_code == 0
                 assert "Configured but not deployed" in result.stdout
-                assert "agentcore launch" in result.stdout
+                assert "agentcore deploy" in result.stdout
             finally:
                 os.chdir(original_cwd)
 
@@ -4159,7 +4159,7 @@ agents:
             os.chdir(tmp_path)
 
             try:
-                result = self.runner.invoke(app, ["launch", "--auto-update-on-conflict"])
+                result = self.runner.invoke(app, ["deploy", "--auto-update-on-conflict"])
 
                 assert result.exit_code == 0
 
@@ -4180,7 +4180,7 @@ agents:
         os.chdir(tmp_path)
 
         try:
-            result = self.runner.invoke(app, ["launch", "--local", "--env", "INVALID_FORMAT"])
+            result = self.runner.invoke(app, ["deploy", "--local", "--env", "INVALID_FORMAT"])
 
             assert result.exit_code == 1
             # Error might be in stdout, stderr, or exception output

--- a/tests/operations/runtime/test_stopsession.py
+++ b/tests/operations/runtime/test_stopsession.py
@@ -220,7 +220,7 @@ class TestStopSessionOperation:
             )
 
         assert "is not deployed" in str(exc_info.value)
-        assert "agentcore launch" in str(exc_info.value)
+        assert "agentcore deploy" in str(exc_info.value)
 
     def test_stop_session_no_session_id_provided_or_tracked(self, mock_boto3_clients, tmp_path):
         """Test stopping session fails when no session ID is provided or tracked."""


### PR DESCRIPTION
BREAKING CHANGE: 'agentcore launch' command replaced with 'agentcore deploy'

## Description

Brief description of changes

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [X] Code refactoring

## Testing

- [X] Unit tests pass locally
- [X] Integration tests pass (if applicable)
- [X] Test coverage remains above 80%
- [X] Manual testing completed

checked `agentcore --help` and `agentcore deploy --help` 

## Checklist

- [X] My code follows the project's style guidelines (ruff/pre-commit)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published

## Security Checklist

- [X] No hardcoded secrets or credentials
- [X] No new security warnings from bandit
- [X] Dependencies are from trusted sources
- [X] No sensitive data logged

## Breaking Changes

**CLI Command Renamed**: `agentcore launch` has been replaced with `agentcore deploy`

The old command will no longer work and will return "No such command" error


## Additional Notes

N/A
