### PR TITLE
feat(memory): add interactive TUI browser for exploring memory content

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/memory/browser.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/memory/browser.py
@@ -1,0 +1,709 @@
+"""Interactive browser for exploring AgentCore Memory content."""
+
+import json
+import logging
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, List, Optional
+
+from botocore.exceptions import BotoCoreError, ClientError
+from prompt_toolkit import Application
+from prompt_toolkit.key_binding import KeyBindings
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+from bedrock_agentcore_starter_toolkit.operations.memory.manager import MemoryManager
+from bedrock_agentcore_starter_toolkit.operations.memory.memory_visualizer import MemoryVisualizer
+
+logger = logging.getLogger(__name__)
+
+PAGE_SIZE = 25
+
+
+@dataclass
+class NavigationState:
+    """State for navigation through memory hierarchy."""
+
+    memory_id: Optional[str] = None
+    actor_id: Optional[str] = None
+    session_id: Optional[str] = None
+    namespace: Optional[str] = None
+    namespace_template: Optional[str] = None
+    event_index: Optional[int] = None
+    record_index: Optional[int] = None
+    view: str = "memory"
+    cursor: int = 0
+
+
+@dataclass
+class BrowserData:
+    """Cached data for the browser."""
+
+    memory: Optional[Dict[str, Any]] = None
+    actors: List[Dict[str, Any]] = field(default_factory=list)
+    sessions: List[Dict[str, Any]] = field(default_factory=list)
+    events: List[Dict[str, Any]] = field(default_factory=list)
+    namespaces: List[Dict[str, Any]] = field(default_factory=list)
+    records: List[Dict[str, Any]] = field(default_factory=list)
+
+
+class MemoryBrowser:
+    """Interactive browser for AgentCore Memory content."""
+
+    def __init__(
+        self,
+        manager: MemoryManager,
+        memory_id: str,
+        visualizer: Optional[MemoryVisualizer] = None,
+        initial_memory: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Initialize the memory browser."""
+        self.manager = manager
+        self.console = Console()
+        self.visualizer = visualizer or MemoryVisualizer(self.console)
+        self.nav_stack: List[NavigationState] = []
+        self.current = NavigationState(memory_id=memory_id, view="memory")
+        self.data = BrowserData()
+        if initial_memory:
+            self.data.memory = initial_memory
+        self.verbose = False
+        self.cursor = 0
+        self.items: List[Any] = []
+        self.actors_next_token: Optional[str] = None
+        self.sessions_next_token: Optional[str] = None
+        self.events_next_token: Optional[str] = None
+        self.records_next_token: Optional[str] = None
+
+    def run(self) -> None:
+        """Run the interactive browser."""
+        from prompt_toolkit.layout import Layout
+        from prompt_toolkit.layout.containers import Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
+
+        bindings = KeyBindings()
+
+        @bindings.add("up")
+        def _(event):
+            self._cursor_up()
+            self._render()
+
+        @bindings.add("down")
+        def _(event):
+            self._cursor_down()
+            self._render()
+
+        @bindings.add("enter")
+        def _(event):
+            self._select()
+            self._render()
+
+        @bindings.add("b")
+        def _(event):
+            self._go_back()
+            self._render()
+
+        @bindings.add("v")
+        def _(event):
+            self.verbose = not self.verbose
+            self._render()
+
+        @bindings.add("a")
+        def _(event):
+            if self.current.view == "memory":
+                self._push_state()
+                self.current.view = "actors"
+                self._load_view()
+                self._render()
+
+        @bindings.add("n")
+        def _(event):
+            if self.current.view == "memory":
+                self._push_state()
+                self.current.view = "namespaces"
+                self._load_view()
+                self._render()
+
+        @bindings.add("m")
+        def _(event):
+            if self.current.view == "actors" and self.actors_next_token:
+                self._load_actors(load_more=True)
+                self._render()
+            elif self.current.view == "sessions" and self.sessions_next_token:
+                self._load_sessions(load_more=True)
+                self._render()
+            elif self.current.view == "events" and self.events_next_token:
+                self._load_events(load_more=True)
+                self._render()
+            elif self.current.view == "records" and self.records_next_token:
+                self._load_records(load_more=True)
+                self._render()
+
+        @bindings.add("h")
+        def _(event):
+            self.nav_stack.clear()
+            self.current = NavigationState(memory_id=self.current.memory_id, view="memory")
+            self.cursor = 0
+            self.data.actors = []
+            self.data.sessions = []
+            self.data.events = []
+            self.data.records = []
+            self.actors_next_token = None
+            self.sessions_next_token = None
+            self.events_next_token = None
+            self.records_next_token = None
+            self._load_view()
+            self._render()
+
+        @bindings.add("q")
+        def _(event):
+            event.app.exit()
+
+        @bindings.add("c-c")
+        def _(event):
+            event.app.exit()
+
+        # Minimal layout to satisfy prompt_toolkit
+        layout = Layout(Window(FormattedTextControl("")))
+        app = Application(key_bindings=bindings, layout=layout, full_screen=False, erase_when_done=True)
+
+        self._load_view()
+        self._render()
+
+        try:
+            app.run()
+        except EOFError:
+            pass
+
+    def _clear(self) -> None:
+        """Clear the terminal."""
+        self.console.clear()
+
+    def _render(self) -> None:
+        """Render the current view."""
+        self._clear()
+        self._render_breadcrumb()
+        self._render_content()
+        self._render_controls()
+
+    def _render_breadcrumb(self) -> None:
+        """Render breadcrumb navigation."""
+        parts = [self.current.memory_id or "Memory"]
+
+        if self.current.view in ("actors", "sessions", "events", "event_detail"):
+            parts.append("Actors")
+        elif self.current.view in ("namespaces", "namespace_actors", "namespace_sessions", "records", "record_detail"):
+            parts.append("Namespaces")
+
+        actor_views = ("sessions", "events", "event_detail", "namespace_sessions", "records", "record_detail")
+        if self.current.actor_id and self.current.view in actor_views:
+            parts.append(self.current.actor_id)
+
+        if self.current.session_id and self.current.view in ("events", "event_detail", "records", "record_detail"):
+            parts.append(self.current.session_id)
+
+        if self.current.namespace and self.current.view in ("records", "record_detail"):
+            parts.append(self.current.namespace)
+
+        if self.current.view == "event_detail" and self.current.event_index is not None:
+            parts.append(f"Event #{self.current.event_index + 1}")
+        elif self.current.view == "record_detail" and self.current.record_index is not None:
+            parts.append(f"Record #{self.current.record_index + 1}")
+
+        breadcrumb = Text()
+        for i, part in enumerate(parts):
+            if i > 0:
+                breadcrumb.append(" > ", style="dim")
+            breadcrumb.append(part, style="bold cyan" if i == len(parts) - 1 else "dim")
+
+        self.console.print(breadcrumb)
+        self.console.print()
+
+    def _render_content(self) -> None:
+        """Render the main content area."""
+        renderers = {
+            "memory": self._render_memory_view,
+            "event_detail": self._render_event_detail,
+            "record_detail": self._render_record_detail,
+        }
+        list_views = ("actors", "sessions", "events", "namespaces", "namespace_actors", "namespace_sessions", "records")
+
+        if self.current.view in renderers:
+            renderers[self.current.view]()
+        elif self.current.view in list_views:
+            self._render_list_view(self.current.view)
+
+    def _render_memory_view(self) -> None:
+        """Render memory detail with navigation options."""
+        if self.data.memory:
+            tree = self.visualizer.build_memory_tree(self.data.memory, self.verbose)
+            self.console.print(tree)
+
+        self.console.print()
+        self.console.print("[bold]📋 Browse[/bold]\n")
+
+        from rich.box import ROUNDED
+
+        table = Table(box=ROUNDED, show_header=False, padding=(0, 1), border_style="dim")
+        table.add_column("#", style="dim", width=4, justify="right")
+        table.add_column()
+        for i, item in enumerate(self.items):
+            selected = i == self.cursor
+            num = f"▸ {i + 1}" if selected else f"  {i + 1}"
+            label = item["label"]
+            if selected:
+                table.add_row(f"[cyan]{num}[/cyan]", f"[cyan]{label}[/cyan]")
+            else:
+                table.add_row(num, label)
+        self.console.print(table)
+
+    def _render_list_view(self, view_type: str) -> None:
+        """Render a list view with cursor highlighting."""
+        if not self.items:
+            self.console.print("[yellow]No items found[/yellow]")
+            return
+
+        # Title
+        titles = {
+            "actors": f"👤 Actors ({len(self.items)})",
+            "namespace_actors": f"👤 Select Actor for {self.current.namespace_template}",
+            "sessions": f"📁 Sessions ({len(self.items)})",
+            "namespace_sessions": "📁 Select Session",
+            "events": f"💬 Events ({len(self.items)})",
+            "namespaces": f"📊 Namespaces ({len(self.items)})",
+            "records": f"📝 Records ({len(self.items)})",
+        }
+        self.console.print(f"[bold]{titles.get(view_type, view_type)}[/bold]\n")
+
+        from rich.box import ROUNDED
+
+        table = Table(box=ROUNDED, show_header=True, padding=(0, 1), border_style="dim")
+        table.add_column("#", style="dim", width=4, justify="right")
+
+        if view_type in ("actors", "namespace_actors"):
+            table.add_column("Actor ID")
+            for i, item in enumerate(self.items):
+                selected = i == self.cursor
+                num = f"▸ {i + 1}" if selected else f"  {i + 1}"
+                val = item.get("actorId", "N/A")
+                if selected:
+                    table.add_row(f"[cyan]{num}[/cyan]", f"[cyan]{val}[/cyan]")
+                else:
+                    table.add_row(num, val)
+
+        elif view_type in ("sessions", "namespace_sessions"):
+            table.add_column("Session ID")
+            for i, item in enumerate(self.items):
+                selected = i == self.cursor
+                num = f"▸ {i + 1}" if selected else f"  {i + 1}"
+                val = item.get("sessionId", "N/A")
+                if selected:
+                    table.add_row(f"[cyan]{num}[/cyan]", f"[cyan]{val}[/cyan]")
+                else:
+                    table.add_row(num, val)
+
+        elif view_type == "events":
+            table.add_column("Time", width=11)
+            table.add_column("Content", no_wrap=False)
+            for i, item in enumerate(self.items):
+                selected = i == self.cursor
+                num = f"▸ {i + 1}" if selected else f"  {i + 1}"
+                ts = str(item.get("eventTimestamp", ""))[11:19]
+                role = self._extract_role(item)
+                text = self._extract_text(item)
+
+                if role and text:
+                    role_prefix = "👤 User: " if role == "USER" else "🤖 Assistant: "
+                    preview = (text[:60] + "…") if len(text) > 60 else text
+                    content = f"{role_prefix}{preview}"
+                else:
+                    # Show raw payload snippet
+                    content = self._extract_payload_snippet(item)
+
+                if selected:
+                    table.add_row(f"[cyan]{num}[/cyan]", f"[cyan]{ts}[/cyan]", f"[cyan]{content}[/cyan]")
+                else:
+                    table.add_row(num, ts, content)
+
+        elif view_type == "namespaces":
+            table.add_column("Strategy")
+            table.add_column("Type", width=16)
+            table.add_column("Namespace")
+            for i, item in enumerate(self.items):
+                selected = i == self.cursor
+                num = f"▸ {i + 1}" if selected else f"  {i + 1}"
+                strat = item.get("strategy", "")
+                stype = item.get("type", "")
+                ns = item.get("namespace", "")
+                if selected:
+                    table.add_row(
+                        f"[cyan]{num}[/cyan]", f"[cyan]{strat}[/cyan]", f"[cyan]{stype}[/cyan]", f"[cyan]{ns}[/cyan]"
+                    )
+                else:
+                    table.add_row(num, strat, stype, ns)
+
+        elif view_type == "records":
+            table.add_column("Created", width=19)
+            table.add_column("Content", no_wrap=False)
+            for i, item in enumerate(self.items):
+                selected = i == self.cursor
+                num = f"▸ {i + 1}" if selected else f"  {i + 1}"
+                created = str(item.get("createdAt", ""))[:19]
+                text = self._extract_record_text(item)
+                preview = (text[:70] + "…") if text and len(text) > 70 else (text or "")
+                if selected:
+                    table.add_row(f"[cyan]{num}[/cyan]", f"[cyan]{created}[/cyan]", f"[cyan]{preview}[/cyan]")
+                else:
+                    table.add_row(num, created, preview)
+
+        self.console.print(table)
+
+    def _render_event_detail(self) -> None:
+        """Render event detail view."""
+        if self.current.event_index is not None and self.current.event_index < len(self.data.events):
+            event = self.data.events[self.current.event_index]
+            panel = self.visualizer.build_event_detail(event, self.verbose)
+            self.console.print(panel)
+
+    def _render_record_detail(self) -> None:
+        """Render record detail view."""
+        if self.current.record_index is not None and self.current.record_index < len(self.data.records):
+            record = self.data.records[self.current.record_index]
+            panel = self.visualizer.build_record_detail(record, self.verbose, namespace=self.current.namespace)
+            self.console.print(panel)
+
+    def _render_controls(self) -> None:
+        """Render control hints."""
+        self.console.print()
+
+        # Show "load more" notice if applicable
+        has_more = (self.current.view == "events" and self.events_next_token) or (
+            self.current.view == "records" and self.records_next_token
+        )
+        if has_more:
+            self.console.print("[yellow]More items available. Press \\[m] to load more.[/yellow]")
+            self.console.print()
+
+        controls = Text()
+        controls.append("[↑↓]", style="bold cyan")
+        controls.append(" navigate  ")
+        controls.append("[Enter]", style="bold cyan")
+        controls.append(" select  ")
+        if self.current.view != "memory":
+            controls.append("[b]", style="bold cyan")
+            controls.append(" back  ")
+            controls.append("[h]", style="bold cyan")
+            controls.append(" home  ")
+        controls.append("[v]", style="bold cyan")
+        controls.append(" verbose  ")
+        if self.current.view == "memory":
+            controls.append("[a]", style="bold cyan")
+            controls.append(" actors  ")
+            controls.append("[n]", style="bold cyan")
+            controls.append(" namespaces  ")
+        else:
+            controls.append("[m]", style="bold cyan")
+            controls.append(" more  ")
+        controls.append("[q]", style="bold cyan")
+        controls.append(" quit")
+        self.console.print(controls)
+
+    def _load_view(self) -> None:
+        """Load data for current view."""
+        self.cursor = 0
+        self.items = []
+
+        loaders = {
+            "memory": self._load_memory,
+            "actors": self._load_actors,
+            "sessions": self._load_sessions,
+            "events": self._load_events,
+            "namespaces": self._load_namespaces,
+            "namespace_actors": self._load_actors,
+            "namespace_sessions": self._load_sessions,
+            "records": self._load_records,
+        }
+
+        try:
+            loader = loaders.get(self.current.view)
+            if loader:
+                loader()
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_msg = e.response.get("Error", {}).get("Message", str(e))
+            logger.exception("ClientError loading view %s", self.current.view)
+            self.console.print(f"[red]API Error ({error_code}): {error_msg}[/red]")
+        except BotoCoreError as e:
+            logger.exception("BotoCoreError loading view %s", self.current.view)
+            self.console.print(f"[red]AWS Error: {e}[/red]")
+        except Exception as e:
+            logger.exception("Unexpected error loading view %s", self.current.view)
+            self.console.print(f"[red]Error: {e}[/red]")
+
+    def _load_memory(self) -> None:
+        if not self.data.memory:
+            self.data.memory = self.manager.get_memory(self.current.memory_id)
+        self.items = [
+            {"label": "👤 Actors (STM)", "view": "actors"},
+            {"label": "📊 Namespaces (LTM)", "view": "namespaces"},
+        ]
+
+    def _load_actors(self, load_more: bool = False) -> None:
+        # Use cached data if available (e.g., when navigating back)
+        if not load_more and self.data.actors:
+            self.items = self.data.actors
+            return
+
+        token = self.actors_next_token if load_more else None
+        actors, self.actors_next_token = self.manager._paginated_list_page(
+            self.manager._data_plane_client.list_actors,
+            "actorSummaries",
+            {"memoryId": self.current.memory_id},
+            max_results=PAGE_SIZE,
+            next_token=token,
+        )
+
+        if load_more:
+            self.data.actors.extend(actors)
+        else:
+            self.data.actors = actors
+
+        self.items = self.data.actors
+
+    def _load_sessions(self, load_more: bool = False) -> None:
+        # Use cached data if available (e.g., when navigating back)
+        if not load_more and self.data.sessions:
+            self.items = self.data.sessions
+            return
+
+        token = self.sessions_next_token if load_more else None
+        sessions, self.sessions_next_token = self.manager._paginated_list_page(
+            self.manager._data_plane_client.list_sessions,
+            "sessionSummaries",
+            {"memoryId": self.current.memory_id, "actorId": self.current.actor_id},
+            max_results=PAGE_SIZE,
+            next_token=token,
+        )
+
+        if load_more:
+            self.data.sessions.extend(sessions)
+        else:
+            self.data.sessions = sessions
+
+        self.items = self.data.sessions
+
+    def _load_events(self, load_more: bool = False) -> None:
+        # Use cached data if available (e.g., when navigating back)
+        if not load_more and self.data.events:
+            self.items = self.data.events
+            return
+
+        token = self.events_next_token if load_more else None
+        events, self.events_next_token = self.manager._paginated_list_page(
+            self.manager._data_plane_client.list_events,
+            "events",
+            {
+                "memoryId": self.current.memory_id,
+                "actorId": self.current.actor_id,
+                "sessionId": self.current.session_id,
+            },
+            max_results=PAGE_SIZE,
+            next_token=token,
+        )
+
+        if load_more:
+            self.data.events.extend(events)
+        else:
+            self.data.events = events
+
+        self.data.events.sort(key=lambda e: e.get("eventTimestamp", ""), reverse=True)
+        self.items = self.data.events
+
+    def _load_namespaces(self) -> None:
+        if not self.data.memory:
+            self.data.memory = self.manager.get_memory(self.current.memory_id)
+        strategies = self.data.memory.get("strategies") or self.data.memory.get("memoryStrategies") or []
+        self.data.namespaces = []
+        for s in strategies:
+            stype = s.get("type") or s.get("memoryStrategyType", "")
+            for ns in s.get("namespaces", []):
+                self.data.namespaces.append({"strategy": s.get("name"), "type": stype, "namespace": ns})
+        self.items = self.data.namespaces
+
+    def _load_records(self, load_more: bool = False) -> None:
+        # Use cached data if available (e.g., when navigating back)
+        if not load_more and self.data.records:
+            self.items = self.data.records
+            return
+
+        token = self.records_next_token if load_more else None
+        records, self.records_next_token = self.manager._paginated_list_page(
+            self.manager._data_plane_client.list_memory_records,
+            "memoryRecordSummaries",
+            {"memoryId": self.current.memory_id, "namespace": self.current.namespace},
+            max_results=PAGE_SIZE,
+            next_token=token,
+        )
+
+        if load_more:
+            self.data.records.extend(records)
+        else:
+            self.data.records = records
+
+        self.data.records.sort(key=lambda r: r.get("createdAt", ""), reverse=True)
+        self.items = self.data.records
+
+    def _cursor_up(self) -> None:
+        """Move cursor up."""
+        if self.cursor > 0:
+            self.cursor -= 1
+
+    def _cursor_down(self) -> None:
+        """Move cursor down."""
+        if self.cursor < len(self.items) - 1:
+            self.cursor += 1
+
+    def _push_state(self) -> None:
+        """Push current state to navigation stack."""
+        self.current.cursor = self.cursor
+        self.nav_stack.append(replace(self.current))
+
+    def _go_back(self) -> None:
+        """Navigate back."""
+        if self.nav_stack:
+            self.current = self.nav_stack.pop()
+            self._load_view()
+            self.cursor = self.current.cursor
+
+    def _select(self) -> None:
+        """Select current item."""
+        if not self.items:
+            return
+
+        handlers = {
+            "memory": self._select_memory_item,
+            "actors": self._select_actor,
+            "sessions": self._select_session,
+            "events": self._select_event,
+            "namespaces": self._select_namespace,
+            "namespace_actors": self._select_namespace_actor,
+            "namespace_sessions": self._select_namespace_session,
+            "records": self._select_record,
+        }
+
+        handler = handlers.get(self.current.view)
+        if handler:
+            handler()
+
+    def _select_memory_item(self) -> None:
+        self._push_state()
+        self.current.view = self.items[self.cursor]["view"]
+        self._load_view()
+
+    def _select_actor(self) -> None:
+        self._push_state()
+        self.current.actor_id = self.items[self.cursor].get("actorId")
+        self.current.view = "sessions"
+        self.data.sessions = []  # Clear cache for new actor
+        self.sessions_next_token = None
+        self._load_view()
+
+    def _select_session(self) -> None:
+        self._push_state()
+        self.current.session_id = self.items[self.cursor].get("sessionId")
+        self.current.view = "events"
+        self.data.events = []  # Clear cache for new session
+        self.events_next_token = None
+        self._load_view()
+
+    def _select_event(self) -> None:
+        self._push_state()
+        self.current.event_index = self.cursor
+        self.current.view = "event_detail"
+
+    def _select_namespace(self) -> None:
+        ns_info = self.items[self.cursor]
+        ns_template = ns_info.get("namespace", "")
+        self._push_state()
+        self.current.namespace_template = ns_template
+
+        if "{actorId}" in ns_template or "{sessionId}" in ns_template:
+            self.current.view = "namespace_actors"
+            self._load_view()
+        else:
+            self.current.namespace = ns_template
+            self.current.view = "records"
+            self.data.records = []  # Clear cache for new namespace
+            self.records_next_token = None
+            self._load_view()
+
+    def _select_namespace_actor(self) -> None:
+        self._push_state()
+        actor_id = self.items[self.cursor].get("actorId")
+        self.current.actor_id = actor_id
+        ns = self.current.namespace_template.replace("{actorId}", actor_id)
+
+        if "{sessionId}" in ns:
+            self.current.view = "namespace_sessions"
+            self._load_view()
+        else:
+            self.current.namespace = ns
+            self.current.view = "records"
+            self.data.records = []  # Clear cache for new namespace
+            self.records_next_token = None
+            self._load_view()
+
+    def _select_namespace_session(self) -> None:
+        self._push_state()
+        session_id = self.items[self.cursor].get("sessionId")
+        self.current.session_id = session_id
+        ns = self.current.namespace_template.replace("{actorId}", self.current.actor_id)
+        ns = ns.replace("{sessionId}", session_id)
+        self.current.namespace = ns
+        self.current.view = "records"
+        self.data.records = []  # Clear cache for new namespace
+        self.records_next_token = None
+        self._load_view()
+
+    def _select_record(self) -> None:
+        self._push_state()
+        self.current.record_index = self.cursor
+        self.current.view = "record_detail"
+
+    def _extract_role(self, event: Dict[str, Any]) -> str:
+        """Extract role from event."""
+        payload = event.get("payload", {})
+        if isinstance(payload, dict):
+            content = payload.get("content", [])
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and "role" in item:
+                        return item["role"]
+        return ""
+
+    def _extract_text(self, event: Dict[str, Any]) -> str:
+        """Extract text from event."""
+        payload = event.get("payload", {})
+        if isinstance(payload, dict):
+            content = payload.get("content", [])
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and "text" in item:
+                        return item["text"]
+        return ""
+
+    def _extract_payload_snippet(self, event: Dict[str, Any]) -> str:
+        """Extract a snippet from raw payload for preview."""
+        payload = event.get("payload")
+        if not payload:
+            return "(empty)"
+        raw = json.dumps(payload, default=str)
+        if len(raw) > 60:
+            return f"{raw[:60]}…"
+        return raw
+
+    def _extract_record_text(self, record: Dict[str, Any]) -> str:
+        """Extract text from record."""
+        content = record.get("content", {})
+        if isinstance(content, dict):
+            return content.get("text", str(content))
+        return str(content) if content else ""

--- a/src/bedrock_agentcore_starter_toolkit/operations/memory/memory_formatters.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/memory/memory_formatters.py
@@ -224,6 +224,27 @@ def render_content_panel(text: str, verbose: bool = False) -> Union[Panel, str]:
     return format_content_preview(text)
 
 
+def format_payload_snippet(event: Dict[str, Any], max_len: int = 60) -> str:
+    """Format raw payload as truncated JSON snippet.
+
+    Args:
+        event: Event dict with payload field.
+        max_len: Maximum length before truncation.
+
+    Returns:
+        Truncated JSON string with dim styling.
+    """
+    import json
+
+    payload = event.get("payload")
+    if not payload:
+        return "[dim](empty)[/dim]"
+    raw = json.dumps(payload, default=str)
+    if len(raw) > max_len:
+        return f"[dim]{raw[:max_len]}…[/dim]"
+    return f"[dim]{raw}[/dim]"
+
+
 def format_truncation_hint(shown: int, total: int) -> str:
     """Format '... N more items' hint.
 

--- a/tests/cli/memory/test_browser.py
+++ b/tests/cli/memory/test_browser.py
@@ -1,0 +1,1017 @@
+"""Tests for memory browser."""
+
+from dataclasses import replace
+from unittest.mock import MagicMock
+
+from botocore.exceptions import BotoCoreError, ClientError
+from rich.console import Console
+
+from bedrock_agentcore_starter_toolkit.cli.memory.browser import (
+    BrowserData,
+    MemoryBrowser,
+    NavigationState,
+)
+
+
+class TestNavigationState:
+    """Test NavigationState dataclass."""
+
+    def test_default_values(self):
+        state = NavigationState()
+        assert state.memory_id is None
+        assert state.actor_id is None
+        assert state.session_id is None
+        assert state.namespace is None
+        assert state.view == "memory"
+        assert state.cursor == 0
+
+    def test_with_values(self):
+        state = NavigationState(
+            memory_id="mem-123",
+            actor_id="actor-1",
+            view="actors",
+            cursor=5,
+        )
+        assert state.memory_id == "mem-123"
+        assert state.actor_id == "actor-1"
+        assert state.view == "actors"
+        assert state.cursor == 5
+
+    def test_replace(self):
+        state = NavigationState(memory_id="mem-123", view="memory", cursor=3)
+        new_state = replace(state, view="actors")
+        assert state.view == "memory"
+        assert new_state.view == "actors"
+        assert new_state.memory_id == "mem-123"
+        assert new_state.cursor == 3
+
+
+class TestBrowserData:
+    """Test BrowserData dataclass."""
+
+    def test_default_values(self):
+        data = BrowserData()
+        assert data.memory is None
+        assert data.actors == []
+        assert data.sessions == []
+        assert data.events == []
+        assert data.namespaces == []
+        assert data.records == []
+
+    def test_mutable_defaults_isolated(self):
+        data1 = BrowserData()
+        data2 = BrowserData()
+        data1.actors.append({"actorId": "a1"})
+        assert data2.actors == []
+
+
+class TestMemoryBrowserInit:
+    """Test MemoryBrowser initialization."""
+
+    def test_init_with_manager(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        assert browser.manager == manager
+        assert browser.current.memory_id == "mem-123"
+        assert browser.current.view == "memory"
+        assert browser.nav_stack == []
+        assert browser.verbose is False
+
+    def test_init_with_visualizer(self):
+        manager = MagicMock()
+        visualizer = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123", visualizer)
+        assert browser.visualizer == visualizer
+
+    def test_init_with_initial_memory(self):
+        manager = MagicMock()
+        memory = {"id": "mem-123", "strategies": []}
+        browser = MemoryBrowser(manager, "mem-123", initial_memory=memory)
+        assert browser.data.memory == memory
+
+    def test_load_memory_skips_api_when_preloaded(self):
+        manager = MagicMock()
+        memory = {"id": "mem-123", "strategies": []}
+        browser = MemoryBrowser(manager, "mem-123", initial_memory=memory)
+        browser._load_memory()
+        manager.get_memory.assert_not_called()
+
+
+class TestMemoryBrowserNavigation:
+    """Test MemoryBrowser navigation methods."""
+
+    def test_push_state(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "actors"
+        browser.cursor = 5
+        browser._push_state()
+        assert len(browser.nav_stack) == 1
+        assert browser.nav_stack[0].view == "actors"
+        assert browser.nav_stack[0].cursor == 5
+
+    def test_go_back_empty_stack(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser._go_back()  # Should not raise
+        assert browser.current.view == "memory"
+
+    def test_go_back_with_stack(self):
+        manager = MagicMock()
+        manager.get_memory.return_value = {"id": "mem-123", "name": "test", "status": "ACTIVE"}
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.nav_stack.append(NavigationState(memory_id="mem-123", view="memory", cursor=2))
+        browser.current.view = "actors"
+        browser.cursor = 0
+
+        browser._go_back()
+
+        assert browser.current.view == "memory"
+        assert browser.cursor == 2
+        assert len(browser.nav_stack) == 0
+
+    def test_go_back_restores_cursor(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([{"actorId": "a1"}, {"actorId": "a2"}, {"actorId": "a3"}], None)
+        browser = MemoryBrowser(manager, "mem-123")
+
+        # Simulate: at actors view, cursor on item 2, then navigated forward
+        browser.nav_stack.append(NavigationState(memory_id="mem-123", view="actors", cursor=2))
+        browser.current.view = "sessions"
+        browser.cursor = 0
+
+        browser._go_back()
+
+        assert browser.current.view == "actors"
+        assert browser.cursor == 2
+
+
+class TestMemoryBrowserCursor:
+    """Test MemoryBrowser cursor movement."""
+
+    def test_cursor_up(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.cursor = 2
+        browser._cursor_up()
+        assert browser.cursor == 1
+
+    def test_cursor_up_at_zero(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.cursor = 0
+        browser._cursor_up()
+        assert browser.cursor == 0
+
+    def test_cursor_down(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.items = [1, 2, 3]
+        browser.cursor = 0
+        browser._cursor_down()
+        assert browser.cursor == 1
+
+    def test_cursor_down_at_end(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.items = [1, 2, 3]
+        browser.cursor = 2
+        browser._cursor_down()
+        assert browser.cursor == 2
+
+
+class TestMemoryBrowserSelection:
+    """Test MemoryBrowser selection handlers."""
+
+    def test_select_actor(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "actors"
+        browser.items = [{"actorId": "actor-1"}, {"actorId": "actor-2"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.actor_id == "actor-1"
+        assert browser.current.view == "sessions"
+        assert len(browser.nav_stack) == 1
+
+    def test_select_session(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "sessions"
+        browser.current.actor_id = "actor-1"
+        browser.items = [{"sessionId": "sess-1"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.session_id == "sess-1"
+        assert browser.current.view == "events"
+
+    def test_select_event(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "events"
+        browser.items = [{"eventId": "evt-1"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.event_index == 0
+        assert browser.current.view == "event_detail"
+
+    def test_select_static_namespace(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "namespaces"
+        browser.items = [{"namespace": "/facts"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.namespace == "/facts"
+        assert browser.current.view == "records"
+
+    def test_select_template_namespace(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "namespaces"
+        browser.items = [{"namespace": "/users/{actorId}/facts"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.view == "namespace_actors"
+        assert browser.current.namespace_template == "/users/{actorId}/facts"
+
+    def test_select_namespace_actor(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "namespace_actors"
+        browser.current.namespace_template = "/users/{actorId}/facts"
+        browser.items = [{"actorId": "user-1"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.namespace == "/users/user-1/facts"
+        assert browser.current.view == "records"
+
+    def test_select_namespace_actor_with_session(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "namespace_actors"
+        browser.current.namespace_template = "/summaries/{actorId}/{sessionId}"
+        browser.items = [{"actorId": "user-1"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.view == "namespace_sessions"
+        assert browser.current.actor_id == "user-1"
+
+    def test_select_namespace_session(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "namespace_sessions"
+        browser.current.namespace_template = "/summaries/{actorId}/{sessionId}"
+        browser.current.actor_id = "user-1"
+        browser.items = [{"sessionId": "sess-1"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.namespace == "/summaries/user-1/sess-1"
+        assert browser.current.view == "records"
+
+    def test_select_record(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "records"
+        browser.current.namespace = "/facts"
+        browser.items = [{"memoryRecordId": "rec-1"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.record_index == 0
+        assert browser.current.view == "record_detail"
+
+    def test_select_empty_items(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.items = []
+        browser._select()  # Should not raise
+
+    def test_select_memory_item_actors(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "memory"
+        browser.items = [{"label": "Actors", "view": "actors"}, {"label": "Namespaces", "view": "namespaces"}]
+        browser.cursor = 0
+
+        browser._select()
+
+        assert browser.current.view == "actors"
+        assert len(browser.nav_stack) == 1
+
+    def test_select_memory_item_namespaces(self):
+        manager = MagicMock()
+        manager.get_memory.return_value = {"strategies": []}
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "memory"
+        browser.items = [{"label": "Actors", "view": "actors"}, {"label": "Namespaces", "view": "namespaces"}]
+        browser.cursor = 1
+
+        browser._select()
+
+        assert browser.current.view == "namespaces"
+
+
+class TestMemoryBrowserExtractors:
+    """Test text extraction methods."""
+
+    def test_extract_role(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        event = {"payload": {"content": [{"role": "USER", "text": "Hello"}]}}
+        assert browser._extract_role(event) == "USER"
+
+    def test_extract_role_empty(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        assert browser._extract_role({}) == ""
+        assert browser._extract_role({"payload": {}}) == ""
+        assert browser._extract_role({"payload": {"content": []}}) == ""
+
+    def test_extract_text(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        event = {"payload": {"content": [{"text": "Hello world"}]}}
+        assert browser._extract_text(event) == "Hello world"
+
+    def test_extract_text_empty(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        assert browser._extract_text({}) == ""
+        assert browser._extract_text({"payload": {"content": [{"role": "USER"}]}}) == ""
+
+    def test_extract_record_text(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        record = {"content": {"text": "Test content"}}
+        assert browser._extract_record_text(record) == "Test content"
+
+    def test_extract_record_text_string_content(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        record = {"content": "plain string"}
+        assert browser._extract_record_text(record) == "plain string"
+
+    def test_extract_record_text_empty(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        assert browser._extract_record_text({}) == "{}"  # Empty dict stringified
+        assert browser._extract_record_text({"content": None}) == ""
+
+    def test_extract_payload_snippet_short(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        event = {"payload": {"key": "val"}}
+        assert browser._extract_payload_snippet(event) == '{"key": "val"}'
+
+    def test_extract_payload_snippet_long(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        event = {"payload": {"text": "a" * 100}}
+        result = browser._extract_payload_snippet(event)
+        assert len(result) == 61  # 60 chars + "…"
+        assert result.endswith("…")
+
+    def test_extract_payload_snippet_empty(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        assert browser._extract_payload_snippet({}) == "(empty)"
+        assert browser._extract_payload_snippet({"payload": None}) == "(empty)"
+
+
+class TestMemoryBrowserLoadView:
+    """Test view loading methods."""
+
+    def test_load_memory_view(self):
+        manager = MagicMock()
+        manager.get_memory.return_value = {"id": "mem-123", "strategies": []}
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "memory"
+        browser._load_view()
+        assert browser.data.memory == {"id": "mem-123", "strategies": []}
+        assert len(browser.items) == 2
+        assert browser.items[0]["view"] == "actors"
+        assert browser.items[1]["view"] == "namespaces"
+
+    def test_load_actors_view(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([{"actorId": "a1"}, {"actorId": "a2"}], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "actors"
+        browser._load_view()
+        assert len(browser.items) == 2
+        assert browser.cursor == 0
+
+    def test_load_sessions_view(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([{"sessionId": "s1"}], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "sessions"
+        browser.current.actor_id = "a1"
+        browser._load_view()
+        assert len(browser.items) == 1
+
+    def test_load_events_view(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = (
+            [
+                {"eventId": "e1", "eventTimestamp": "2024-01-01T10:00:00"},
+                {"eventId": "e2", "eventTimestamp": "2024-01-01T09:00:00"},
+                {"eventId": "e3", "eventTimestamp": "2024-01-01T11:00:00"},
+                {"eventId": "e4", "eventTimestamp": "2024-01-01T08:00:00"},
+            ],
+            None,
+        )
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "events"
+        browser.current.actor_id = "a1"
+        browser.current.session_id = "s1"
+        browser._load_view()
+        assert len(browser.items) == 4
+        # Should be sorted by timestamp ascending
+        assert [e["eventId"] for e in browser.items] == ["e3", "e1", "e2", "e4"]
+
+    def test_load_namespaces_view(self):
+        manager = MagicMock()
+        manager.get_memory.return_value = {
+            "strategies": [
+                {"name": "Facts", "type": "SEMANTIC", "namespaces": ["/facts"]},
+                {"name": "Prefs", "type": "USER_PREFERENCE", "namespaces": ["/prefs/{actorId}"]},
+            ]
+        }
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "namespaces"
+        browser._load_view()
+        assert len(browser.items) == 2
+        assert browser.items[0]["namespace"] == "/facts"
+        assert browser.items[1]["type"] == "USER_PREFERENCE"
+
+    def test_load_records_view(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([{"memoryRecordId": "r1"}], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "records"
+        browser.current.namespace = "/facts"
+        browser._load_view()
+        assert len(browser.items) == 1
+
+    def test_load_view_error_handling(self):
+        manager = MagicMock()
+        manager._paginated_list_page.side_effect = Exception("API error")
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.console = MagicMock()
+        browser.current.view = "actors"
+        browser._load_view()
+        assert browser.items == []
+        browser.console.print.assert_called()
+        error_msg = browser.console.print.call_args[0][0]
+        assert "Error" in error_msg and "API error" in error_msg
+
+    def test_load_view_client_error_handling(self):
+        """Test ClientError is caught and displays error code."""
+        manager = MagicMock()
+        error_response = {"Error": {"Code": "ExpiredTokenException", "Message": "Token expired"}}
+        manager._paginated_list_page.side_effect = ClientError(error_response, "ListActors")
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.console = MagicMock()
+        browser.current.view = "actors"
+        browser._load_view()
+        assert browser.items == []
+        browser.console.print.assert_called()
+        error_msg = browser.console.print.call_args[0][0]
+        assert "ExpiredTokenException" in error_msg
+
+    def test_load_view_botocore_error_handling(self):
+        """Test BotoCoreError is caught."""
+        manager = MagicMock()
+        manager._paginated_list_page.side_effect = BotoCoreError()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.console = MagicMock()
+        browser.current.view = "actors"
+        browser._load_view()
+        assert browser.items == []
+        browser.console.print.assert_called()
+        error_msg = browser.console.print.call_args[0][0]
+        assert "AWS Error" in error_msg
+
+
+class TestMemoryBrowserLoadMore:
+    """Test load_more pagination and cache behavior."""
+
+    def test_load_actors_load_more(self):
+        manager = MagicMock()
+        manager._paginated_list_page.side_effect = [
+            ([{"actorId": "a1"}], "token1"),
+            ([{"actorId": "a2"}], None),
+        ]
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "actors"
+        browser._load_actors()
+        assert len(browser.data.actors) == 1
+        assert browser.actors_next_token == "token1"
+
+        browser._load_actors(load_more=True)
+        assert len(browser.data.actors) == 2
+        assert browser.data.actors[1]["actorId"] == "a2"
+        assert browser.actors_next_token is None
+
+    def test_load_sessions_load_more(self):
+        manager = MagicMock()
+        manager._paginated_list_page.side_effect = [
+            ([{"sessionId": "s1"}], "tok"),
+            ([{"sessionId": "s2"}], None),
+        ]
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.actor_id = "a1"
+        browser._load_sessions()
+        assert browser.sessions_next_token == "tok"
+
+        browser._load_sessions(load_more=True)
+        assert len(browser.data.sessions) == 2
+        assert browser.sessions_next_token is None
+
+    def test_load_events_load_more_sorts(self):
+        manager = MagicMock()
+        manager._paginated_list_page.side_effect = [
+            ([{"eventId": "e1", "eventTimestamp": "2024-01-01T10:00:00"}], "tok"),
+            ([{"eventId": "e2", "eventTimestamp": "2024-01-01T08:00:00"}], None),
+        ]
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.actor_id = "a1"
+        browser.current.session_id = "s1"
+        browser._load_events()
+        browser._load_events(load_more=True)
+        assert len(browser.data.events) == 2
+        # Sorted by timestamp descending — e1 (10:00) before e2 (08:00)
+        assert browser.data.events[0]["eventId"] == "e1"
+        assert browser.data.events[1]["eventId"] == "e2"
+
+    def test_load_records_load_more(self):
+        manager = MagicMock()
+        manager._paginated_list_page.side_effect = [
+            ([{"memoryRecordId": "r1"}], "tok"),
+            ([{"memoryRecordId": "r2"}], None),
+        ]
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.namespace = "/facts"
+        browser._load_records()
+        assert browser.records_next_token == "tok"
+
+        browser._load_records(load_more=True)
+        assert len(browser.data.records) == 2
+        assert browser.records_next_token is None
+
+    def test_load_actors_cache_hit(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.data.actors = [{"actorId": "cached"}]
+        browser._load_actors()
+        manager._paginated_list_page.assert_not_called()
+        assert browser.items == [{"actorId": "cached"}]
+
+    def test_load_namespaces_fallback_key(self):
+        manager = MagicMock()
+        manager.get_memory.return_value = {
+            "memoryStrategies": [
+                {"name": "Facts", "memoryStrategyType": "SEMANTIC", "namespaces": ["/facts"]},
+            ]
+        }
+        browser = MemoryBrowser(manager, "mem-123")
+        browser._load_namespaces()
+        assert len(browser.items) == 1
+        assert browser.items[0]["namespace"] == "/facts"
+        assert browser.items[0]["type"] == "SEMANTIC"
+
+
+class TestMemoryBrowserCacheInvalidation:
+    """Test cache clearing on navigation."""
+
+    def test_select_actor_clears_session_cache(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "actors"
+        browser.data.sessions = [{"sessionId": "stale"}]
+        browser.sessions_next_token = "old_token"
+        browser.items = [{"actorId": "a1"}]
+        browser.cursor = 0
+
+        browser._select_actor()
+
+        assert browser.data.sessions == []
+        assert browser.sessions_next_token is None
+
+    def test_select_session_clears_event_cache(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "sessions"
+        browser.current.actor_id = "a1"
+        browser.data.events = [{"eventId": "stale"}]
+        browser.events_next_token = "old_token"
+        browser.items = [{"sessionId": "s1"}]
+        browser.cursor = 0
+
+        browser._select_session()
+
+        assert browser.data.events == []
+        assert browser.events_next_token is None
+
+    def test_select_namespace_clears_record_cache(self):
+        manager = MagicMock()
+        manager._paginated_list_page.return_value = ([], None)
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.current.view = "namespaces"
+        browser.data.records = [{"memoryRecordId": "stale"}]
+        browser.records_next_token = "old_token"
+        browser.items = [{"namespace": "/facts"}]
+        browser.cursor = 0
+
+        browser._select_namespace()
+
+        assert browser.data.records == []
+        assert browser.records_next_token is None
+
+
+class TestMemoryBrowserRender:
+    """Test rendering methods."""
+
+    def _make_browser(self, **kwargs):
+        manager = kwargs.pop("manager", MagicMock())
+        from io import StringIO
+
+        buf = StringIO()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.console = Console(file=buf, force_terminal=True, width=120)
+        browser.visualizer = MagicMock()
+        return browser, buf
+
+    def test_render_breadcrumb_memory_root(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "memory"
+        browser._render_breadcrumb()
+        output = buf.getvalue()
+        assert "mem-123" in output
+
+    def test_render_breadcrumb_deep_navigation(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "event_detail"
+        browser.current.actor_id = "actor-1"
+        browser.current.session_id = "sess-1"
+        browser.current.event_index = 2
+        browser._render_breadcrumb()
+        output = buf.getvalue()
+        assert "Actors" in output
+        assert "actor-1" in output
+        assert "sess-1" in output
+        assert "Event #3" in output
+
+    def test_render_breadcrumb_record_detail(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "record_detail"
+        browser.current.namespace = "/facts"
+        browser.current.record_index = 0
+        browser._render_breadcrumb()
+        output = buf.getvalue()
+        assert "Namespaces" in output
+        assert "/facts" in output
+        assert "Record #1" in output
+
+    def test_render_memory_view_calls_visualizer(self):
+        browser, buf = self._make_browser()
+        browser.data.memory = {"id": "mem-123"}
+        browser.items = [
+            {"label": "👤 Actors (STM)", "view": "actors"},
+            {"label": "📊 Namespaces (LTM)", "view": "namespaces"},
+        ]
+        browser._render_memory_view()
+        browser.visualizer.build_memory_tree.assert_called_once_with({"id": "mem-123"}, False)
+        output = buf.getvalue()
+        assert "Actors" in output
+        assert "Namespaces" in output
+
+    def test_render_memory_view_no_data_shows_nav(self):
+        browser, buf = self._make_browser()
+        browser.data.memory = None
+        browser.items = [
+            {"label": "👤 Actors (STM)", "view": "actors"},
+            {"label": "📊 Namespaces (LTM)", "view": "namespaces"},
+        ]
+        browser._render_memory_view()
+        browser.visualizer.build_memory_tree.assert_not_called()
+        output = buf.getvalue()
+        assert "Actors" in output
+        assert "Namespaces" in output
+
+    def test_render_event_detail_calls_visualizer(self):
+        browser, _ = self._make_browser()
+        browser.current.view = "event_detail"
+        browser.current.event_index = 0
+        browser.data.events = [{"eventId": "e1"}]
+        browser._render_event_detail()
+        browser.visualizer.build_event_detail.assert_called_once_with({"eventId": "e1"}, False)
+
+    def test_render_record_detail_with_namespace(self):
+        browser, _ = self._make_browser()
+        browser.current.view = "record_detail"
+        browser.current.record_index = 0
+        browser.current.namespace = "/facts"
+        browser.data.records = [{"memoryRecordId": "r1"}]
+        browser._render_record_detail()
+        browser.visualizer.build_record_detail.assert_called_once_with(
+            {"memoryRecordId": "r1"}, False, namespace="/facts"
+        )
+
+    def test_render_event_detail_out_of_bounds(self):
+        browser, _ = self._make_browser()
+        browser.current.event_index = 5
+        browser.data.events = [{"eventId": "e1"}]
+        browser._render_event_detail()  # Should not raise
+        browser.visualizer.build_event_detail.assert_not_called()
+
+    def test_render_list_view_empty(self):
+        browser, buf = self._make_browser()
+        browser.items = []
+        browser._render_list_view("actors")
+        assert "No items found" in buf.getvalue()
+
+    def test_render_list_view_events_with_role(self):
+        browser, buf = self._make_browser()
+        browser.items = [
+            {"eventTimestamp": "2024-01-01T10:30:00", "payload": {"content": [{"role": "USER", "text": "Hello"}]}},
+            {"eventTimestamp": "2024-01-01T11:00:00", "payload": {"content": [{"role": "ASSISTANT", "text": "Hi"}]}},
+        ]
+        browser.cursor = 0
+        browser._render_list_view("events")
+        output = buf.getvalue()
+        assert "Hello" in output
+        assert "Hi" in output
+
+    def test_render_list_view_events_payload_fallback(self):
+        browser, buf = self._make_browser()
+        browser.items = [
+            {"eventTimestamp": "2024-01-01T10:30:00", "payload": {"toolUse": "something"}},
+        ]
+        browser.cursor = 0
+        browser._render_list_view("events")
+        output = buf.getvalue()
+        assert "toolUse" in output
+
+
+class TestMemoryBrowserRenderControls:
+    """Test _render_controls load-more notice behavior."""
+
+    def _make_browser(self):
+        from io import StringIO
+
+        buf = StringIO()
+        browser = MemoryBrowser(MagicMock(), "mem-123")
+        browser.console = Console(file=buf, force_terminal=True, width=120)
+        return browser, buf
+
+    def test_render_controls_shows_more_for_events(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "events"
+        browser.events_next_token = "tok"
+        browser._render_controls()
+        assert "More items available" in buf.getvalue()
+
+    def test_render_controls_no_notice_for_actors(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "actors"
+        browser.actors_next_token = "tok"
+        browser._render_controls()
+        assert "More items available" not in buf.getvalue()
+
+    def test_render_controls_shows_shortcuts_on_memory_view(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "memory"
+        browser._render_controls()
+        output = buf.getvalue()
+        assert "actors" in output
+        assert "namespaces" in output
+        assert "back" not in output
+        assert "home" not in output
+        assert "more" not in output
+
+    def test_render_controls_no_shortcuts_on_other_views(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "actors"
+        browser._render_controls()
+        output = buf.getvalue()
+        assert "namespaces" not in output
+        assert "back" in output
+        assert "home" in output
+        assert "more" in output
+
+
+class TestMemoryBrowserCoverage:
+    """Tests to cover remaining uncovered lines and branches."""
+
+    def _make_browser(self, **kwargs):
+        manager = kwargs.pop("manager", MagicMock())
+        from io import StringIO
+
+        buf = StringIO()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.console = Console(file=buf, force_terminal=True, width=120)
+        browser.visualizer = MagicMock()
+        return browser, buf
+
+    # _clear and _render (lines 179, 183-186)
+    def test_render_calls_all_phases(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "memory"
+        browser.items = [
+            {"label": "👤 Actors (STM)", "view": "actors"},
+            {"label": "📊 Namespaces (LTM)", "view": "namespaces"},
+        ]
+        browser._render()
+        output = buf.getvalue()
+        # Breadcrumb, content, and controls all rendered
+        assert "Browse" in output
+        assert "quit" in output
+
+    # _render_content dispatch (lines 223-233)
+    def test_render_content_dispatches_to_list_view(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "actors"
+        browser.items = [{"actorId": "a1"}]
+        browser.cursor = 0
+        browser._render_content()
+        assert "a1" in buf.getvalue()
+
+    def test_render_content_unknown_view(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "unknown_view"
+        browser._render_content()
+        assert buf.getvalue() == ""
+
+    # _render_list_view actors (lines 283-291)
+    def test_render_list_view_actors(self):
+        browser, buf = self._make_browser()
+        browser.items = [{"actorId": "actor-1"}, {"actorId": "actor-2"}]
+        browser.cursor = 0
+        browser._render_list_view("actors")
+        output = buf.getvalue()
+        assert "actor-1" in output
+        assert "actor-2" in output
+
+    def test_render_list_view_namespace_actors(self):
+        browser, buf = self._make_browser()
+        browser.items = [{"actorId": "ns-actor"}]
+        browser.cursor = 0
+        browser._render_list_view("namespace_actors")
+        assert "ns-actor" in buf.getvalue()
+
+    # _render_list_view sessions (lines 294-302)
+    def test_render_list_view_sessions(self):
+        browser, buf = self._make_browser()
+        browser.items = [{"sessionId": "sess-1"}, {"sessionId": "sess-2"}]
+        browser.cursor = 0
+        browser._render_list_view("sessions")
+        output = buf.getvalue()
+        assert "sess-1" in output
+        assert "sess-2" in output
+
+    # _render_list_view namespaces (lines 325-340)
+    def test_render_list_view_namespaces(self):
+        browser, buf = self._make_browser()
+        browser.items = [
+            {"strategy": "Facts", "type": "SEMANTIC", "namespace": "/facts"},
+            {"strategy": "Conv", "type": "CONVERSATION_SUMMARY", "namespace": "/conv"},
+        ]
+        browser.cursor = 0
+        browser._render_list_view("namespaces")
+        output = buf.getvalue()
+        assert "Facts" in output
+        assert "/conv" in output
+
+    # _render_list_view records (lines 342-356)
+    def test_render_list_view_records(self):
+        browser, buf = self._make_browser()
+        long_text = "x" * 80
+        browser.items = [
+            {"createdAt": "2024-01-01T10:00:00Z", "content": {"text": long_text}},
+            {"createdAt": "2024-01-02T10:00:00Z", "content": {"text": "short"}},
+        ]
+        browser.cursor = 0
+        browser._render_list_view("records")
+        output = buf.getvalue()
+        assert "2024-01-01" in output
+        assert "…" in output  # truncation of long text
+
+    # Cache hits: sessions (lines 475-476)
+    def test_load_sessions_cache_hit(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.data.sessions = [{"sessionId": "cached"}]
+        browser._load_sessions()
+        manager._paginated_list_page.assert_not_called()
+        assert browser.items == [{"sessionId": "cached"}]
+
+    # Cache hits: events (lines 497-498)
+    def test_load_events_cache_hit(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.data.events = [{"eventId": "cached"}]
+        browser._load_events()
+        manager._paginated_list_page.assert_not_called()
+        assert browser.items == [{"eventId": "cached"}]
+
+    # Cache hits: records (lines 535-536)
+    def test_load_records_cache_hit(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.data.records = [{"recordId": "cached"}]
+        browser._load_records()
+        manager._paginated_list_page.assert_not_called()
+        assert browser.items == [{"recordId": "cached"}]
+
+    # _load_view unknown view (line 428->exit)
+    def test_load_view_unknown_view(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "nonexistent"
+        browser._load_view()  # should not raise
+        assert browser.items == []
+
+    # _select with no items (line 593->exit)
+    def test_select_empty_items(self):
+        browser, _ = self._make_browser()
+        browser.items = []
+        browser._select()  # should not raise
+
+    # _select unknown view (line 593->exit handler branch)
+    def test_select_unknown_view(self):
+        browser, _ = self._make_browser()
+        browser.items = [{"something": "val"}]
+        browser.current.view = "nonexistent"
+        browser._select()  # should not raise
+
+    # Branch: _extract_role with non-dict payload (674->680)
+    def test_extract_role_non_dict_payload(self):
+        browser, _ = self._make_browser()
+        assert browser._extract_role({"payload": "string"}) == ""
+
+    # Branch: _extract_role with non-list content (676->680)
+    def test_extract_role_non_list_content(self):
+        browser, _ = self._make_browser()
+        assert browser._extract_role({"payload": {"content": "string"}}) == ""
+
+    # Branch: _extract_role item not dict (678->677)
+    def test_extract_role_non_dict_item(self):
+        browser, _ = self._make_browser()
+        assert browser._extract_role({"payload": {"content": ["not_a_dict"]}}) == ""
+
+    # Branch: _extract_text with non-dict payload (685->691)
+    def test_extract_text_non_dict_payload(self):
+        browser, _ = self._make_browser()
+        assert browser._extract_text({"payload": "string"}) == ""
+
+    # Branch: _extract_text with non-list content (687->691)
+    def test_extract_text_non_list_content(self):
+        browser, _ = self._make_browser()
+        assert browser._extract_text({"payload": {"content": "string"}}) == ""
+
+    # _render_controls branch exit (369->exit): no token, no memory view
+    def test_render_controls_minimal(self):
+        browser, buf = self._make_browser()
+        browser.current.view = "sessions"
+        browser._render_controls()
+        output = buf.getvalue()
+        assert "navigate" in output
+        assert "More items" not in output
+
+    # _load_namespaces with memory already cached (522->524)
+    def test_load_namespaces_memory_already_cached(self):
+        manager = MagicMock()
+        browser = MemoryBrowser(manager, "mem-123")
+        browser.data.memory = {"strategies": [{"name": "S", "type": "SEMANTIC", "namespaces": ["/ns"]}]}
+        browser._load_namespaces()
+        manager.get_memory.assert_not_called()
+        assert browser.items[0]["namespace"] == "/ns"

--- a/tests/operations/memory/test_formatters.py
+++ b/tests/operations/memory/test_formatters.py
@@ -12,6 +12,7 @@ from bedrock_agentcore_starter_toolkit.operations.memory.memory_formatters impor
     format_content_preview,
     format_memory_age,
     format_namespaces,
+    format_payload_snippet,
     format_role_icon,
     format_truncation_hint,
     get_memory_status_icon,
@@ -162,6 +163,14 @@ class TestExtractEventText:
         event = {"payload": [{"conversational": {"content": {"text": "not json"}}}]}
         assert extract_event_text(event) is None
 
+    def test_extract_event_text_empty_message_content(self):
+        """Test when message.content is empty list."""
+        import json
+
+        inner = {"message": {"content": []}}
+        event = {"payload": [{"conversational": {"content": {"text": json.dumps(inner)}}}]}
+        assert extract_event_text(event) is None
+
 
 class TestExtractEventRole:
     """Test event role extraction."""
@@ -296,3 +305,25 @@ class TestStrategyTypeConstants:
 
         assert StrategyType.SEMANTIC.get_override_type() is None
         assert StrategyType.SUMMARY.get_override_type() is None
+
+
+class TestFormatPayloadSnippet:
+    """Test format_payload_snippet function."""
+
+    def test_format_payload_snippet_empty(self):
+        """Test with empty payload."""
+        event = {"payload": None}
+        result = format_payload_snippet(event)
+        assert "(empty)" in result
+
+    def test_format_payload_snippet_short(self):
+        """Test with short payload."""
+        event = {"payload": [{"key": "value"}]}
+        result = format_payload_snippet(event, max_len=100)
+        assert "key" in result
+
+    def test_format_payload_snippet_truncated(self):
+        """Test with long payload that gets truncated."""
+        event = {"payload": [{"key": "a" * 200}]}
+        result = format_payload_snippet(event, max_len=50)
+        assert "…" in result

--- a/tests_integ/notebook/memory_integration_test.ipynb
+++ b/tests_integ/notebook/memory_integration_test.ipynb
@@ -323,13 +323,13 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.10.0"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add a new 'agentcore memory browse' command that provides an interactive terminal UI for exploring AgentCore Memory content.

Features:
- Navigate through actors, sessions, events (STM) and namespaces, records (LTM)
- Keyboard navigation: ↑↓ navigate, Enter select, b back, h home, v verbose, m more, q quit
- Glass UI design with Rich tables and cyan highlighting
- Proper API pagination for all list operations (actors, sessions, events, records)
- Breadcrumb display showing current navigation path
- Cursor preservation when navigating back

Also includes:
- Pagination support for list_actors and list_sessions APIs
- Tests to maintain 88% coverage threshold

## Description

Brief description of changes

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [X] Unit tests pass locally
- [X] Integration tests pass (if applicable)
- [X] Test coverage remains above 80%
- [X] Manual testing completed

## Checklist

- [X] My code follows the project's style guidelines (ruff/pre-commit)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published

## Security Checklist

- [X] No hardcoded secrets or credentials
- [X] No new security warnings from bandit
- [X] Dependencies are from trusted sources
- [X] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:



N/A

## Additional Notes
https://github.com/user-attachments/assets/6864460c-3d69-4813-a99e-7e10453f7c0a