### PR TITLE
fix: export Memory class from package root

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/__init__.py
+++ b/src/bedrock_agentcore_starter_toolkit/__init__.py
@@ -1,5 +1,5 @@
 """BedrockAgentCore Starter Toolkit."""
 
-from .notebook import Evaluation, Observability, Runtime
+from .notebook import Evaluation, Memory, Observability, Runtime
 
-__all__ = ["Runtime", "Observability", "Evaluation"]
+__all__ = ["Runtime", "Observability", "Evaluation", "Memory"]


### PR DESCRIPTION
## Summary
- Adds `Memory` class to the package's main `__init__.py` exports
- Makes it consistent with other notebook classes (`Runtime`, `Observability`, `Evaluation`)

## Before
```python
from bedrock_agentcore_starter_toolkit import Memory
# ImportError: cannot import name 'Memory'
```

## After
```python
from bedrock_agentcore_starter_toolkit import Memory
# Works correctly
```

## Test plan
- [x] Verified `from bedrock_agentcore_starter_toolkit import Memory` works
- [x] All existing imports still work

Fixes #442