### PR TITLE
fix: update 'agentcore launch' to 'agentcore deploy' in Next Steps messages

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/identity/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/identity/commands.py
@@ -832,7 +832,7 @@ def setup_aws_jwt(
                 f"Duration: [cyan]{aws_jwt_config.duration_seconds}s[/cyan]\n\n"
                 f"[bold]Next Steps:[/bold]\n"
                 f"1. Configure your external service to trust this issuer URL\n"
-                f"2. Run [cyan]agentcore launch[/cyan] to deploy (IAM permissions auto-added)\n"
+                f"2. Run [cyan]agentcore deploy[/cyan] to deploy (IAM permissions auto-added)\n"
                 f"3. Use [cyan]@requires_iam_access_token(audience=[...])[/cyan] in your agent",
                 title="✅ Success",
                 border_style="green",

--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/_configure_impl.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/_configure_impl.py
@@ -642,7 +642,7 @@ def configure_impl(
                 f"{lifecycle_info}\n"
                 f"📄 Config saved to: [dim]{result.config_path}[/dim]\n\n"
                 f"[bold]Next Steps:[/bold]\n"
-                f"[cyan]agentcore launch[/cyan]{' [cyan]agentcore create[/cyan]' if create_mode_enabled else ''}",
+                f"[cyan]agentcore deploy[/cyan]{' [cyan]agentcore create[/cyan]' if create_mode_enabled else ''}",
                 title="Configuration Success",
                 border_style="bright_blue",
             )


### PR DESCRIPTION
## Summary
- Update outdated `agentcore launch` command references to `agentcore deploy` in "Next Steps" messages
- Affects the output of `agentcore configure` and `agentcore identity setup-aws-jwt` commands

## Background
The CLI has been transitioning from `agentcore launch` to `agentcore deploy` as the recommended command. The Next Steps messages displayed after configuration should reflect this change to avoid confusing users.

## Changes
- `src/bedrock_agentcore_starter_toolkit/cli/runtime/_configure_impl.py`: Updated Next Steps message
- `src/bedrock_agentcore_starter_toolkit/cli/identity/commands.py`: Updated Next Steps message

## Test plan
- [x] Run `agentcore configure` and verify the Next Steps shows `agentcore deploy`
- [x] Run `agentcore identity setup-aws-jwt` and verify the Next Steps shows `agentcore deploy`