### PR TITLE
feat: add Slack notification workflow for new issues

### DIFF
--- a/.github/workflows/slack-issue-notification.yml
+++ b/.github/workflows/slack-issue-notification.yml
@@ -4,24 +4,22 @@ on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
   notify-slack:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Slack notification
+      - name: Send issue details to Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
-            {
-              "text": "New Issue Created",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*New Issue:* <${{ github.event.issue.html_url }}|#${{ github.event.issue.number }} ${{ github.event.issue.title }}>\n*Repository:* ${{ github.repository }}\n*Author:* ${{ github.event.issue.user.login }}\n*Created:* ${{ github.event.issue.created_at }}\n\n${{ github.event.issue.body }}"
-                  }
-                }
-              ]
-            }
+            issue_title: "${{ github.event.issue.title }}"
+            issue_number: "${{ github.event.issue.number }}"
+            issue_url: "${{ github.event.issue.html_url }}"
+            issue_author: "${{ github.event.issue.user.login }}"
+            issue_body: "${{ github.event.issue.body }}"
+            repository: "${{ github.repository }}"
+            created_at: "${{ github.event.issue.created_at }}"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically sends notifications to Slack when new issues are created
- Uses the official Slack GitHub Action (slackapi/slack-github-action@v2.0.0)
- Includes issue metadata: title, number, URL, author, body, repository name, and timestamp

## Test plan
- [ ] Configure SLACK_WEBHOOK_URL secret in repository settings
- [ ] Create a test issue to verify the Slack notification is sent
- [ ] Verify the notification includes all expected metadata