### PR TITLE
fix: remove default value prefill from prompt inputs

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/_configure_impl.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/_configure_impl.py
@@ -325,7 +325,7 @@ def configure_impl(
         default_idx = str(runtime_options.index(default_runtime) + 1)
 
         while True:
-            choice = prompt(f"Choice [{default_idx}]: ", default=default_idx).strip()
+            choice = prompt(f"Choice [{default_idx}]: ").strip() or default_idx
             if choice in ["1", "2", "3", "4"]:
                 return runtime_options[int(choice) - 1]
             console.print("[red]Invalid choice. Please enter 1-4.[/red]")
@@ -444,7 +444,7 @@ def configure_impl(
             runtime_type = None
         else:
             while True:
-                choice = prompt("Choice [1]: ", default="1").strip()
+                choice = prompt("Choice [1]: ").strip() or "1"
                 if choice in ["1", "2"]:
                     deployment_type = deployment_options[int(choice) - 1][1]
                     break


### PR DESCRIPTION
## Summary

- Fix prompt input showing prefilled default value (e.g., `Choice [1]: 1` instead of `Choice [1]: `)
- The `default` parameter in `prompt_toolkit.prompt()` both sets the fallback value AND prefills the input field, which is confusing UX

## Changes

Changed 2 occurrences in `_configure_impl.py`:
- Deployment type selection (line 447)
- Runtime version selection (line 328)

**Before:**
```python
choice = prompt("Choice [1]: ", default="1").strip()
```

**After:**
```python
choice = prompt("Choice [1]: ").strip() or "1"
```

This keeps the default behavior (pressing Enter uses the default value) while showing a clean empty input field.

## Test plan

- [x] Run `agentcore configure` and verify deployment type selection shows `Choice [1]:` with empty input
- [x] Verify pressing Enter still selects option 1
- [x] Verify entering 2 correctly selects option 2
- [x] Verify runtime selection behaves the same way