### PR TITLE
fix: resolve double-encoded execution policy causing MalformedPolicyD…

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/create_role.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/create_role.py
@@ -130,7 +130,7 @@ def get_or_create_runtime_execution_role(
                 if agent_config and agent_config.memory and agent_config.memory.memory_id:
                     memory_id = agent_config.memory.memory_id
 
-                execution_policy = render_execution_policy_template(
+                execution_policy_json = render_execution_policy_template(
                     region=region,
                     account_id=account_id,
                     agent_name=agent_name,
@@ -139,6 +139,7 @@ def get_or_create_runtime_execution_role(
                     memory_id=memory_id,
                     ecr_repository_name=ecr_repo_name,
                 )
+                execution_policy = validate_rendered_policy(execution_policy_json)
 
                 logger.info("Creating IAM role: %s", role_name)
 


### PR DESCRIPTION
## Description

Fixes the `MalformedPolicyDocumentException` error when auto-creating execution roles during `agentcore launch`.

The bug was introduced in commit e548fc7 (#394) where `render_execution_policy_template()` returns a JSON string, but `json.dumps()` was called on it again before passing to `put_role_policy()`, causing double-encoding:
- Actual: `"{\"Version\": \"2012-10-17\", ...}"`
- Expected: `{"Version": "2012-10-17", ...}`

The fix adds `validate_rendered_policy()` call to convert the JSON string to a dict before `json.dumps()`, consistent with how the trust policy is already handled in the same function.

Fixes #403

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [x] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

Manual testing performed:
1. Built the fixed package locally
2. Deleted existing `AmazonBedrockAgentCoreSDKRuntime-*` roles
3. Ran `agentcore launch` with auto-create role enabled
4. Verified role and inline policy were created successfully
5. Agent deployed successfully to AgentCore Runtime

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

N/A

## Additional Notes

- Added regression test `test_execution_policy_not_double_encoded` to prevent this bug from recurring
- The fix is a minimal one-line change that makes execution policy handling consistent with trust policy handling in the same file
- No documentation changes needed - this is a bug fix for existing functionality
- No additional comments needed in code - the change is self-explanatory and follows the existing pattern in the same file (lines 121-122)