### PR TITLE
Add trailing slash to namespace strings

### DIFF
--- a/documentation/docs/examples/memory_gateway_agent.md
+++ b/documentation/docs/examples/memory_gateway_agent.md
@@ -183,12 +183,12 @@ ltm = client.create_memory_and_wait(
         # Extracts user preferences like "I prefer Python"
         {"userPreferenceMemoryStrategy": {
             "name": "prefs",
-            "namespaces": ["/user/preferences"]
+            "namespaces": ["/user/preferences/"]
         }},
         # Extracts facts like "My birthday is in January"
         {"semanticMemoryStrategy": {
             "name": "facts",
-            "namespaces": ["/user/facts"]
+            "namespaces": ["/user/facts/"]
         }}
     ],
     event_expiry_days=30  # Keep for 30 days

--- a/documentation/docs/examples/semantic_search.md
+++ b/documentation/docs/examples/semantic_search.md
@@ -21,7 +21,7 @@ memory = memory_manager.get_or_create_memory(
     strategies=[
         SemanticStrategy(
             name="semanticLongTermMemory",
-            namespaces=['/strategies/{memoryStrategyId}/actors/{actorId}'],
+            namespaces=['/strategies/{memoryStrategyId}/actors/{actorId}/'],
         )
     ]
 )

--- a/documentation/docs/user-guide/import-agent/design.md
+++ b/documentation/docs/user-guide/import-agent/design.md
@@ -92,7 +92,7 @@ In AgentCore Memory, the utility implements a similar memory model using a summa
 {
     "summaryMemoryStrategy": {
         "name": "SessionSummarizer",
-        "namespaces": ["/summaries/{actorId}/{sessionId}"],
+        "namespaces": ["/summaries/{actorId}/{sessionId}/"],
     }
 }
 ```

--- a/documentation/docs/user-guide/memory/quickstart.md
+++ b/documentation/docs/user-guide/memory/quickstart.md
@@ -59,7 +59,7 @@ memory = memory_manager.get_or_create_memory(
     strategies=[
         SemanticStrategy(
             name="semanticLongTermMemory",
-            namespaces=['/strategies/{memoryStrategyId}/actors/{actorId}'],
+            namespaces=['/strategies/{memoryStrategyId}/actors/{actorId}/'],
         )
     ]
 )

--- a/src/bedrock_agentcore_starter_toolkit/create/features/terraform/templates/monorepo/bedrock_agentcore.tf.j2
+++ b/src/bedrock_agentcore_starter_toolkit/create/features/terraform/templates/monorepo/bedrock_agentcore.tf.j2
@@ -373,21 +373,21 @@ resource "aws_bedrockagentcore_memory" "agentcore_memory" {
 resource "aws_bedrockagentcore_memory_strategy" "user_preference_memory_strategy" {
   memory_id  = aws_bedrockagentcore_memory.agentcore_memory.id
   name       = "UserPreferences"
-  namespaces = ["/users/{actorId}/preferences"]
+  namespaces = ["/users/{actorId}/preferences/"]
   type       = "USER_PREFERENCE"
 }
 
 resource "aws_bedrockagentcore_memory_strategy" "semantic_memory_strategy" {
   memory_id  = aws_bedrockagentcore_memory.agentcore_memory.id
   name       = "SemanticFacts"
-  namespaces = ["/users/{actorId}/facts"]
+  namespaces = ["/users/{actorId}/facts/"]
   type       = "SEMANTIC"
 }
 
 resource "aws_bedrockagentcore_memory_strategy" "summary_memory_strategy" {
   memory_id  = aws_bedrockagentcore_memory.agentcore_memory.id
   name       = "SessionSummaries"
-  namespaces = ["/summaries/{actorId}/{sessionId}"]
+  namespaces = ["/summaries/{actorId}/{sessionId}/"]
   type       = "SUMMARIZATION"
 }
 {%- else %}

--- a/src/bedrock_agentcore_starter_toolkit/operations/memory/README.md
+++ b/src/bedrock_agentcore_starter_toolkit/operations/memory/README.md
@@ -99,7 +99,7 @@ manager = MemoryManager(region_name="us-east-1")
 semantic_strategy = SemanticStrategy(
     name="ConversationSemantics",
     description="Extract semantic information from conversations",
-    namespaces=["semantics/{actorId}/{sessionId}"]
+    namespaces=["semantics/{actorId}/{sessionId}/"]
 )
 
 memory = manager.create_memory_and_wait(
@@ -233,7 +233,7 @@ from bedrock_agentcore_starter_toolkit.operations.memory.models import SummarySt
 summary = SummaryStrategy(
     name="ConversationSummary",
     description="Summarize conversations",
-    namespaces=["summaries/{actorId}/{sessionId}"]
+    namespaces=["summaries/{actorId}/{sessionId}/"]
 )
 
 memory = manager.add_strategy_and_wait(
@@ -278,7 +278,7 @@ memory = manager.update_memory_strategies_and_wait(
 modify_configs = [{
     "strategyId": "strat-456",
     "description": "Updated description",
-    "namespaces": ["updated/{actorId}"]
+    "namespaces": ["updated/{actorId}/"]
 }]
 
 memory = manager.update_memory_strategies_and_wait(
@@ -309,7 +309,7 @@ memory = manager.modify_strategy(
     memory_id="mem-123",
     strategy_id="strat-456",
     description="Updated strategy description",
-    namespaces=["custom/{actorId}/{sessionId}"]
+    namespaces=["custom/{actorId}/{sessionId}/"]
 )
 
 # Update strategy configuration
@@ -343,7 +343,7 @@ memory = manager.add_semantic_strategy_and_wait(
     memory_id="mem-123",
     name="ConversationSemantics",
     description="Extract semantic information",
-    namespaces=["semantics/{actorId}/{sessionId}"]
+    namespaces=["semantics/{actorId}/{sessionId}/"]
 )
 ```
 
@@ -352,7 +352,7 @@ memory = manager.add_summary_strategy_and_wait(
     memory_id="mem-123",
     name="ConversationSummary",
     description="Summarize conversations",
-    namespaces=["summaries/{actorId}/{sessionId}"]
+    namespaces=["summaries/{actorId}/{sessionId}/"]
 )
 ```
 
@@ -361,7 +361,7 @@ memory = manager.add_user_preference_strategy_and_wait(
     memory_id="mem-123",
     name="UserPreferences",
     description="Store user preferences",
-    namespaces=["preferences/{actorId}"]
+    namespaces=["preferences/{actorId}/"]
 )
 ```
 
@@ -400,7 +400,7 @@ semantic = SemanticStrategy(
 semantic = SemanticStrategy(
     name="ConversationSemantics",
     description="Extract semantic information from conversations",
-    namespaces=["semantics/{actorId}/{sessionId}"]
+    namespaces=["semantics/{actorId}/{sessionId}/"]
 )
 
 # Add to memory
@@ -422,7 +422,7 @@ summary = SummaryStrategy(
 summary = SummaryStrategy(
     name="ConversationSummary",
     description="Summarize conversation content",
-    namespaces=["summaries/{actorId}/{sessionId}"]
+    namespaces=["summaries/{actorId}/{sessionId}/"]
 )
 
 # Add to memory
@@ -438,7 +438,7 @@ from bedrock_agentcore_starter_toolkit.operations.memory.models import UserPrefe
 user_pref = UserPreferenceStrategy(
     name="UserPreferences",
     description="Store user preferences and settings",
-    namespaces=["preferences/{actorId}"]  # Note: typically per-actor, not per-session
+    namespaces=["preferences/{actorId}/"]  # Note: typically per-actor, not per-session
 )
 
 # Add to memory
@@ -469,7 +469,7 @@ custom = CustomSemanticStrategy(
     description="Extract and consolidate business insights",
     extraction_config=extraction_config,
     consolidation_config=consolidation_config,
-    namespaces=["business/{actorId}/{sessionId}"]
+    namespaces=["business/{actorId}/{sessionId}/"]
 )
 
 # Add to memory
@@ -486,7 +486,7 @@ semantic = {
     "semanticMemoryStrategy": {
         "name": "SemanticStrategy",
         "description": "dictionary-based strategy",
-        "namespaces": ["business/{actorId}/{sessionId}"]
+        "namespaces": ["business/{actorId}/{sessionId}/"]
     }
 }
 
@@ -519,11 +519,11 @@ Namespaces support template variables for dynamic organization:
 ```python
 # Available template variables
 namespaces = [
-    "global/shared",                   # Static namespace
-    "actor/{actorId}",                 # Per-actor namespace
-    "session/{actorId}/{sessionId}",   # Per-session namespace
-    "strategy/{strategyId}",           # Per-strategy namespace
-    "custom/{actorId}/{sessionId}"     # Custom pattern
+    "global/shared/",                   # Static namespace
+    "actor/{actorId}/",                 # Per-actor namespace
+    "session/{actorId}/{sessionId}/",   # Per-session namespace
+    "strategy/{strategyId}/",           # Per-strategy namespace
+    "custom/{actorId}/{sessionId}/"     # Custom pattern
 ]
 
 strategy = SemanticStrategy(
@@ -788,7 +788,7 @@ memory = manager.add_strategy(memory_id, new_strategy)  # May leave memory in CR
 semantic = SemanticStrategy(
     name="CustomerSupportSemantics",
     description="Extract semantic information from customer support conversations",
-    namespaces=["support/semantics/{actorId}/{sessionId}"]
+    namespaces=["support/semantics/{actorId}/{sessionId}/"]
 )
 
 # ❌ Avoid: Generic names
@@ -831,18 +831,18 @@ memory = manager.get_or_create_memory(
 conversation_strategies = [
     SemanticStrategy(
         name="ConversationSemantics",
-        namespaces=["conversation/semantics/{actorId}/{sessionId}"]
+        namespaces=["conversation/semantics/{actorId}/{sessionId}/"]
     ),
     SummaryStrategy(
         name="ConversationSummary",
-        namespaces=["conversation/summaries/{actorId}/{sessionId}"]
+        namespaces=["conversation/summaries/{actorId}/{sessionId}/"]
     )
 ]
 
 user_strategies = [
     UserPreferenceStrategy(
         name="UserPreferences",
-        namespaces=["user/preferences/{actorId}"]
+        namespaces=["user/preferences/{actorId}/"]
     )
 ]
 

--- a/src/bedrock_agentcore_starter_toolkit/operations/memory/models/__init__.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/memory/models/__init__.py
@@ -17,7 +17,7 @@ Example:
     semantic_strategy = SemanticStrategy(
         name="ConversationSemantics",
         description="Extract semantic information",
-        namespaces=["semantics/{actorId}/{sessionId}"]
+        namespaces=["semantics/{actorId}/{sessionId}/"]
     )
 
     custom_strategy = CustomSemanticStrategy(

--- a/src/bedrock_agentcore_starter_toolkit/operations/memory/models/strategies/custom.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/memory/models/strategies/custom.py
@@ -29,7 +29,7 @@ class CustomSemanticStrategy(BaseStrategy):
                 append_to_prompt="Consolidate business insights",
                 model_id="anthropic.claude-3-haiku-20240307-v1:0"
             ),
-            namespaces=["custom/{actorId}/{sessionId}"]
+            namespaces=["custom/{actorId}/{sessionId}/"]
         )
     """
 
@@ -91,7 +91,7 @@ class CustomSummaryStrategy(BaseStrategy):
                 append_to_prompt="Consolidate business insights",
                 model_id="anthropic.claude-3-haiku-20240307-v1:0"
             ),
-            namespaces=["custom/{actorId}/{sessionId}"]
+            namespaces=["custom/{actorId}/{sessionId}/"]
         )
     """
 
@@ -148,7 +148,7 @@ class CustomUserPreferenceStrategy(BaseStrategy):
                 append_to_prompt="Consolidate business insights",
                 model_id="anthropic.claude-3-haiku-20240307-v1:0"
             ),
-            namespaces=["custom/{actorId}/{sessionId}"]
+            namespaces=["custom/{actorId}/{sessionId}/"]
         )
     """
 

--- a/src/bedrock_agentcore_starter_toolkit/operations/memory/models/strategies/semantic.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/memory/models/strategies/semantic.py
@@ -16,7 +16,7 @@ class SemanticStrategy(BaseStrategy):
         strategy = SemanticStrategy(
             name="ConversationSemantics",
             description="Extract semantic information from conversations",
-            namespaces=["semantics/{actorId}/{sessionId}"]
+            namespaces=["semantics/{actorId}/{sessionId}/"]
         )
     """
 

--- a/src/bedrock_agentcore_starter_toolkit/operations/memory/models/strategies/summary.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/memory/models/strategies/summary.py
@@ -16,7 +16,7 @@ class SummaryStrategy(BaseStrategy):
         strategy = SummaryStrategy(
             name="ConversationSummary",
             description="Summarize conversation content",
-            namespaces=["summaries/{actorId}/{sessionId}"]
+            namespaces=["summaries/{actorId}/{sessionId}/"]
         )
     """
 

--- a/src/bedrock_agentcore_starter_toolkit/operations/memory/models/strategies/user_preference.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/memory/models/strategies/user_preference.py
@@ -15,7 +15,7 @@ class UserPreferenceStrategy(BaseStrategy):
         strategy = UserPreferenceStrategy(
             name="UserPreferences",
             description="Store user preferences and settings",
-            namespaces=["preferences/{actorId}"]
+            namespaces=["preferences/{actorId}/"]
         )
     """
 

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -413,19 +413,19 @@ def _ensure_memory_for_agent(
                         {
                             StrategyType.USER_PREFERENCE.value: {
                                 "name": "UserPreferences",
-                                "namespaces": ["/users/{actorId}/preferences"],
+                                "namespaces": ["/users/{actorId}/preferences/"],
                             }
                         },
                         {
                             StrategyType.SEMANTIC.value: {
                                 "name": "SemanticFacts",
-                                "namespaces": ["/users/{actorId}/facts"],
+                                "namespaces": ["/users/{actorId}/facts/"],
                             }
                         },
                         {
                             StrategyType.SUMMARY.value: {
                                 "name": "SessionSummaries",
-                                "namespaces": ["/summaries/{actorId}/{sessionId}"],
+                                "namespaces": ["/summaries/{actorId}/{sessionId}/"],
                             }
                         },
                     ],
@@ -457,19 +457,19 @@ def _ensure_memory_for_agent(
                     {
                         StrategyType.USER_PREFERENCE.value: {
                             "name": "UserPreferences",
-                            "namespaces": ["/users/{actorId}/preferences"],
+                            "namespaces": ["/users/{actorId}/preferences/"],
                         }
                     },
                     {
                         StrategyType.SEMANTIC.value: {
                             "name": "SemanticFacts",
-                            "namespaces": ["/users/{actorId}/facts"],
+                            "namespaces": ["/users/{actorId}/facts/"],
                         }
                     },
                     {
                         StrategyType.SUMMARY.value: {
                             "name": "SessionSummaries",
-                            "namespaces": ["/summaries/{actorId}/{sessionId}"],
+                            "namespaces": ["/summaries/{actorId}/{sessionId}/"],
                         }
                     },
                 ]

--- a/src/bedrock_agentcore_starter_toolkit/services/import_agent/scripts/base_bedrock_translate.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/import_agent/scripts/base_bedrock_translate.py
@@ -303,7 +303,7 @@ class BaseBedrockTranslator:
                     {
                         "summaryMemoryStrategy": {
                             "name": "SessionSummarizer",
-                            "namespaces": ["/summaries/{actorId}/{sessionId}"],
+                            "namespaces": ["/summaries/{actorId}/{sessionId}/"],
                         }
                     }
                 ],

--- a/src/bedrock_agentcore_starter_toolkit/services/import_agent/scripts/bedrock_to_langchain.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/import_agent/scripts/bedrock_to_langchain.py
@@ -196,7 +196,7 @@ class BedrockLangchainTranslation(BaseBedrockTranslator):
                 "memory_synopsis = memory_manager.get_memory_synopsis()"
                 if not self.agentcore_memory_enabled
                 else """
-            memories = memory_client.retrieve_memories(memory_id=memory_id, namespace=f'/summaries/{user_id}', query="Retrieve the most recent session sumamries.", actor_id=user_id, top_k=20)
+            memories = memory_client.retrieve_memories(memory_id=memory_id, namespace=f'/summaries/{user_id}/', query="Retrieve the most recent session sumamries.", actor_id=user_id, top_k=20)
             memory_synopsis = "\\n".join([m.get("content", {}).get("text", "") for m in memories])
 """
             )

--- a/src/bedrock_agentcore_starter_toolkit/services/import_agent/scripts/bedrock_to_strands.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/import_agent/scripts/bedrock_to_strands.py
@@ -180,7 +180,7 @@ class BedrockStrandsTranslation(BaseBedrockTranslator):
                 "memory_synopsis = memory_manager.get_memory_synopsis()"
                 if not self.agentcore_memory_enabled
                 else """
-            memories = memory_client.retrieve_memories(memory_id=memory_id, namespace=f'/summaries/{user_id}', query="Retrieve the most recent session sumamries.", top_k=20)
+            memories = memory_client.retrieve_memories(memory_id=memory_id, namespace=f'/summaries/{user_id}/', query="Retrieve the most recent session sumamries.", top_k=20)
             memory_synopsis = "\\n".join([m.get("content", {}).get("text", "") for m in memories])
 """
             )

--- a/tests/cli/memory/test_commands.py
+++ b/tests/cli/memory/test_commands.py
@@ -285,7 +285,7 @@ class TestShowRecordsCommand:
         mock_config.return_value = {"memory_id": "mem-123", "region": "us-east-1"}
         mock_manager_class.return_value = MagicMock()
 
-        result = runner.invoke(show_app, ["records", "--all", "--namespace", "/test"])
+        result = runner.invoke(show_app, ["records", "--all", "--namespace", "/test/"])
 
         assert result.exit_code == 1
         assert "Use --namespace without --all" in result.output
@@ -329,7 +329,7 @@ class TestShowRecordsCommand:
         mock_visualizer = MagicMock()
         mock_visualizer_class.return_value = mock_visualizer
 
-        result = runner.invoke(show_app, ["records", "--namespace", "/test", "--query", "search term"])
+        result = runner.invoke(show_app, ["records", "--namespace", "/test/", "--query", "search term"])
 
         assert result.exit_code == 0
         mock_manager.search_records.assert_called_once()
@@ -527,7 +527,7 @@ class TestShowRecordsEdgeCases:
         mock_manager_class.return_value = mock_manager
         mock_manager.search_records.return_value = []
 
-        result = runner.invoke(show_app, ["records", "--namespace", "/test", "--query", "nonexistent"])
+        result = runner.invoke(show_app, ["records", "--namespace", "/test/", "--query", "nonexistent"])
 
         assert result.exit_code == 0
         assert "No matching records" in result.output
@@ -588,17 +588,17 @@ class TestCollectAllRecords:
         manager = MagicMock()
         manager.list_records.return_value = [{"memoryRecordId": "r1", "content": {"text": "test"}}]
 
-        records = _collect_all_records(manager, "mem-123", "/test", 10)
+        records = _collect_all_records(manager, "mem-123", "/test/", 10)
 
         assert len(records) == 1
-        assert records[0]["_namespace"] == "/test"
+        assert records[0]["_namespace"] == "/test/"
 
     def test_collect_records_all_namespaces(self):
         """Test collecting records from all namespaces."""
         from bedrock_agentcore_starter_toolkit.cli.memory.commands import _collect_all_records
 
         manager = MagicMock()
-        manager.get_memory.return_value = {"strategies": [{"name": "Facts", "namespaces": ["/facts"]}]}
+        manager.get_memory.return_value = {"strategies": [{"name": "Facts", "namespaces": ["/facts/"]}]}
         manager.list_records.return_value = [{"memoryRecordId": "r1"}]
         manager.list_actors.return_value = []
 
@@ -618,7 +618,7 @@ class TestCollectRecordsFromNamespaceTemplate:
         manager.list_records.return_value = [{"memoryRecordId": "r1"}]
         all_records = []
 
-        _collect_records_from_namespace_template(manager, "mem-123", "/facts", 10, all_records)
+        _collect_records_from_namespace_template(manager, "mem-123", "/facts/", 10, all_records)
 
         assert len(all_records) == 1
 
@@ -631,7 +631,7 @@ class TestCollectRecordsFromNamespaceTemplate:
         manager.list_records.return_value = [{"memoryRecordId": "r1"}]
         all_records = []
 
-        _collect_records_from_namespace_template(manager, "mem-123", "/users/{actorId}/facts", 10, all_records)
+        _collect_records_from_namespace_template(manager, "mem-123", "/users/{actorId}/facts/", 10, all_records)
 
         assert len(all_records) == 1
 
@@ -646,7 +646,7 @@ class TestCollectRecordsFromNamespaceTemplate:
         all_records = []
 
         _collect_records_from_namespace_template(
-            manager, "mem-123", "/users/{actorId}/sessions/{sessionId}", 10, all_records
+            manager, "mem-123", "/users/{actorId}/sessions/{sessionId}/", 10, all_records
         )
 
         assert len(all_records) == 1
@@ -659,7 +659,7 @@ class TestCollectRecordsFromNamespaceTemplate:
         manager.list_actors.side_effect = Exception("API error")
         all_records = []
 
-        _collect_records_from_namespace_template(manager, "mem-123", "/users/{actorId}/facts", 10, all_records)
+        _collect_records_from_namespace_template(manager, "mem-123", "/users/{actorId}/facts/", 10, all_records)
 
         assert len(all_records) == 0
 
@@ -675,10 +675,10 @@ class TestTryCollectRecords:
         manager.list_records.return_value = [{"memoryRecordId": "r1"}]
         all_records = []
 
-        _try_collect_records(manager, "mem-123", "/test", 10, all_records)
+        _try_collect_records(manager, "mem-123", "/test/", 10, all_records)
 
         assert len(all_records) == 1
-        assert all_records[0]["_namespace"] == "/test"
+        assert all_records[0]["_namespace"] == "/test/"
 
     def test_error_handling(self):
         """Test error handling in record collection."""
@@ -688,7 +688,7 @@ class TestTryCollectRecords:
         manager.list_records.side_effect = Exception("API error")
         all_records = []
 
-        _try_collect_records(manager, "mem-123", "/test", 10, all_records)
+        _try_collect_records(manager, "mem-123", "/test/", 10, all_records)
 
         assert len(all_records) == 0
 

--- a/tests/client/test_memory.py
+++ b/tests/client/test_memory.py
@@ -370,7 +370,7 @@ class TestMemoryShowRecords:
         mem = Memory(memory_id="mem-123")
 
         with pytest.raises(ValueError, match="Use namespace without all"):
-            mem.show_records(all=True, namespace="/some/path")
+            mem.show_records(all=True, namespace="/some/path/")
 
     @patch("bedrock_agentcore_starter_toolkit.notebook.memory.memory._resolve_memory_config")
     def test_show_records_namespace_only(self, mock_resolve):
@@ -384,10 +384,11 @@ class TestMemoryShowRecords:
 
         mem = Memory(memory_id="mem-123")
         mem.visualizer = mock_visualizer
-        result = mem.show_records(namespace="/test/ns")
+        result = mem.show_records(namespace="/test/ns/")
 
         assert len(result) == 1
-        mock_manager.list_records.assert_called_once_with("mem-123", "/test/ns", 10)
+        # Namespace is passed through as-is
+        mock_manager.list_records.assert_called_once_with("mem-123", "/test/ns/", 10)
 
     @patch("bedrock_agentcore_starter_toolkit.notebook.memory.memory._resolve_memory_config")
     def test_show_records_query_requires_namespace(self, mock_resolve):
@@ -413,10 +414,11 @@ class TestMemoryShowRecords:
 
         mem = Memory(memory_id="mem-123")
         mem.visualizer = mock_visualizer
-        result = mem.show_records(namespace="/test", query="search term")
+        result = mem.show_records(namespace="/test/", query="search term")
 
         assert len(result) == 1
-        mock_manager.search_records.assert_called_once_with("mem-123", "/test", "search term", 10)
+        # Namespace is passed through as-is
+        mock_manager.search_records.assert_called_once_with("mem-123", "/test/", "search term", 10)
 
     @patch("bedrock_agentcore_starter_toolkit.notebook.memory.memory._resolve_memory_config")
     def test_show_records_query_no_results(self, mock_resolve):
@@ -430,7 +432,7 @@ class TestMemoryShowRecords:
 
         mem = Memory(memory_id="mem-123")
         mem.visualizer = mock_visualizer
-        result = mem.show_records(namespace="/test", query="no match")
+        result = mem.show_records(namespace="/test/", query="no match")
 
         assert result == []
         mock_visualizer.display_search_results.assert_not_called()

--- a/tests/operations/memory/test_formatters.py
+++ b/tests/operations/memory/test_formatters.py
@@ -61,11 +61,11 @@ class TestFormatNamespaces:
         assert format_namespaces([]) == "[dim]None[/dim]"
 
     def test_format_namespaces_single(self):
-        assert format_namespaces(["/users/{actorId}"]) == "/users/{actorId}"
+        assert format_namespaces(["/users/{actorId}/"]) == "/users/{actorId}/"
 
     def test_format_namespaces_multiple(self):
-        result = format_namespaces(["/a", "/b"])
-        assert result == "/a, /b"
+        result = format_namespaces(["/a/", "/b/"])
+        assert result == "/a/, /b/"
 
 
 class TestFormatMemoryAge:

--- a/tests/operations/memory/test_manager.py
+++ b/tests/operations/memory/test_manager.py
@@ -544,7 +544,7 @@ def test_add_user_preference_strategy():
                 memory_id="mem-456",
                 name="Test User Preference Strategy",
                 description="User preference test description",
-                namespaces=["preferences/{actorId}"],
+                namespaces=["preferences/{actorId}/"],
             )
 
             assert mock_control_plane_client.update_memory.called
@@ -564,7 +564,7 @@ def test_add_user_preference_strategy():
             user_pref_config = strategy["userPreferenceMemoryStrategy"]
             assert user_pref_config["name"] == "Test User Preference Strategy"
             assert user_pref_config["description"] == "User preference test description"
-            assert user_pref_config["namespaces"] == ["preferences/{actorId}"]
+            assert user_pref_config["namespaces"] == ["preferences/{actorId}/"]
 
             # Verify client token and memory ID
             assert kwargs["memoryId"] == "mem-456"
@@ -600,7 +600,7 @@ def test_add_custom_semantic_strategy():
                 extraction_config=extraction_config,
                 consolidation_config=consolidation_config,
                 description="Custom semantic strategy test description",
-                namespaces=["custom/{actorId}/{sessionId}"],
+                namespaces=["custom/{actorId}/{sessionId}/"],
             )
 
             assert mock_control_plane_client.update_memory.called
@@ -620,7 +620,7 @@ def test_add_custom_semantic_strategy():
             custom_config = strategy["customMemoryStrategy"]
             assert custom_config["name"] == "Test Custom Semantic Strategy"
             assert custom_config["description"] == "Custom semantic strategy test description"
-            assert custom_config["namespaces"] == ["custom/{actorId}/{sessionId}"]
+            assert custom_config["namespaces"] == ["custom/{actorId}/{sessionId}/"]
 
             # Verify the semantic override configuration
             assert "configuration" in custom_config
@@ -966,7 +966,7 @@ def test_modify_strategy():
                 memory_id="mem-123",
                 strategy_id="strat-789",
                 description="Modified description",
-                namespaces=["custom/namespace"],
+                namespaces=["custom/namespace/"],
             )
 
             assert mock_control_plane_client.update_memory.called
@@ -981,7 +981,7 @@ def test_modify_strategy():
             modified_strategy = kwargs["memoryStrategies"]["modifyMemoryStrategies"][0]
             assert modified_strategy["strategyId"] == "strat-789"
             assert modified_strategy["description"] == "Modified description"
-            assert modified_strategy["namespaces"] == ["custom/namespace"]
+            assert modified_strategy["namespaces"] == ["custom/namespace/"]
 
 
 def test_add_semantic_strategy_and_wait():
@@ -1435,14 +1435,14 @@ def test_validate_namespace():
         manager = MemoryManager(region_name="us-east-1")
 
         # Test valid namespaces
-        assert manager._validate_namespace("custom/{actorId}/{sessionId}")
-        assert manager._validate_namespace("preferences/{actorId}")
-        assert manager._validate_namespace("strategy/{strategyId}")
-        assert manager._validate_namespace("simple/namespace")
+        assert manager._validate_namespace("custom/{actorId}/{sessionId}/")
+        assert manager._validate_namespace("preferences/{actorId}/")
+        assert manager._validate_namespace("strategy/{strategyId}/")
+        assert manager._validate_namespace("simple/namespace/")
 
         # Test namespace with invalid template variables (should log warning)
         with patch("bedrock_agentcore_starter_toolkit.operations.memory.manager.logger") as mock_logger:
-            assert manager._validate_namespace("invalid/{unknownVar}")
+            assert manager._validate_namespace("invalid/{unknownVar}/")
             mock_logger.warning.assert_called_once()
 
 
@@ -1456,7 +1456,7 @@ def test_validate_strategy_config():
             strategy = {
                 "semanticMemoryStrategy": {
                     "name": "Test Strategy",
-                    "namespaces": ["custom/{actorId}", "preferences/{sessionId}"],
+                    "namespaces": ["custom/{actorId}/", "preferences/{sessionId}/"],
                 }
             }
 
@@ -1464,8 +1464,8 @@ def test_validate_strategy_config():
 
             # Should validate each namespace
             assert mock_validate.call_count == 2
-            mock_validate.assert_any_call("custom/{actorId}")
-            mock_validate.assert_any_call("preferences/{sessionId}")
+            mock_validate.assert_any_call("custom/{actorId}/")
+            mock_validate.assert_any_call("preferences/{sessionId}/")
 
 
 def test_check_strategies_terminal_state():
@@ -2062,10 +2062,10 @@ def test_validate_namespace_with_invalid_template():
 
         # Test namespace with invalid template variables (should log warning)
         with patch("bedrock_agentcore_starter_toolkit.operations.memory.manager.logger") as mock_logger:
-            result = manager._validate_namespace("invalid/{unknownVar}")
+            result = manager._validate_namespace("invalid/{unknownVar}/")
             assert result
             mock_logger.warning.assert_called_once_with(
-                "Namespace with templates should contain valid variables: %s", "invalid/{unknownVar}"
+                "Namespace with templates should contain valid variables: %s", "invalid/{unknownVar}/"
             )
 
 
@@ -2079,7 +2079,7 @@ def test_validate_strategy_config_with_namespaces():
             strategy = {
                 "semanticMemoryStrategy": {
                     "name": "Test Strategy",
-                    "namespaces": ["custom/{actorId}", "preferences/{sessionId}"],
+                    "namespaces": ["custom/{actorId}/", "preferences/{sessionId}/"],
                 }
             }
 
@@ -2087,8 +2087,8 @@ def test_validate_strategy_config_with_namespaces():
 
             # Should validate each namespace
             assert mock_validate.call_count == 2
-            mock_validate.assert_any_call("custom/{actorId}")
-            mock_validate.assert_any_call("preferences/{sessionId}")
+            mock_validate.assert_any_call("custom/{actorId}/")
+            mock_validate.assert_any_call("preferences/{sessionId}/")
 
 
 def test_wrap_configuration_consolidation_passthrough():
@@ -2213,7 +2213,7 @@ def test_add_semantic_strategy_with_namespaces():
                 memory_id="mem-123",
                 name="Test Semantic Strategy",
                 description="Test description",
-                namespaces=["custom/{actorId}/{sessionId}"],
+                namespaces=["custom/{actorId}/{sessionId}/"],
             )
 
             assert mock_control_plane_client.update_memory.called
@@ -2222,7 +2222,7 @@ def test_add_semantic_strategy_with_namespaces():
             args, kwargs = mock_control_plane_client.update_memory.call_args
             add_strategies = kwargs["memoryStrategies"]["addMemoryStrategies"]
             strategy = add_strategies[0]["semanticMemoryStrategy"]
-            assert strategy["namespaces"] == ["custom/{actorId}/{sessionId}"]
+            assert strategy["namespaces"] == ["custom/{actorId}/{sessionId}/"]
 
 
 def test_add_summary_strategy_with_namespaces():
@@ -2246,7 +2246,7 @@ def test_add_summary_strategy_with_namespaces():
                 memory_id="mem-456",
                 name="Test Summary Strategy",
                 description="Test description",
-                namespaces=["summaries/{actorId}"],
+                namespaces=["summaries/{actorId}/"],
             )
 
             assert mock_control_plane_client.update_memory.called
@@ -2255,7 +2255,7 @@ def test_add_summary_strategy_with_namespaces():
             args, kwargs = mock_control_plane_client.update_memory.call_args
             add_strategies = kwargs["memoryStrategies"]["addMemoryStrategies"]
             strategy = add_strategies[0]["summaryMemoryStrategy"]
-            assert strategy["namespaces"] == ["summaries/{actorId}"]
+            assert strategy["namespaces"] == ["summaries/{actorId}/"]
 
 
 def test_delete_memory_and_wait_debug_logging():
@@ -2318,7 +2318,7 @@ def test_modify_strategy_with_configuration():
                 memory_id="mem-123",
                 strategy_id="strat-789",
                 description="Modified description",
-                namespaces=["custom/namespace"],
+                namespaces=["custom/namespace/"],
                 configuration=configuration,
             )
 
@@ -3161,12 +3161,12 @@ def test_list_records():
             "nextToken": None,
         }
 
-        result = manager.list_records("mem-123", "/users/alice/facts")
+        result = manager.list_records("mem-123", "/users/alice/facts/")
 
         assert len(result) == 2
         assert result[0]["recordId"] == "rec-1"
         mock_data_plane_client.list_memory_records.assert_called_once_with(
-            memoryId="mem-123", namespace="/users/alice/facts"
+            memoryId="mem-123", namespace="/users/alice/facts/"
         )
 
 
@@ -3203,13 +3203,13 @@ def test_search_records():
             ]
         }
 
-        result = manager.search_records("mem-123", "/users/alice/facts", "favorite color", max_results=5)
+        result = manager.search_records("mem-123", "/users/alice/facts/", "favorite color", max_results=5)
 
         assert len(result) == 2
         assert result[0]["score"] == 0.95
         mock_data_plane_client.retrieve_memory_records.assert_called_once_with(
             memoryId="mem-123",
-            namespace="/users/alice/facts",
+            namespace="/users/alice/facts/",
             searchCriteria={"searchQuery": "favorite color"},
             maxResults=5,
         )

--- a/tests/operations/memory/test_strategy_types.py
+++ b/tests/operations/memory/test_strategy_types.py
@@ -79,12 +79,12 @@ class TestSemanticStrategy:
         strategy = SemanticStrategy(
             name="ConversationSemantics",
             description="Extract semantic information",
-            namespaces=["semantics/{actorId}/{sessionId}"],
+            namespaces=["semantics/{actorId}/{sessionId}/"],
         )
 
         assert strategy.name == "ConversationSemantics"
         assert strategy.description == "Extract semantic information"
-        assert strategy.namespaces == ["semantics/{actorId}/{sessionId}"]
+        assert strategy.namespaces == ["semantics/{actorId}/{sessionId}/"]
 
     def test_semantic_strategy_minimal(self):
         """Test SemanticStrategy with only required fields."""
@@ -96,14 +96,14 @@ class TestSemanticStrategy:
 
     def test_semantic_strategy_to_dict(self):
         """Test SemanticStrategy to_dict conversion."""
-        strategy = SemanticStrategy(name="TestSemantic", description="Test description", namespaces=["test/{actorId}"])
+        strategy = SemanticStrategy(name="TestSemantic", description="Test description", namespaces=["test/{actorId}/"])
 
         result = strategy.to_dict()
         expected = {
             "semanticMemoryStrategy": {
                 "name": "TestSemantic",
                 "description": "Test description",
-                "namespaces": ["test/{actorId}"],
+                "namespaces": ["test/{actorId}/"],
             }
         }
 
@@ -124,23 +124,23 @@ class TestSummaryStrategy:
         strategy = SummaryStrategy(
             name="ConversationSummary",
             description="Summarize conversations",
-            namespaces=["summaries/{actorId}/{sessionId}"],
+            namespaces=["summaries/{actorId}/{sessionId}/"],
         )
 
         assert strategy.name == "ConversationSummary"
         assert strategy.description == "Summarize conversations"
-        assert strategy.namespaces == ["summaries/{actorId}/{sessionId}"]
+        assert strategy.namespaces == ["summaries/{actorId}/{sessionId}/"]
 
     def test_summary_strategy_to_dict(self):
         """Test SummaryStrategy to_dict conversion."""
-        strategy = SummaryStrategy(name="TestSummary", description="Test description", namespaces=["test/{actorId}"])
+        strategy = SummaryStrategy(name="TestSummary", description="Test description", namespaces=["test/{actorId}/"])
 
         result = strategy.to_dict()
         expected = {
             "summaryMemoryStrategy": {
                 "name": "TestSummary",
                 "description": "Test description",
-                "namespaces": ["test/{actorId}"],
+                "namespaces": ["test/{actorId}/"],
             }
         }
 
@@ -153,17 +153,17 @@ class TestUserPreferenceStrategy:
     def test_user_preference_strategy_creation(self):
         """Test basic UserPreferenceStrategy creation."""
         strategy = UserPreferenceStrategy(
-            name="UserPreferences", description="Store user preferences", namespaces=["preferences/{actorId}"]
+            name="UserPreferences", description="Store user preferences", namespaces=["preferences/{actorId}/"]
         )
 
         assert strategy.name == "UserPreferences"
         assert strategy.description == "Store user preferences"
-        assert strategy.namespaces == ["preferences/{actorId}"]
+        assert strategy.namespaces == ["preferences/{actorId}/"]
 
     def test_user_preference_strategy_to_dict(self):
         """Test UserPreferenceStrategy to_dict conversion."""
         strategy = UserPreferenceStrategy(
-            name="TestPreferences", description="Test description", namespaces=["test/{actorId}"]
+            name="TestPreferences", description="Test description", namespaces=["test/{actorId}/"]
         )
 
         result = strategy.to_dict()
@@ -171,7 +171,7 @@ class TestUserPreferenceStrategy:
             "userPreferenceMemoryStrategy": {
                 "name": "TestPreferences",
                 "description": "Test description",
-                "namespaces": ["test/{actorId}"],
+                "namespaces": ["test/{actorId}/"],
             }
         }
 
@@ -195,14 +195,14 @@ class TestCustomSemanticStrategy:
             description="Custom semantic extraction",
             extraction_config=extraction_config,
             consolidation_config=consolidation_config,
-            namespaces=["custom/{actorId}/{sessionId}"],
+            namespaces=["custom/{actorId}/{sessionId}/"],
         )
 
         assert strategy.name == "CustomExtraction"
         assert strategy.description == "Custom semantic extraction"
         assert strategy.extraction_config == extraction_config
         assert strategy.consolidation_config == consolidation_config
-        assert strategy.namespaces == ["custom/{actorId}/{sessionId}"]
+        assert strategy.namespaces == ["custom/{actorId}/{sessionId}/"]
 
     def test_custom_semantic_strategy_to_dict(self):
         """Test CustomSemanticStrategy to_dict conversion."""
@@ -220,7 +220,7 @@ class TestCustomSemanticStrategy:
             description="Test description",
             extraction_config=extraction_config,
             consolidation_config=consolidation_config,
-            namespaces=["test/{actorId}"],
+            namespaces=["test/{actorId}/"],
         )
 
         result = strategy.to_dict()
@@ -228,7 +228,7 @@ class TestCustomSemanticStrategy:
             "customMemoryStrategy": {
                 "name": "TestCustom",
                 "description": "Test description",
-                "namespaces": ["test/{actorId}"],
+                "namespaces": ["test/{actorId}/"],
                 "configuration": {
                     "semanticOverride": {
                         "extraction": {
@@ -435,10 +435,10 @@ class TestBaseStrategyAbstract:
 
     def test_base_strategy_optional_fields(self):
         """Test BaseStrategy optional fields through concrete classes."""
-        strategy = SemanticStrategy(name="Test", description="Test description", namespaces=["test/namespace"])
+        strategy = SemanticStrategy(name="Test", description="Test description", namespaces=["test/namespace/"])
 
         assert strategy.description == "Test description"
-        assert strategy.namespaces == ["test/namespace"]
+        assert strategy.namespaces == ["test/namespace/"]
 
         # Test with None values
         strategy2 = SemanticStrategy(name="Test2")
@@ -449,11 +449,11 @@ class TestBaseStrategyAbstract:
 class TestPydanticIntegration:
     def test_model_serialization(self):
         """Test Pydantic model serialization."""
-        strategy = SemanticStrategy(name="TestSemantic", description="Test description", namespaces=["test/{actorId}"])
+        strategy = SemanticStrategy(name="TestSemantic", description="Test description", namespaces=["test/{actorId}/"])
 
         # Test model_dump() method (Pydantic v2)
         strategy_dict = strategy.model_dump()
-        expected = {"name": "TestSemantic", "description": "Test description", "namespaces": ["test/{actorId}"]}
+        expected = {"name": "TestSemantic", "description": "Test description", "namespaces": ["test/{actorId}/"]}
         assert strategy_dict == expected
 
         # Test model_dump_json() method (Pydantic v2)
@@ -499,13 +499,13 @@ class TestCustomSummaryStrategy:
             name="CustomSummary",
             description="Custom summary extraction",
             consolidation_config=consolidation_config,
-            namespaces=["summary/{actorId}/{sessionId}"],
+            namespaces=["summary/{actorId}/{sessionId}/"],
         )
 
         assert strategy.name == "CustomSummary"
         assert strategy.description == "Custom summary extraction"
         assert strategy.consolidation_config == consolidation_config
-        assert strategy.namespaces == ["summary/{actorId}/{sessionId}"]
+        assert strategy.namespaces == ["summary/{actorId}/{sessionId}/"]
 
     def test_custom_summary_strategy_minimal(self):
         """Test CustomSummaryStrategy with minimal configuration."""
@@ -528,7 +528,7 @@ class TestCustomSummaryStrategy:
             name="TestSummary",
             description="Test summary description",
             consolidation_config=consolidation_config,
-            namespaces=["test/{actorId}"],
+            namespaces=["test/{actorId}/"],
         )
 
         result = strategy.to_dict()
@@ -536,7 +536,7 @@ class TestCustomSummaryStrategy:
             "customMemoryStrategy": {
                 "name": "TestSummary",
                 "description": "Test summary description",
-                "namespaces": ["test/{actorId}"],
+                "namespaces": ["test/{actorId}/"],
                 "configuration": {
                     "summaryOverride": {
                         "consolidation": {
@@ -646,14 +646,14 @@ class TestCustomUserPreferenceStrategy:
             description="Custom user preference extraction",
             extraction_config=extraction_config,
             consolidation_config=consolidation_config,
-            namespaces=["preferences/{actorId}"],
+            namespaces=["preferences/{actorId}/"],
         )
 
         assert strategy.name == "CustomUserPref"
         assert strategy.description == "Custom user preference extraction"
         assert strategy.extraction_config == extraction_config
         assert strategy.consolidation_config == consolidation_config
-        assert strategy.namespaces == ["preferences/{actorId}"]
+        assert strategy.namespaces == ["preferences/{actorId}/"]
 
     def test_custom_user_preference_strategy_minimal(self):
         """Test CustomUserPreferenceStrategy with minimal configuration."""
@@ -682,7 +682,7 @@ class TestCustomUserPreferenceStrategy:
             description="Test user preference description",
             extraction_config=extraction_config,
             consolidation_config=consolidation_config,
-            namespaces=["test/{actorId}"],
+            namespaces=["test/{actorId}/"],
         )
 
         result = strategy.to_dict()
@@ -690,7 +690,7 @@ class TestCustomUserPreferenceStrategy:
             "customMemoryStrategy": {
                 "name": "TestUserPref",
                 "description": "Test user preference description",
-                "namespaces": ["test/{actorId}"],
+                "namespaces": ["test/{actorId}/"],
                 "configuration": {
                     "userPreferenceOverride": {
                         "extraction": {

--- a/tests/operations/memory/test_strategy_validator.py
+++ b/tests/operations/memory/test_strategy_validator.py
@@ -31,7 +31,7 @@ class TestStrategyComparatorEdgeCases:
             "type": "CUSTOM",
             "name": "TestStrategy",
             "description": "Test description",
-            "namespaces": ["test/{actorId}"],
+            "namespaces": ["test/{actorId}/"],
             "configuration": {
                 "type": "SEMANTIC_OVERRIDE",
                 "extraction": {
@@ -55,7 +55,7 @@ class TestStrategyComparatorEdgeCases:
         assert normalized["type"] == "CUSTOM"
         assert normalized["name"] == "TestStrategy"
         assert normalized["description"] == "Test description"
-        assert normalized["namespaces"] == ["test/{actorId}"]
+        assert normalized["namespaces"] == ["test/{actorId}/"]
         assert "configuration" in normalized
 
     def test_normalize_memory_strategy_without_configuration(self):
@@ -64,7 +64,7 @@ class TestStrategyComparatorEdgeCases:
             "type": "SEMANTIC",
             "name": "TestStrategy",
             "description": "Test description",
-            "namespaces": ["test/{actorId}"],
+            "namespaces": ["test/{actorId}/"],
         }
 
         normalized = StrategyComparator._normalize_memory_strategy(strategy)
@@ -72,7 +72,7 @@ class TestStrategyComparatorEdgeCases:
         assert normalized["type"] == "SEMANTIC"
         assert normalized["name"] == "TestStrategy"
         assert normalized["description"] == "Test description"
-        assert normalized["namespaces"] == ["test/{actorId}"]
+        assert normalized["namespaces"] == ["test/{actorId}/"]
 
     def test_transform_memory_configuration_semantic_override(self):
         """Test _transform_memory_configuration with SEMANTIC_OVERRIDE."""
@@ -250,7 +250,7 @@ class TestStrategyComparatorEdgeCases:
             "newTypeMemoryStrategy": {
                 "name": "NewTypeStrategy",
                 "description": "Test new type strategy",
-                "namespaces": ["newtype/{actorId}"],
+                "namespaces": ["newtype/{actorId}/"],
                 "customField": "customValue",
             }
         }
@@ -260,7 +260,7 @@ class TestStrategyComparatorEdgeCases:
         assert normalized["type"] == "NEW_TYPE"
         assert normalized["name"] == "NewTypeStrategy"
         assert normalized["description"] == "Test new type strategy"
-        assert normalized["namespaces"] == ["newtype/{actorId}"]
+        assert normalized["namespaces"] == ["newtype/{actorId}/"]
         assert normalized["custom_field"] == "customValue"
 
     def test_normalize_request_strategy_excluded_fields(self):
@@ -269,7 +269,7 @@ class TestStrategyComparatorEdgeCases:
             "semanticMemoryStrategy": {
                 "name": "TestStrategy",
                 "description": "Test description",
-                "namespaces": ["test/{actorId}"],
+                "namespaces": ["test/{actorId}/"],
                 "status": "ACTIVE",  # Should be excluded
                 "strategyId": "strategy-123",  # Should be excluded
                 "customField": "customValue",  # Should be included
@@ -281,7 +281,7 @@ class TestStrategyComparatorEdgeCases:
         assert normalized["type"] == "SEMANTIC"
         assert normalized["name"] == "TestStrategy"
         assert normalized["description"] == "Test description"
-        assert normalized["namespaces"] == ["test/{actorId}"]
+        assert normalized["namespaces"] == ["test/{actorId}/"]
         assert normalized["custom_field"] == "customValue"
         # Excluded fields should not be present
         assert "status" not in normalized
@@ -294,7 +294,7 @@ class TestStrategyComparatorEdgeCases:
                 "type": "CUSTOM",
                 "name": "CustomStrategy",
                 "description": "Test custom strategy",
-                "namespaces": ["custom/{actorId}"],
+                "namespaces": ["custom/{actorId}/"],
                 "configuration": {
                     "semanticOverride": {
                         "extraction": {"appendToPrompt": "Extract insights", "modelId": "claude-3-sonnet"},
@@ -314,7 +314,7 @@ class TestStrategyComparatorEdgeCases:
                 description="Test custom strategy",
                 extraction_config=extraction_config,
                 consolidation_config=consolidation_config,
-                namespaces=["custom/{actorId}"],
+                namespaces=["custom/{actorId}/"],
             )
         ]
 
@@ -543,7 +543,7 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 "type": "CUSTOM",
                 "name": "CustomStrategy",
                 "description": "Test custom strategy",
-                "namespaces": ["custom/{actorId}"],
+                "namespaces": ["custom/{actorId}/"],
                 "configuration": {
                     "semanticOverride": {
                         "extraction": {"appendToPrompt": "Extract insights", "modelId": "claude-3-sonnet"},
@@ -563,7 +563,7 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 description="Test custom strategy",
                 extraction_config=extraction_config,
                 consolidation_config=consolidation_config,
-                namespaces=["custom/{actorId}"],
+                namespaces=["custom/{actorId}/"],
             )
         ]
 
@@ -577,7 +577,7 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 "type": "CUSTOM",
                 "name": "CustomSummaryStrategy",
                 "description": "Test custom summary strategy",
-                "namespaces": ["summary/{actorId}"],
+                "namespaces": ["summary/{actorId}/"],
                 "configuration": {
                     "summaryOverride": {
                         "consolidation": {"appendToPrompt": "Consolidate summaries", "modelId": "claude-3-haiku"}
@@ -593,7 +593,7 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 name="CustomSummaryStrategy",
                 description="Test custom summary strategy",
                 consolidation_config=consolidation_config,
-                namespaces=["summary/{actorId}"],
+                namespaces=["summary/{actorId}/"],
             )
         ]
 
@@ -607,7 +607,7 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 "type": "CUSTOM",
                 "name": "CustomUserPrefStrategy",
                 "description": "Test custom user preference strategy",
-                "namespaces": ["preferences/{actorId}"],
+                "namespaces": ["preferences/{actorId}/"],
                 "configuration": {
                     "userPreferenceOverride": {
                         "extraction": {"appendToPrompt": "Extract preferences", "modelId": "claude-3-sonnet"},
@@ -628,7 +628,7 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 description="Test custom user preference strategy",
                 extraction_config=extraction_config,
                 consolidation_config=consolidation_config,
-                namespaces=["preferences/{actorId}"],
+                namespaces=["preferences/{actorId}/"],
             )
         ]
 
@@ -642,7 +642,7 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 "type": "CUSTOM",
                 "name": "CustomStrategy",
                 "description": "Existing description",
-                "namespaces": ["existing/{actorId}"],
+                "namespaces": ["existing/{actorId}/"],
                 "configuration": {
                     "semanticOverride": {
                         "extraction": {"appendToPrompt": "Existing extraction prompt", "modelId": "existing-model"},
@@ -669,7 +669,7 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 description="Existing description",
                 extraction_config=extraction_config,
                 consolidation_config=consolidation_config,
-                namespaces=["existing/{actorId}"],
+                namespaces=["existing/{actorId}/"],
             )
         ]
 
@@ -687,13 +687,13 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test semantic strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             },
             {
                 "type": "SUMMARIZATION",
                 "name": "SummaryStrategy",
                 "description": "Test summary strategy",
-                "namespaces": ["summary/{actorId}"],
+                "namespaces": ["summary/{actorId}/"],
             },
         ]
 
@@ -702,14 +702,14 @@ class TestValidateExistingMemoryStrategiesEdgeCases:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test semantic strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             },
             {
                 "summaryMemoryStrategy": {
                     "name": "SummaryStrategy",
                     "description": "Test summary strategy",
-                    "namespaces": ["summary/{actorId}"],
+                    "namespaces": ["summary/{actorId}/"],
                 }
             },
         ]
@@ -788,7 +788,7 @@ class TestErrorHandlingAndEdgeCases:
             "memoryStrategyType": "SEMANTIC",
             "name": "TestStrategy",
             "description": "Test description",
-            "namespaces": ["test/{actorId}"],
+            "namespaces": ["test/{actorId}/"],
         }
 
         normalized = StrategyComparator.normalize_strategy(strategy)
@@ -796,7 +796,7 @@ class TestErrorHandlingAndEdgeCases:
         assert normalized["type"] == "SEMANTIC"
         assert normalized["name"] == "TestStrategy"
         assert normalized["description"] == "Test description"
-        assert normalized["namespaces"] == ["test/{actorId}"]
+        assert normalized["namespaces"] == ["test/{actorId}/"]
 
     def test_normalize_strategy_with_empty_configuration(self):
         """Test normalize_strategy with empty configuration."""
@@ -804,7 +804,7 @@ class TestErrorHandlingAndEdgeCases:
             "type": "CUSTOM",
             "name": "TestStrategy",
             "description": "Test description",
-            "namespaces": ["test/{actorId}"],
+            "namespaces": ["test/{actorId}/"],
             "configuration": {},
         }
 
@@ -866,7 +866,7 @@ class TestStrategyComparator:
             "type": "SEMANTIC",
             "name": "SemanticStrategy",
             "description": "Test semantic strategy",
-            "namespaces": ["semantic/{actorId}"],
+            "namespaces": ["semantic/{actorId}/"],
         }
 
         normalized = StrategyComparator.normalize_strategy(strategy)
@@ -874,7 +874,7 @@ class TestStrategyComparator:
         assert normalized["type"] == "SEMANTIC"
         assert normalized["name"] == "SemanticStrategy"
         assert normalized["description"] == "Test semantic strategy"
-        assert normalized["namespaces"] == ["semantic/{actorId}"]
+        assert normalized["namespaces"] == ["semantic/{actorId}/"]
 
     def test_normalize_strategy_legacy_fields(self):
         """Test normalizing strategy with legacy field names."""
@@ -882,7 +882,7 @@ class TestStrategyComparator:
             "memoryStrategyType": "SEMANTIC",
             "name": "SemanticStrategy",
             "description": "Test semantic strategy",
-            "namespaces": ["semantic/{actorId}"],
+            "namespaces": ["semantic/{actorId}/"],
         }
 
         normalized = StrategyComparator.normalize_strategy(strategy)
@@ -896,7 +896,7 @@ class TestStrategyComparator:
             "type": "CUSTOM",
             "name": "CustomStrategy",
             "description": "Test custom strategy",
-            "namespaces": ["custom/{actorId}"],
+            "namespaces": ["custom/{actorId}/"],
             "configuration": {
                 "semanticOverride": {
                     "extraction": {"appendToPrompt": "Extract insights", "modelId": "claude-3-sonnet"},
@@ -919,7 +919,7 @@ class TestStrategyComparator:
             "semanticMemoryStrategy": {
                 "name": "SemanticStrategy",
                 "description": "Test semantic strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         }
 
@@ -928,7 +928,7 @@ class TestStrategyComparator:
         assert normalized["type"] == "SEMANTIC"
         assert normalized["name"] == "SemanticStrategy"
         assert normalized["description"] == "Test semantic strategy"
-        assert normalized["namespaces"] == ["semantic/{actorId}"]
+        assert normalized["namespaces"] == ["semantic/{actorId}/"]
 
     def test_normalize_strategy_custom_request(self):
         """Test normalizing custom strategy from request."""
@@ -936,7 +936,7 @@ class TestStrategyComparator:
             "customMemoryStrategy": {
                 "name": "CustomStrategy",
                 "description": "Test custom strategy",
-                "namespaces": ["custom/{actorId}"],
+                "namespaces": ["custom/{actorId}/"],
                 "configuration": {
                     "semanticOverride": {
                         "extraction": {"appendToPrompt": "Extract insights", "modelId": "claude-3-sonnet"},
@@ -968,7 +968,7 @@ class TestStrategyComparator:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -977,7 +977,7 @@ class TestStrategyComparator:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             }
         ]
@@ -994,7 +994,7 @@ class TestStrategyComparator:
                 "type": "SEMANTIC",
                 "name": "ExistingStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -1003,7 +1003,7 @@ class TestStrategyComparator:
                 "semanticMemoryStrategy": {
                     "name": "RequestedStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             }
         ]
@@ -1022,7 +1022,7 @@ class TestStrategyComparator:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Existing description",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -1031,7 +1031,7 @@ class TestStrategyComparator:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Requested description",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             }
         ]
@@ -1048,7 +1048,7 @@ class TestStrategyComparator:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -1057,7 +1057,7 @@ class TestStrategyComparator:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["different/{actorId}"],
+                    "namespaces": ["different/{actorId}/"],
                 }
             }
         ]
@@ -1083,7 +1083,7 @@ class TestStrategyComparator:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["different/{actorId}"],  # Non-empty namespaces
+                    "namespaces": ["different/{actorId}/"],  # Non-empty namespaces
                 }
             }
         ]
@@ -1100,7 +1100,7 @@ class TestStrategyComparator:
                 "type": "CUSTOM",
                 "name": "CustomStrategy",
                 "description": "Test custom strategy",
-                "namespaces": ["custom/{actorId}"],
+                "namespaces": ["custom/{actorId}/"],
                 "configuration": {
                     "semanticOverride": {
                         "extraction": {"appendToPrompt": "Existing prompt", "modelId": "claude-3-sonnet"},
@@ -1115,7 +1115,7 @@ class TestStrategyComparator:
                 "customMemoryStrategy": {
                     "name": "CustomStrategy",
                     "description": "Test custom strategy",
-                    "namespaces": ["custom/{actorId}"],
+                    "namespaces": ["custom/{actorId}/"],
                     "configuration": {
                         "semanticOverride": {
                             "extraction": {"appendToPrompt": "Requested prompt", "modelId": "claude-3-sonnet"},
@@ -1138,7 +1138,7 @@ class TestStrategyComparator:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -1147,7 +1147,7 @@ class TestStrategyComparator:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             },
             {"summaryMemoryStrategy": {"name": "SummaryStrategy", "description": "Test summary strategy"}},
@@ -1171,14 +1171,14 @@ class TestStrategyComparator:
     def test_compare_strategies_description_none_equivalence(self):
         """Test that None and empty descriptions are treated as equivalent."""
         existing = [
-            {"type": "SEMANTIC", "name": "SemanticStrategy", "description": None, "namespaces": ["semantic/{actorId}"]}
+            {"type": "SEMANTIC", "name": "SemanticStrategy", "description": None, "namespaces": ["semantic/{actorId}/"]}
         ]
 
         requested = [
             {
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                     # No description field
                 }
             }
@@ -1196,7 +1196,7 @@ class TestStrategyComparator:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}", "semantic/{sessionId}"],
+                "namespaces": ["semantic/{actorId}/", "semantic/{sessionId}/"],
             }
         ]
 
@@ -1205,7 +1205,7 @@ class TestStrategyComparator:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["semantic/{sessionId}", "semantic/{actorId}"],  # Different order
+                    "namespaces": ["semantic/{sessionId}/", "semantic/{actorId}/"],  # Different order
                 }
             }
         ]
@@ -1253,7 +1253,7 @@ class TestValidateExistingMemoryStrategies:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -1262,7 +1262,7 @@ class TestValidateExistingMemoryStrategies:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             }
         ]
@@ -1277,7 +1277,7 @@ class TestValidateExistingMemoryStrategies:
                 "type": "SEMANTIC",
                 "name": "ExistingStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -1286,7 +1286,7 @@ class TestValidateExistingMemoryStrategies:
                 "semanticMemoryStrategy": {
                     "name": "RequestedStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             }
         ]
@@ -1301,7 +1301,7 @@ class TestValidateExistingMemoryStrategies:
                 "type": "CUSTOM",
                 "name": "CustomStrategy",
                 "description": "Test custom strategy",
-                "namespaces": ["custom/{actorId}"],
+                "namespaces": ["custom/{actorId}/"],
                 "configuration": {
                     "semanticOverride": {
                         "extraction": {"appendToPrompt": "Extract insights", "modelId": "claude-3-sonnet"},
@@ -1316,7 +1316,7 @@ class TestValidateExistingMemoryStrategies:
                 "customMemoryStrategy": {
                     "name": "CustomStrategy",
                     "description": "Test custom strategy",
-                    "namespaces": ["custom/{actorId}"],
+                    "namespaces": ["custom/{actorId}/"],
                     "configuration": {
                         "semanticOverride": {
                             "extraction": {"appendToPrompt": "Extract insights", "modelId": "claude-3-sonnet"},
@@ -1337,7 +1337,7 @@ class TestValidateExistingMemoryStrategies:
                 "type": "CUSTOM",
                 "name": "CustomStrategy",
                 "description": "Test custom strategy",
-                "namespaces": ["custom/{actorId}"],
+                "namespaces": ["custom/{actorId}/"],
                 "configuration": {
                     "semanticOverride": {
                         "extraction": {"appendToPrompt": "Existing prompt", "modelId": "claude-3-sonnet"},
@@ -1352,7 +1352,7 @@ class TestValidateExistingMemoryStrategies:
                 "customMemoryStrategy": {
                     "name": "CustomStrategy",
                     "description": "Test custom strategy",
-                    "namespaces": ["custom/{actorId}"],
+                    "namespaces": ["custom/{actorId}/"],
                     "configuration": {
                         "semanticOverride": {
                             "extraction": {"appendToPrompt": "Requested prompt", "modelId": "claude-3-sonnet"},
@@ -1373,13 +1373,13 @@ class TestValidateExistingMemoryStrategies:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test semantic strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             },
             {
                 "type": "SUMMARIZATION",
                 "name": "SummaryStrategy",
                 "description": "Test summary strategy",
-                "namespaces": ["summary/{actorId}"],
+                "namespaces": ["summary/{actorId}/"],
             },
         ]
 
@@ -1388,14 +1388,14 @@ class TestValidateExistingMemoryStrategies:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test semantic strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             },
             {
                 "summaryMemoryStrategy": {
                     "name": "SummaryStrategy",
                     "description": "Test summary strategy",
-                    "namespaces": ["summary/{actorId}"],
+                    "namespaces": ["summary/{actorId}/"],
                 }
             },
         ]
@@ -1410,13 +1410,13 @@ class TestValidateExistingMemoryStrategies:
                 "type": "SUMMARIZATION",
                 "name": "SummaryStrategy",
                 "description": "Test summary strategy",
-                "namespaces": ["summary/{actorId}"],
+                "namespaces": ["summary/{actorId}/"],
             },
             {
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test semantic strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             },
         ]
 
@@ -1425,14 +1425,14 @@ class TestValidateExistingMemoryStrategies:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test semantic strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             },
             {
                 "summaryMemoryStrategy": {
                     "name": "SummaryStrategy",
                     "description": "Test summary strategy",
-                    "namespaces": ["summary/{actorId}"],
+                    "namespaces": ["summary/{actorId}/"],
                 }
             },
         ]
@@ -1447,7 +1447,7 @@ class TestValidateExistingMemoryStrategies:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -1456,7 +1456,7 @@ class TestValidateExistingMemoryStrategies:
                 "semanticMemoryStrategy": {
                     "name": "SemanticStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             }
         ]
@@ -1509,7 +1509,7 @@ class TestValidateExistingMemoryStrategies:
                 "type": "USER_PREFERENCE",
                 "name": "UserPrefStrategy",
                 "description": "Test user preference strategy",
-                "namespaces": ["preferences/{actorId}"],
+                "namespaces": ["preferences/{actorId}/"],
             }
         ]
 
@@ -1518,7 +1518,7 @@ class TestValidateExistingMemoryStrategies:
                 "userPreferenceMemoryStrategy": {
                     "name": "UserPrefStrategy",
                     "description": "Test user preference strategy",
-                    "namespaces": ["preferences/{actorId}"],
+                    "namespaces": ["preferences/{actorId}/"],
                 }
             }
         ]
@@ -1533,7 +1533,7 @@ class TestValidateExistingMemoryStrategies:
                 "type": "SEMANTIC",
                 "name": "SemanticStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         ]
 
@@ -1542,7 +1542,7 @@ class TestValidateExistingMemoryStrategies:
                 StrategyType.SEMANTIC.value: {
                     "name": "SemanticStrategy",
                     "description": "Test strategy",
-                    "namespaces": ["semantic/{actorId}"],
+                    "namespaces": ["semantic/{actorId}/"],
                 }
             }
         ]
@@ -1569,7 +1569,7 @@ class TestValidateExistingMemoryStrategies:
             "type": "CUSTOM",
             "name": "CustomStrategy",
             "description": "Test custom strategy",
-            "namespaces": ["custom/{actorId}"],
+            "namespaces": ["custom/{actorId}/"],
             # No configuration field
         }
 
@@ -1662,7 +1662,7 @@ class TestFutureProofValidation:
             "type": "SEMANTIC",
             "name": "SemanticStrategy",
             "description": "Test strategy",
-            "namespaces": ["semantic/{actorId}"],
+            "namespaces": ["semantic/{actorId}/"],
             "new_future_field": "existing_value",  # Simulated future field
         }
 
@@ -1670,7 +1670,7 @@ class TestFutureProofValidation:
             "type": "SEMANTIC",
             "name": "SemanticStrategy",
             "description": "Test strategy",
-            "namespaces": ["semantic/{actorId}"],
+            "namespaces": ["semantic/{actorId}/"],
             "new_future_field": "existing_value",  # Same value
         }
 
@@ -1685,7 +1685,7 @@ class TestFutureProofValidation:
             "type": "SEMANTIC",
             "name": "SemanticStrategy",
             "description": "Test strategy",
-            "namespaces": ["semantic/{actorId}"],
+            "namespaces": ["semantic/{actorId}/"],
             "new_future_field": "existing_value",
         }
 
@@ -1693,7 +1693,7 @@ class TestFutureProofValidation:
             "type": "SEMANTIC",
             "name": "SemanticStrategy",
             "description": "Test strategy",
-            "namespaces": ["semantic/{actorId}"],
+            "namespaces": ["semantic/{actorId}/"],
             "new_future_field": "different_value",  # Different value
         }
 
@@ -1710,7 +1710,7 @@ class TestFutureProofValidation:
             "type": "SEMANTIC",
             "name": "SemanticStrategy",
             "description": "Test strategy",
-            "namespaces": ["semantic/{actorId}"],
+            "namespaces": ["semantic/{actorId}/"],
             "new_future_field": "existing_value",
         }
 
@@ -1718,7 +1718,7 @@ class TestFutureProofValidation:
             "type": "SEMANTIC",
             "name": "SemanticStrategy",
             "description": "Test strategy",
-            "namespaces": ["semantic/{actorId}"],
+            "namespaces": ["semantic/{actorId}/"],
             # Missing new_future_field
         }
 
@@ -1788,7 +1788,7 @@ class TestFutureProofNormalization:
             "newTypeMemoryStrategy": {
                 "name": "NewTypeStrategy",
                 "description": "Test new type strategy",
-                "namespaces": ["newtype/{actorId}"],
+                "namespaces": ["newtype/{actorId}/"],
             }
         }
 
@@ -1797,7 +1797,7 @@ class TestFutureProofNormalization:
         assert normalized["type"] == "NEW_TYPE"
         assert normalized["name"] == "NewTypeStrategy"
         assert normalized["description"] == "Test new type strategy"
-        assert normalized["namespaces"] == ["newtype/{actorId}"]
+        assert normalized["namespaces"] == ["newtype/{actorId}/"]
 
     def test_normalize_custom_with_new_fields(self):
         """Test normalization of custom strategy with new camelCase fields."""
@@ -1805,7 +1805,7 @@ class TestFutureProofNormalization:
             "customMemoryStrategy": {
                 "name": "CustomStrategy",
                 "description": "Test custom strategy",
-                "namespaces": ["custom/{actorId}"],
+                "namespaces": ["custom/{actorId}/"],
                 "newFutureField": "future_value",  # Future field at strategy level
                 "configuration": {
                     "semanticOverride": {
@@ -1836,7 +1836,7 @@ class TestFutureProofNormalization:
             StrategyType.SEMANTIC.value: {
                 "name": "SemanticStrategy",
                 "description": "Test semantic strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
             }
         }
 
@@ -1845,7 +1845,7 @@ class TestFutureProofNormalization:
         assert normalized["type"] == "SEMANTIC"
         assert normalized["name"] == "SemanticStrategy"
         assert normalized["description"] == "Test semantic strategy"
-        assert normalized["namespaces"] == ["semantic/{actorId}"]
+        assert normalized["namespaces"] == ["semantic/{actorId}/"]
 
     def test_normalize_invalid_format_still_fails(self):
         """Test that invalid strategy formats still raise errors."""
@@ -1860,7 +1860,7 @@ class TestFutureProofNormalization:
             "customMemoryStrategy": {
                 "name": "CustomStrategy",
                 "description": "Test custom strategy",
-                "namespaces": ["custom/{actorId}"],
+                "namespaces": ["custom/{actorId}/"],
                 # No configuration section
             }
         }
@@ -1878,7 +1878,7 @@ class TestFutureProofNormalization:
             "semanticMemoryStrategy": {
                 "name": "SemanticStrategy",
                 "description": "Test strategy",
-                "namespaces": ["semantic/{actorId}"],
+                "namespaces": ["semantic/{actorId}/"],
                 "newFutureField": "future_value",  # Future field
                 "anotherNewField": {"nested": "data"},
             }
@@ -1889,7 +1889,7 @@ class TestFutureProofNormalization:
         assert normalized["type"] == "SEMANTIC"
         assert normalized["name"] == "SemanticStrategy"
         assert normalized["description"] == "Test strategy"
-        assert normalized["namespaces"] == ["semantic/{actorId}"]
+        assert normalized["namespaces"] == ["semantic/{actorId}/"]
         # Future fields should be preserved with normalized names
         assert normalized["new_future_field"] == "future_value"
         assert normalized["another_new_field"] == {"nested": "data"}

--- a/tests/operations/memory/test_visualizer.py
+++ b/tests/operations/memory/test_visualizer.py
@@ -57,7 +57,7 @@ class TestVisualizeMemory:
                 "id": "mem-123",
                 "name": "test_mem",
                 "status": "ACTIVE",
-                "strategies": [{"name": "Facts", "type": "SEMANTIC", "status": "ACTIVE", "namespaces": ["/facts"]}],
+                "strategies": [{"name": "Facts", "type": "SEMANTIC", "status": "ACTIVE", "namespaces": ["/facts/"]}],
             }
         )
 
@@ -176,7 +176,7 @@ class TestDisplayRecordsTree:
     def test_display_records_tree_with_records(self, visualizer, console):
         manager = MagicMock()
         manager.get_memory.return_value = MagicMock(
-            _data={"strategies": [{"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts"]}]}
+            _data={"strategies": [{"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts/"]}]}
         )
         manager.list_records.return_value = [{"memoryRecordId": "r1", "content": {"text": "test"}}]
 
@@ -191,14 +191,14 @@ class TestDisplayNamespaceRecords:
         manager = MagicMock()
         manager.list_records.return_value = []
 
-        visualizer.display_namespace_records(manager, "mem-123", "/test", verbose=False, max_results=10, output=None)
+        visualizer.display_namespace_records(manager, "mem-123", "/test/", verbose=False, max_results=10, output=None)
         console.print.assert_called()
 
     def test_display_namespace_records_with_records(self, visualizer, console):
         manager = MagicMock()
         manager.list_records.return_value = [{"memoryRecordId": "r1", "content": {"text": "test"}}]
 
-        visualizer.display_namespace_records(manager, "mem-123", "/test", verbose=False, max_results=10, output=None)
+        visualizer.display_namespace_records(manager, "mem-123", "/test/", verbose=False, max_results=10, output=None)
         console.print.assert_called()
 
 
@@ -208,7 +208,7 @@ class TestDisplaySingleRecord:
     def test_display_single_record_basic(self, visualizer, console):
         record = {
             "memoryRecordId": "r1",
-            "namespace": "/test",
+            "namespace": "/test/",
             "createdAt": "2024-01-01T00:00:00Z",
             "content": {"text": "test content"},
         }
@@ -219,7 +219,7 @@ class TestDisplaySingleRecord:
     def test_display_single_record_verbose(self, visualizer, console):
         record = {
             "memoryRecordId": "r1",
-            "namespace": "/test",
+            "namespace": "/test/",
             "createdAt": "2024-01-01T00:00:00Z",
             "content": {"text": "test content"},
         }
@@ -236,12 +236,12 @@ class TestDisplaySearchResults:
         console.print.assert_called()
 
     def test_display_search_results_with_results(self, visualizer, console):
-        results = [{"memoryRecordId": "r1", "namespace": "/test", "score": 0.95, "content": {"text": "match"}}]
+        results = [{"memoryRecordId": "r1", "namespace": "/test/", "score": 0.95, "content": {"text": "match"}}]
         visualizer.display_search_results(results, "query", verbose=False)
         console.print.assert_called()
 
     def test_display_search_results_verbose(self, visualizer, console):
-        results = [{"memoryRecordId": "r1", "namespace": "/test", "score": 0.95, "content": {"text": "match"}}]
+        results = [{"memoryRecordId": "r1", "namespace": "/test/", "score": 0.95, "content": {"text": "match"}}]
         visualizer.display_search_results(results, "query", verbose=True)
         console.print.assert_called()
 
@@ -419,7 +419,7 @@ class TestRecordsTreeEdgeCases:
     def test_records_tree_with_strategy_records(self, visualizer, console):
         manager = MagicMock()
         manager.get_memory.return_value = {
-            "strategies": [{"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts"]}]
+            "strategies": [{"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts/"]}]
         }
         manager.list_records.return_value = [{"memoryRecordId": "r1", "content": {"text": "test"}, "createdAt": "2024"}]
         visualizer.display_records_tree(manager, "mem-123", False, 10, None)
@@ -428,7 +428,7 @@ class TestRecordsTreeEdgeCases:
     def test_records_tree_list_records_error(self, visualizer, console):
         manager = MagicMock()
         manager.get_memory.return_value = {
-            "strategies": [{"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts"]}]
+            "strategies": [{"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts/"]}]
         }
         manager.list_records.side_effect = Exception("API error")
         visualizer.display_records_tree(manager, "mem-123", False, 10, None)
@@ -441,14 +441,14 @@ class TestNamespaceRecordsEdgeCases:
     def test_namespace_records_error(self, visualizer, console):
         manager = MagicMock()
         manager.list_records.side_effect = Exception("API error")
-        visualizer.display_namespace_records(manager, "mem-123", "/test", False, 10, None)
+        visualizer.display_namespace_records(manager, "mem-123", "/test/", False, 10, None)
         console.print.assert_called()
 
     def test_namespace_records_with_output(self, visualizer, console, tmp_path):
         manager = MagicMock()
         manager.list_records.return_value = [{"memoryRecordId": "r1", "content": {"text": "test"}, "createdAt": "2024"}]
         output_file = tmp_path / "ns_records.json"
-        visualizer.display_namespace_records(manager, "mem-123", "/test", False, 10, str(output_file))
+        visualizer.display_namespace_records(manager, "mem-123", "/test/", False, 10, str(output_file))
         assert output_file.exists()
 
 
@@ -457,27 +457,27 @@ class TestResolveNamespace:
 
     def test_resolve_simple_namespace(self, visualizer):
         manager = MagicMock()
-        result = visualizer._resolve_namespace(manager, "mem-123", "/facts")
-        assert result == ["/facts"]
+        result = visualizer._resolve_namespace(manager, "mem-123", "/facts/")
+        assert result == ["/facts/"]
 
     def test_resolve_actor_template(self, visualizer):
         manager = MagicMock()
         manager.list_actors.return_value = [{"actorId": "user1"}, {"actorId": "user2"}]
-        result = visualizer._resolve_namespace(manager, "mem-123", "/users/{actorId}/facts")
-        assert "/users/user1/facts" in result
-        assert "/users/user2/facts" in result
+        result = visualizer._resolve_namespace(manager, "mem-123", "/users/{actorId}/facts/")
+        assert "/users/user1/facts/" in result
+        assert "/users/user2/facts/" in result
 
     def test_resolve_session_template(self, visualizer):
         manager = MagicMock()
         manager.list_actors.return_value = [{"actorId": "user1"}]
         manager.list_sessions.return_value = [{"sessionId": "sess1"}]
-        result = visualizer._resolve_namespace(manager, "mem-123", "/users/{actorId}/sessions/{sessionId}")
-        assert "/users/user1/sessions/sess1" in result
+        result = visualizer._resolve_namespace(manager, "mem-123", "/users/{actorId}/sessions/{sessionId}/")
+        assert "/users/user1/sessions/sess1/" in result
 
     def test_resolve_namespace_error(self, visualizer):
         manager = MagicMock()
         manager.list_actors.side_effect = Exception("API error")
-        result = visualizer._resolve_namespace(manager, "mem-123", "/users/{actorId}/facts")
+        result = visualizer._resolve_namespace(manager, "mem-123", "/users/{actorId}/facts/")
         assert result == []
 
 
@@ -499,7 +499,7 @@ class TestStrategyWithVerbose:
                         "status": "ACTIVE",
                         "strategyId": "strat-123",
                         "description": "Test strategy",
-                        "namespaces": ["/facts"],
+                        "namespaces": ["/facts/"],
                         "createdAt": "2024-01-01T00:00:00Z",
                         "updatedAt": "2024-01-02T00:00:00Z",
                         "configuration": {"nested": {"key": "value"}, "simple": "val"},
@@ -520,7 +520,7 @@ class TestAddRecordsToTree:
         parent = Tree("test")
         records = [{"memoryRecordId": f"r{i}", "content": {"text": f"text{i}"}, "createdAt": "2024"} for i in range(15)]
         export_list = []
-        visualizer._add_records_to_tree(parent, "/test", records, False, export_list)
+        visualizer._add_records_to_tree(parent, "/test/", records, False, export_list)
         assert len(export_list) <= 10
 
 
@@ -612,12 +612,17 @@ class TestSingleRecordDisplay:
     """Test single record display edge cases."""
 
     def test_single_record_no_content(self, visualizer, console):
-        record = {"memoryRecordId": "r1", "namespace": "/test", "createdAt": "2024-01-01T00:00:00Z"}
+        record = {"memoryRecordId": "r1", "namespace": "/test/", "createdAt": "2024-01-01T00:00:00Z"}
         visualizer.display_single_record(record, 1, 1, verbose=False)
         console.print.assert_called()
 
     def test_single_record_with_recordId(self, visualizer, console):
-        record = {"recordId": "r1", "namespace": "/test", "createdAt": "2024-01-01T00:00:00Z", "content": {"text": "x"}}
+        record = {
+            "recordId": "r1",
+            "namespace": "/test/",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "content": {"text": "x"},
+        }
         visualizer.display_single_record(record, 1, 1, verbose=True)
         console.print.assert_called()
 
@@ -628,7 +633,7 @@ class TestStrategyRecordsWithResolvedNamespaces:
     def test_strategy_records_with_actor_template(self, visualizer, console):
         manager = MagicMock()
         manager.get_memory.return_value = {
-            "strategies": [{"name": "UserFacts", "type": "SEMANTIC", "namespaces": ["/users/{actorId}/facts"]}]
+            "strategies": [{"name": "UserFacts", "type": "SEMANTIC", "namespaces": ["/users/{actorId}/facts/"]}]
         }
         manager.list_actors.return_value = [{"actorId": "user1"}]
         manager.list_records.return_value = [{"memoryRecordId": "r1", "content": {"text": "test"}, "createdAt": "2024"}]
@@ -898,7 +903,7 @@ class TestAddStrategyRecords:
             root,
             manager,
             "mem-123",
-            {"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts"]},
+            {"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts/"]},
             False,
             10,
             export_data,
@@ -932,7 +937,7 @@ class TestMemoryVisualizerIntegration:
                         "status": "ACTIVE",
                         "strategyId": "strat-123",
                         "description": "Semantic facts",
-                        "namespaces": ["/facts", "/summaries"],
+                        "namespaces": ["/facts/", "/summaries/"],
                         "createdAt": "2024-01-01T00:00:00Z",
                         "updatedAt": "2024-01-02T00:00:00Z",
                         "configuration": {"key": "value", "nested": {"inner": "data"}},


### PR DESCRIPTION
## Description

Add trailing slash to namespace strings.

We are using namespace with trailing slash as the standard convention, so we want to ensure all memory namespace examples consistently use trailing slashes for proper path parsing and prefix matching.

## Type of Change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [ ] Manual testing completed

## Checklist

- [x ] My code follows the project's style guidelines (ruff/pre-commit)
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes


N/A

## Additional Notes

Add any additional notes or context about the PR here.
