### PR TITLE
fix: preserve file permissions in deployment zip

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/package.py
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/package.py
@@ -475,12 +475,16 @@ class CodeZipPackager:
             if dependencies_zip and dependencies_zip.exists():
                 with zipfile.ZipFile(dependencies_zip, "r") as dep:
                     for item in dep.namelist():
-                        out.writestr(item, dep.read(item))
+                        # Preserve original permissions for dependencies
+                        original_info = dep.getinfo(item)
+                        out.writestr(original_info, dep.read(item))
 
             # Layer 2: Code (overwrites conflicts - user code takes precedence)
             with zipfile.ZipFile(direct_code_deploy, "r") as code:
                 for item in code.namelist():
-                    out.writestr(item, code.read(item))
+                    # Preserve original permissions
+                    original_info = code.getinfo(item)
+                    out.writestr(original_info, code.read(item))
 
     def _get_ignore_patterns(self) -> List[str]:
         """Get ignore patterns from dockerignore.template (matches CodeBuild logic).


### PR DESCRIPTION
- Fix zipfile.writestr() stripping file permissions during merge
- Preserve original ZipInfo objects with external_attr for both dependencies and code layers
- Resolves permission errors when executing entrypoint files in runtime

Fixes issue where files had 600 permissions instead of 644 after zip merge, causing 'Permission denied' errors during module imports and execution.