### PR TITLE
feat: add pull command to import agent configuration from deployed runtime

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -20,6 +20,7 @@ from .runtime.commands import (
     deploy,
     destroy,
     invoke,
+    pull,
     status,
     stop_session,
 )
@@ -39,6 +40,7 @@ app.command("invoke")(invoke)
 app.command("status")(status)
 app.command("destroy")(destroy)
 app.command("stop-session")(stop_session)
+app.command("pull")(pull)
 app.add_typer(configure_app)
 
 # Services

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/__init__.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/__init__.py
@@ -16,10 +16,12 @@ from .models import (
     DestroyResult,
     InvokeResult,
     LaunchResult,
+    PullResult,
     StatusConfigInfo,
     StatusResult,
     StopSessionResult,
 )
+from .pull import list_agents_for_pull, pull_agent
 from .status import get_status
 from .stop_session import stop_runtime_session
 
@@ -33,12 +35,15 @@ __all__ = [
     "infer_agent_name",
     "launch_bedrock_agentcore",
     "invoke_bedrock_agentcore",
+    "pull_agent",
+    "list_agents_for_pull",
     "stop_runtime_session",
     "get_status",
     "ConfigureResult",
     "DestroyResult",
     "InvokeResult",
     "LaunchResult",
+    "PullResult",
     "StatusResult",
     "StatusConfigInfo",
     "StopSessionResult",

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/models.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/models.py
@@ -116,3 +116,26 @@ class StopSessionResult(BaseModel):
     agent_name: str = Field(..., description="Name of the agent")
     status_code: int = Field(..., description="HTTP status code of the operation")
     message: str = Field(default="Session stopped successfully", description="Result message")
+
+
+class PullResult(BaseModel):
+    """Result of pull operation."""
+
+    agent_name: str = Field(..., description="Pulled agent name")
+    agent_id: str = Field(..., description="AgentCore agent ID")
+    config_path: Path = Field(..., description="Path to generated configuration file")
+    deployment_type: str = Field(..., description="Deployment type (container or direct_code_deploy)")
+    runtime_type: Optional[str] = Field(None, description="Python runtime version for direct_code_deploy")
+    network_mode: str = Field(..., description="Network mode (PUBLIC or VPC)")
+    protocol: str = Field(default="HTTP", description="Server protocol (HTTP, MCP, or A2A)")
+    region: str = Field(..., description="AWS region")
+
+    # Warning information
+    env_var_keys: List[str] = Field(default_factory=list, description="Environment variable keys (values not imported)")
+    has_memory: bool = Field(default=False, description="Whether agent uses memory")
+    memory_id: Optional[str] = Field(None, description="Memory ID if agent uses memory")
+
+    @property
+    def has_warnings(self) -> bool:
+        """Check if there are any warnings to display."""
+        return len(self.env_var_keys) > 0 or self.has_memory

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/pull.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/pull.py
@@ -1,0 +1,236 @@
+"""Pull operation - pulls agent configuration from deployed AgentCore runtime."""
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+from ...services.runtime import BedrockAgentCoreClient
+from ...utils.runtime.config import save_config
+from ...utils.runtime.schema import (
+    AWSConfig,
+    BedrockAgentCoreAgentSchema,
+    BedrockAgentCoreConfigSchema,
+    BedrockAgentCoreDeploymentInfo,
+    LifecycleConfiguration,
+    NetworkConfiguration,
+    NetworkModeConfig,
+    ProtocolConfiguration,
+)
+from .models import PullResult
+
+log = logging.getLogger(__name__)
+
+
+def pull_agent(
+    region: str,
+    agent_name: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    output_path: Optional[Path] = None,
+    force: bool = False,
+) -> PullResult:
+    """Pull agent configuration from deployed AgentCore runtime.
+
+    Args:
+        region: AWS region where the agent is deployed
+        agent_name: Agent name to pull (mutually exclusive with agent_id)
+        agent_id: Agent ID to pull (mutually exclusive with agent_name)
+        output_path: Output path for configuration file (default: .bedrock_agentcore.yaml)
+        force: Overwrite existing configuration file
+
+    Returns:
+        PullResult with pulled configuration details
+
+    Raises:
+        ValueError: If agent not found or invalid arguments
+        FileExistsError: If configuration file exists and force is False
+    """
+    log.info("Starting agent pull from region: %s", region)
+
+    # Set default output path
+    if output_path is None:
+        output_path = Path.cwd() / ".bedrock_agentcore.yaml"
+
+    # Check if output file already exists
+    if output_path.exists() and not force:
+        raise FileExistsError(
+            f"Configuration file already exists: {output_path}\n"
+            f"Use --force to overwrite."
+        )
+
+    # Initialize AWS client
+    client = BedrockAgentCoreClient(region)
+
+    # Get agent data
+    if agent_id:
+        log.info("Fetching agent by ID: %s", agent_id)
+        agent_data = client.get_agent_runtime(agent_id)
+    elif agent_name:
+        log.info("Searching for agent by name: %s", agent_name)
+        agent_info = client.find_agent_by_name(agent_name)
+        if not agent_info:
+            raise ValueError(f"Agent '{agent_name}' not found in region {region}")
+        agent_data = client.get_agent_runtime(agent_info["agentRuntimeId"])
+    else:
+        raise ValueError("Either agent_name or agent_id must be provided")
+
+    # Convert API response to config schema
+    agent_config, warnings = _convert_to_schema(agent_data, region)
+
+    # Build project config
+    project_config = BedrockAgentCoreConfigSchema(
+        default_agent=agent_config.name,
+        agents={agent_config.name: agent_config},
+    )
+
+    # Save configuration file
+    save_config(project_config, output_path)
+    log.info("Configuration saved to: %s", output_path)
+
+    return PullResult(
+        agent_name=agent_config.name,
+        agent_id=agent_config.bedrock_agentcore.agent_id,
+        config_path=output_path,
+        deployment_type=agent_config.deployment_type,
+        runtime_type=agent_config.runtime_type,
+        network_mode=agent_config.aws.network_configuration.network_mode,
+        protocol=agent_config.aws.protocol_configuration.server_protocol,
+        region=region,
+        env_var_keys=warnings.get("env_var_keys", []),
+        has_memory=warnings.get("has_memory", False),
+        memory_id=warnings.get("memory_id"),
+    )
+
+
+def list_agents_for_pull(region: str) -> list:
+    """List all agents in a region for interactive selection.
+
+    Args:
+        region: AWS region to list agents from
+
+    Returns:
+        List of agent summaries with id, name, status, and created date
+    """
+    client = BedrockAgentCoreClient(region)
+    agents = client.list_agents()
+
+    return [
+        {
+            "id": agent.get("agentRuntimeId"),
+            "name": agent.get("agentRuntimeName"),
+            "status": agent.get("status", "UNKNOWN"),
+            "created_at": agent.get("createdAt"),
+        }
+        for agent in agents
+    ]
+
+
+def _convert_to_schema(agent_data: dict, region: str) -> tuple[BedrockAgentCoreAgentSchema, dict]:
+    """Convert API response to BedrockAgentCoreAgentSchema.
+
+    Args:
+        agent_data: Response from get_agent_runtime API
+        region: AWS region
+
+    Returns:
+        Tuple of (agent_config, warnings_dict)
+    """
+    warnings = {}
+
+    # Extract basic info
+    agent_name = agent_data.get("agentRuntimeName", "pulled_agent")
+    agent_id = agent_data.get("agentRuntimeId")
+    agent_arn = agent_data.get("agentRuntimeArn")
+    role_arn = agent_data.get("roleArn")
+
+    # Extract account ID from ARN
+    account_id = None
+    if agent_arn:
+        # ARN format: arn:aws:bedrock-agentcore:region:account:agent-runtime/id
+        arn_match = re.match(r"arn:aws:bedrock-agentcore:[^:]+:(\d+):", agent_arn)
+        if arn_match:
+            account_id = arn_match.group(1)
+
+    # Determine deployment type and runtime from artifact configuration
+    artifact = agent_data.get("agentRuntimeArtifact", {})
+    deployment_type = "direct_code_deploy"
+    runtime_type = None
+    ecr_repository = None
+
+    if "codeConfiguration" in artifact:
+        deployment_type = "direct_code_deploy"
+        code_config = artifact["codeConfiguration"]
+        runtime_type = code_config.get("runtime", "PYTHON_3_11")
+    elif "containerConfiguration" in artifact:
+        deployment_type = "container"
+        container_config = artifact["containerConfiguration"]
+        container_uri = container_config.get("containerUri", "")
+        # Extract ECR repository from URI (remove tag)
+        if container_uri:
+            ecr_repository = container_uri.split(":")[0] if ":" in container_uri else container_uri
+
+    # Extract network configuration
+    network_data = agent_data.get("networkConfiguration", {})
+    network_mode = network_data.get("networkMode", "PUBLIC")
+    network_mode_config = None
+
+    if network_mode == "VPC":
+        mode_config_data = network_data.get("networkModeConfig", {})
+        network_mode_config = NetworkModeConfig(
+            subnets=mode_config_data.get("subnets", []),
+            security_groups=mode_config_data.get("securityGroups", []),
+        )
+
+    network_configuration = NetworkConfiguration(
+        network_mode=network_mode,
+        network_mode_config=network_mode_config,
+    )
+
+    # Extract protocol configuration
+    protocol_data = agent_data.get("protocolConfiguration", {})
+    protocol = protocol_data.get("serverProtocol", "HTTP")
+    protocol_configuration = ProtocolConfiguration(server_protocol=protocol)
+
+    # Extract lifecycle configuration
+    lifecycle_data = agent_data.get("lifecycleConfiguration", {})
+    lifecycle_configuration = LifecycleConfiguration(
+        idle_runtime_session_timeout=lifecycle_data.get("idleRuntimeSessionTimeout"),
+        max_lifetime=lifecycle_data.get("maxLifetime"),
+    )
+
+    # Check for environment variables (warning: values not available)
+    env_vars = agent_data.get("environmentVariables", {})
+    if env_vars:
+        warnings["env_var_keys"] = list(env_vars.keys())
+        log.warning("Environment variables detected but values cannot be pulled: %s", list(env_vars.keys()))
+
+    # Check for memory configuration (warning: not pulled)
+    memory_config = agent_data.get("memoryConfiguration", {})
+    memory_id = memory_config.get("memoryId")
+    if memory_id:
+        warnings["has_memory"] = True
+        warnings["memory_id"] = memory_id
+        log.warning("Memory configuration detected but not pulled: %s", memory_id)
+
+    # Build agent config with placeholder entrypoint
+    agent_config = BedrockAgentCoreAgentSchema(
+        name=agent_name,
+        entrypoint="TODO:set_with_configure",  # Must be set by user
+        deployment_type=deployment_type,
+        runtime_type=runtime_type,
+        aws=AWSConfig(
+            execution_role=role_arn,
+            account=account_id,
+            region=region,
+            ecr_repository=ecr_repository,
+            network_configuration=network_configuration,
+            protocol_configuration=protocol_configuration,
+            lifecycle_configuration=lifecycle_configuration,
+        ),
+        bedrock_agentcore=BedrockAgentCoreDeploymentInfo(
+            agent_id=agent_id,
+            agent_arn=agent_arn,
+        ),
+    )
+
+    return agent_config, warnings


### PR DESCRIPTION
## Summary

Add `agentcore pull` command to retrieve configuration from already deployed AgentCore Runtime agents and generate a local `.bedrock_agentcore.yaml` file.

This command enables:
- Replicating an agent configuration to a new environment
- Making modifications to a deployed agent and redeploying
- Sharing agent configurations between team members

## Features

- Pull by agent name (`--agent-name`) or agent ID (`--agent-id`)
- Interactive mode to list and select from deployed agents when neither name nor ID is specified
- Display warnings for environment variables (keys only - values cannot be pulled for security)
- Display warnings for memory configuration (not automatically configured)
- Force overwrite existing configuration with `--force` flag

## Usage Examples

```bash
# Pull by agent name
agentcore pull --agent-name my_agent --region us-east-1

# Pull by agent ID
agentcore pull --agent-id abc123xyz --region us-east-1

# Interactive mode (list and select)
agentcore pull --region us-east-1

# Force overwrite existing config
agentcore pull --agent-name my_agent --region us-east-1 --force
```

## Constraints

- **Environment variables**: Only keys are pulled (values are not available via API). Users need to set values with `agentcore deploy --env KEY=value`
- **Entrypoint**: Must be set manually after pull with `agentcore configure --entrypoint <file>`
- **Memory**: Memory configuration is not automatically set up. Users need to configure with `agentcore configure --memory-mode`

## Test Plan

- [x] `agentcore pull --help` displays properly
- [x] Pull by agent name works correctly
- [x] Interactive mode lists agents correctly
- [x] Warning displayed for agents with environment variables
- [x] Warning displayed for agents with memory configuration

**Note**: To run tests locally, you need PR #421 to be merged first (typer Literal type fix), or cherry-pick that fix to your local branch.