### PR TITLE
fix: Remove double JSON serialization causing MalformedPolicyDocument error

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/create_role.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/create_role.py
@@ -159,7 +159,7 @@ def get_or_create_runtime_execution_role(
                     iam_client=iam,
                     role_name=role_name,
                     policy_name=policy_name,
-                    policy_document=json.dumps(execution_policy),
+                    policy_document=execution_policy,
                     logger=logger,
                 )
 


### PR DESCRIPTION
## Summary
Fix the `MalformedPolicyDocument` error that occurs when creating execution roles with `agentcore deploy`.

## Problem
When deploying an agent with `execution_role_auto_create: true`, the following error occurs:

```
✓ Role created: arn:aws:iam::xxxxx:role/AmazonBedrockAgentCoreSDKRuntime-ap-northeast-1-xxxxx
Error attaching policy BedrockAgentCoreRuntimeExecutionPolicy-{agent_name} to role ...: 
An error occurred (MalformedPolicyDocument) when calling the PutRolePolicy operation: Syntax errors in policy.
```

## Root Cause
In `operations/runtime/create_role.py` line 162:

```python
policy_document=json.dumps(execution_policy),
```

The `execution_policy` returned from `render_execution_policy_template()` is already a JSON string (see `utils/runtime/policy_template.py` line 76-84). Wrapping it with `json.dumps()` causes double serialization, producing an invalid policy document:

- **Before:** `'{"Version": "2012-10-17", ...}'`  
- **After json.dumps():** `'"{\\"Version\\": \\"2012-10-17\\", ...}"'` ← This is a JSON-escaped string, not a valid IAM policy

The IAM `PutRolePolicy` API expects a valid JSON policy document, but receives a double-escaped string, causing the `MalformedPolicyDocument` error.

## Solution
Remove the unnecessary `json.dumps()` call since `execution_policy` is already a properly formatted JSON string ready for the IAM API.

## Testing
- Tested deployment with `execution_role_auto_create: true` on a new agent
- Verified role creation succeeds with proper policy attachment
- Confirmed agent deployment completes successfully

## Related Issues
- Potentially related to #98 (auto_create_execution_role issues)
- Potentially related to #148 (execution role configuration issues)

## Environment
- bedrock-agentcore-starter-toolkit version: 0.2.3
- Region: ap-northeast-1
- Python: 3.12+