### PR TITLE
fix: add UTF-8 encoding to template file writes for Windows compatibility

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/create/features/base_feature.py
+++ b/src/bedrock_agentcore_starter_toolkit/create/features/base_feature.py
@@ -101,4 +101,4 @@ class Feature(ABC):
             rendered_content = template.render(context.dict())
             # Only write the file if it has content (skip empty files)
             if rendered_content.strip():
-                dest.write_text(rendered_content)
+                dest.write_text(rendered_content, encoding="utf-8")


### PR DESCRIPTION
## Summary
- Adds explicit `encoding="utf-8"` to `write_text()` call in `base_feature.py`
- Fixes `UnicodeEncodeError` when running `agentcore create` on Windows with templates containing emojis (📊)

## Problem
On Windows, Python's `write_text()` uses the system default encoding (`cp1252`), which cannot handle Unicode characters like emojis. This causes the create command to fail with:
```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4ca'
```

## Solution
Explicitly specify UTF-8 encoding to ensure cross-platform compatibility:
```python
dest.write_text(rendered_content, encoding="utf-8")
```

## Test plan
- [x] All 18 snapshot tests pass (these exercise the full template rendering code path)
- [x] All 2564 unit tests pass
- [ ] Manual verification on Windows with Strands SDK + Memory configuration

Fixes #427