### PR TITLE
fix: pass session_id to dev server in invoke --dev mode

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -736,7 +736,7 @@ def invoke(
 
     # Handle dev mode - simple HTTP request to development server
     if dev_mode:
-        _invoke_dev_server(payload, port)
+        _invoke_dev_server(payload, port, session_id)
         return
 
     try:
@@ -1347,7 +1347,7 @@ def destroy(
         _handle_error(f"Destruction failed: {e}", e)
 
 
-def _invoke_dev_server(payload: str, port: int = 8080) -> None:
+def _invoke_dev_server(payload: str, port: int = 8080, session_id: str = None) -> None:
     """Invoke local development server with simple HTTP request."""
     # Try to parse payload as JSON, fallback to wrapping in prompt
     try:
@@ -1357,11 +1357,15 @@ def _invoke_dev_server(payload: str, port: int = 8080) -> None:
 
     url = f"http://localhost:{port}/invocations"
 
+    # Use provided session_id or generate a new one
+    if session_id is None:
+        session_id = generate_session_id()
+
     # Set headers including Accept for streaming support and session ID
     headers = {
         "Content-Type": "application/json",
         "Accept": "text/event-stream, application/json",
-        "x-amzn-bedrock-agentcore-runtime-session-id": generate_session_id(),
+        "x-amzn-bedrock-agentcore-runtime-session-id": session_id,
     }
 
     try:


### PR DESCRIPTION
## Summary
- Fixes session_id not being passed to the development server when using `agentcore invoke --dev --session-id`
- Previously, each request generated a new UUID, breaking conversation memory during local development
- Now the provided session_id is correctly forwarded to the dev server header

## Test plan
- [x] Added `test_invoke_dev_mode_basic` - verifies basic dev mode with auto-generated session_id
- [x] Added `test_invoke_dev_mode_with_session_id` - verifies provided session_id is used
- [x] Added `test_invoke_dev_mode_connection_error` - verifies helpful error when server not running
- [x] All existing invoke tests pass (24 total)

Fixes #447