### PR TITLE
feat: Printing localhost and local network addresses for local dev commands

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -27,6 +27,7 @@ from ...operations.runtime import (
 from ...services.runtime import _handle_http_response
 from ...utils.runtime.config import load_config
 from ...utils.runtime.logs import get_agent_log_paths, get_aws_tail_commands, get_genai_observability_url
+from ...utils.server_addresses import build_server_urls
 from ..common import _handle_error, _print_success, console, requires_aws_creds
 from ._configure_impl import configure_impl
 
@@ -379,12 +380,15 @@ def deploy(
         if result.mode == "local":
             _print_success(f"Docker image built: {result.tag}")
             _print_success("Ready to run locally")
-            console.print("Starting server at http://localhost:8080")
-            console.print("Starting OAuth2 3LO callback server at http://localhost:8081")
-            console.print("[yellow]Press Ctrl+C to stop[/yellow]\n")
-
             if result.runtime is None or result.port is None:
                 _handle_error("Unable to launch locally")
+
+            port = int(result.port)
+            console.print("[blue]Starting server at:[/blue]")
+            for label, url in build_server_urls(port):
+                console.print(f"[blue]  • {label}: {url}[/blue]")
+            console.print("Starting OAuth2 3LO callback server at http://localhost:8081")
+            console.print("[yellow]Press Ctrl+C to stop[/yellow]\n")
 
             try:
                 oauth2_callback_endpoint = Thread(
@@ -403,7 +407,13 @@ def deploy(
 
         elif result.mode == "local_direct_code_deploy":
             _print_success("Ready to run locally with uv run")
-            console.print(f"Starting server at http://localhost:{result.port}")
+            if result.port is None:
+                _handle_error("Unable to launch locally")
+
+            port = int(result.port)
+            console.print("[blue]Starting server at:[/blue]")
+            for label, url in build_server_urls(port):
+                console.print(f"[blue]  • {label}: {url}[/blue]")
             console.print("[yellow]Press Ctrl+C to stop[/yellow]\n")
 
             try:

--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/dev_command.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/dev_command.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 import typer
 
 from ...utils.runtime.config import load_config, load_config_if_exists
+from ...utils.server_addresses import build_server_urls
 from ..common import _handle_error, _handle_warn, assert_valid_aws_creds_or_exit, console
 
 logger = logging.getLogger(__name__)
@@ -41,8 +42,6 @@ def dev(
         console.print(f"[yellow]⚠️  Port {requested_port_val} is already in use[/yellow]")
         console.print(f"[green]✓ Using port {devPort} instead[/green]")
 
-    console.print(f"[blue]Server will be available at: http://localhost:{devPort}/invocations[/blue]")
-
     if port_changed:
         console.print(
             f'[cyan]💡 Test your agent with: agentcore invoke --dev --port {devPort} "Hello" '
@@ -53,6 +52,10 @@ def dev(
 
     console.print("[green]ℹ️  This terminal window will be used to run the dev server [/green]")
     console.print("[yellow]Press Ctrl+C to stop the server[/yellow]\n")
+    console.print("[blue]Server will be available at:[/blue]")
+    for label, url in build_server_urls(int(devPort), path_suffix="/invocations"):
+        console.print(f"[blue]  • {label}: {url}[/blue]")
+    console.print()
 
     cmd = [
         "uv",
@@ -64,8 +67,6 @@ def dev(
         "0.0.0.0",  # nosec B104 - dev server intentionally binds to all interfaces
         "--port",
         str(devPort),
-        "--log-level",
-        "info",
     ]
 
     process = None

--- a/src/bedrock_agentcore_starter_toolkit/utils/server_addresses.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/server_addresses.py
@@ -1,0 +1,51 @@
+"""Utilities for displaying local server addresses."""
+
+from __future__ import annotations
+
+import socket
+from typing import List, Optional, Tuple
+
+ServerUrl = Tuple[str, str]
+
+
+def build_server_urls(port: int, *, path_suffix: str = "", protocol: str = "http") -> List[ServerUrl]:
+    """Return URLs that are reachable when binding to 0.0.0.0."""
+    suffix = _normalize_path_suffix(path_suffix)
+    urls: List[ServerUrl] = [
+        ("Localhost", f"{protocol}://localhost:{port}{suffix}"),
+        ("127.0.0.1", f"{protocol}://127.0.0.1:{port}{suffix}"),
+    ]
+
+    local_network_ip = _detect_local_network_ip()
+    if local_network_ip:
+        urls.append(("Local network", f"{protocol}://{local_network_ip}:{port}{suffix}"))
+
+    return urls
+
+
+def _normalize_path_suffix(path_suffix: str) -> str:
+    if not path_suffix:
+        return ""
+    return path_suffix if path_suffix.startswith("/") else f"/{path_suffix}"
+
+
+def _detect_local_network_ip() -> Optional[str]:
+    """Best-effort detection of an externally reachable LAN IP."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            candidate = sock.getsockname()[0]
+            if candidate and not candidate.startswith("127."):
+                return candidate
+    except OSError:
+        pass
+
+    try:
+        host_info = socket.gethostbyname_ex(socket.gethostname())
+        for candidate in host_info[2]:
+            if candidate and not candidate.startswith("127."):
+                return candidate
+    except OSError:
+        pass
+
+    return None


### PR DESCRIPTION
## Description

  - Added the shared build_server_urls helper so agentcore dev and agentcore deploy --local both list localhost, loopback, and LAN URLs on startup.
  - Updated agentcore dev output ordering so the server address summary prints last, removed the inherited VIRTUAL_ENV, and tightened uvicorn logging so startup noise is
    suppressed while request INFO lines still appear.
  - Hooked the helper into deploy’s local flows so they emit the same address summary.

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

  ## Testing

  - [ ] Unit tests pass locally
  - [ ] Integration tests pass (if applicable)
  - [ ] Test coverage remains above 80%
  - [x] Manual testing completed

  ## Checklist

  - [x] My code follows the project's style guidelines (ruff/pre-commit)
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing unit tests pass locally with my changes
  - [ ] Any dependent changes have been merged and published

  ## Security Checklist

  - [x] No hardcoded secrets or credentials
  - [x] No new security warnings from bandit
  - [x] Dependencies are from trusted sources
  - [x] No sensitive data logged

  ## Breaking Changes

  List any breaking changes and migration instructions:

  N/A

  ## Additional Notes

  - Manual validation: agentcore dev now prints the concise address list at the end and logs incoming requests without duplicating the startup banner; agentcore deploy --local
    mirrors the same output.