### PR TITLE
fix: modify execution role naming and disallow codebuild for govcloud

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/configure.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple
 import boto3
 
 from ...cli.runtime.configuration_manager import ConfigurationManager
-from ...utils.aws import get_account_id, get_region
+from ...utils.aws import get_account_id, get_partition, get_region
 from ...utils.paths import expand_source_path_for_dependencies
 from ...utils.runtime.config import load_config_if_exists, merge_agent_config, save_config
 from ...utils.runtime.container import ContainerRuntime
@@ -244,14 +244,15 @@ def configure_bedrock_agentcore(
 
     # Handle execution role - convert to ARN if provided, otherwise use auto-create setting
     execution_role_arn = None
-    execution_role_auto_create = auto_create_execution_role
+    execution_role_auto_create = False if execution_role else auto_create_execution_role
 
     if execution_role:
         # User provided a role - convert to ARN format if needed
-        if execution_role.startswith("arn:aws:iam::"):
+        if re.match(r"^arn:aws[\w-]*:iam::\d{12}", execution_role):
             execution_role_arn = execution_role
         else:
-            execution_role_arn = f"arn:aws:iam::{account_id}:role/{execution_role}"
+            partition = get_partition(region)
+            execution_role_arn = f"arn:{partition}:iam::{account_id}:role/{execution_role}"
 
         if verbose:
             log.debug("Using execution role: %s", execution_role_arn)
@@ -344,13 +345,17 @@ def configure_bedrock_agentcore(
             log.debug("Unable to read existing memory configuration: %s", e)
 
     # Handle CodeBuild execution role - use separate role if provided, otherwise use execution_role
+    # Currently cannot use codebuild in govcloud due to ARM container not being available in region
+    # but in the future it may be supported so duplicate execution_role logic
+    # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html
     codebuild_execution_role_arn = None
     if code_build_execution_role:
         # User provided a separate CodeBuild role
-        if code_build_execution_role.startswith("arn:aws:iam::"):
+        if re.match(r"^arn:aws[\w-]*:iam::\d{12}:role", code_build_execution_role):
             codebuild_execution_role_arn = code_build_execution_role
         else:
-            codebuild_execution_role_arn = f"arn:aws:iam::{account_id}:role/{code_build_execution_role}"
+            partition = get_partition(region)
+            codebuild_execution_role_arn = f"arn:{partition}:iam::{account_id}:role/{code_build_execution_role}"
 
         if verbose:
             log.debug("Using separate CodeBuild execution role: %s", codebuild_execution_role_arn)

--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -15,6 +15,7 @@ from ...services.codebuild import CodeBuildService
 from ...services.ecr import deploy_to_ecr, generate_image_tag, get_or_create_ecr_repository
 from ...services.runtime import BedrockAgentCoreClient
 from ...services.xray import enable_traces_delivery_for_runtime, enable_transaction_search_if_needed
+from ...utils.aws import get_partition
 from ...utils.runtime.agentcore_identity import _load_api_key_from_env_if_configured
 from ...utils.runtime.config import load_config, save_config
 from ...utils.runtime.container import ContainerRuntime
@@ -859,8 +860,19 @@ def launch_bedrock_agentcore(
         env_vars["BEDROCK_AGENTCORE_MEMORY_ID"] = agent_config.memory.memory_id
         env_vars["BEDROCK_AGENTCORE_MEMORY_NAME"] = agent_config.memory.memory_name
 
+    region = agent_config.aws.region
+    if not region:
+        raise ValueError("Region not found in configuration")
+
     # Handle CodeBuild deployment (container deployments, not for local mode)
     if use_codebuild and not local:
+        partition = get_partition(region)
+        if partition != "aws":
+            raise RuntimeError(
+                f"CodeBuild ARM_CONTAINER environment type is not available in the '{partition}' partition.\n"
+                "Use '--local-build' to build the container image locally and deploy to cloud instead"
+            )
+
         return _launch_with_codebuild(
             config_path=config_path,
             agent_name=agent_config.name,
@@ -951,10 +963,6 @@ def launch_bedrock_agentcore(
             runtime=runtime,
             env_vars=env_vars,
         )
-
-    region = agent_config.aws.region
-    if not region:
-        raise ValueError("Region not found in configuration")
 
     account_id = agent_config.aws.account
 

--- a/tests/operations/runtime/test_configure.py
+++ b/tests/operations/runtime/test_configure.py
@@ -311,7 +311,7 @@ bedrock_agentcore = BedrockAgentCoreApp()
             ):
                 # Test role name (should be converted to full ARN)
                 result1 = configure_bedrock_agentcore(
-                    agent_name="test_agent", entrypoint_path=agent_file, execution_role="MyRole"
+                    agent_name="test_agent", entrypoint_path=agent_file, execution_role="MyRole", region="us-east-1"
                 )
                 assert result1.execution_role == "arn:aws:iam::123456789012:role/MyRole"
 
@@ -321,6 +321,21 @@ bedrock_agentcore = BedrockAgentCoreApp()
                     agent_name="test_agent", entrypoint_path=agent_file, execution_role=full_arn
                 )
                 assert result2.execution_role == full_arn
+
+                gov_arn = "arn:aws-us-gov:iam::123456789012:role/MyCustomRole"
+                result3 = configure_bedrock_agentcore(
+                    agent_name="test_agent", entrypoint_path=agent_file, execution_role=gov_arn, region="us-gov-west-1"
+                )
+                assert result3.execution_role == gov_arn
+
+                # Test that correct arn partition is resolved given region in generated role ARN
+                result4 = configure_bedrock_agentcore(
+                    agent_name="test_agent",
+                    entrypoint_path=agent_file,
+                    execution_role="MyCustomRole",
+                    region="us-gov-east-1",
+                )
+                assert result4.execution_role == "arn:aws-us-gov:iam::123456789012:role/MyCustomRole"
 
         finally:
             os.chdir(original_cwd)
@@ -541,6 +556,7 @@ def handler(payload):
                     entrypoint_path=agent_file,
                     execution_role="ExecutionRole",
                     code_build_execution_role="CodeBuildRole",
+                    region="us-west-2",
                 )
 
                 # Load and verify the configuration
@@ -551,6 +567,20 @@ def handler(payload):
 
                 assert agent_config.aws.execution_role == "arn:aws:iam::123456789012:role/ExecutionRole"
                 assert agent_config.codebuild.execution_role == "arn:aws:iam::123456789012:role/CodeBuildRole"
+
+                result2 = configure_bedrock_agentcore(
+                    agent_name="test_agent",
+                    entrypoint_path=agent_file,
+                    execution_role="ExecutionRole",
+                    code_build_execution_role="CodeBuildRole",
+                    region="us-gov-west-1",
+                )
+
+                config2 = load_config(result2.config_path)
+                agent_config2 = config2.get_agent_config("test_agent")
+
+                assert agent_config2.aws.execution_role == "arn:aws-us-gov:iam::123456789012:role/ExecutionRole"
+                assert agent_config2.codebuild.execution_role == "arn:aws-us-gov:iam::123456789012:role/CodeBuildRole"
 
         finally:
             os.chdir(original_cwd)

--- a/tests/operations/runtime/test_launch.py
+++ b/tests/operations/runtime/test_launch.py
@@ -1195,6 +1195,20 @@ class TestLaunchBedrockAgentCore:
             # Check that env_vars parameter was passed to _launch_with_codebuild
             assert mock_launch_with_codebuild.call_args.kwargs["env_vars"] == test_env_vars
 
+    def test_launch_codebuild_blocked_in_govcloud(self, tmp_path):
+        """Test that CodeBuild deployment is blocked in GovCloud regions."""
+        config_path = create_test_config(
+            tmp_path,
+            region="us-gov-west-1",
+            execution_role="arn:aws-us-gov:iam::123456789012:role/TestRole",
+            ecr_repository="123456789012.dkr.ecr.us-gov-west-1.amazonaws.com/test-repo",
+            deployment_type="container",
+        )
+        create_test_agent_file(tmp_path)
+
+        with pytest.raises(RuntimeError, match="ARM_CONTAINER.*not available"):
+            launch_bedrock_agentcore(config_path, local=False, use_codebuild=True)
+
     def test_launch_with_memory_creation_codebuild(self, mock_boto3_clients, mock_container_runtime, tmp_path):
         """Test launch with memory creation in CodeBuild mode."""
         from bedrock_agentcore_starter_toolkit.utils.runtime.schema import MemoryConfig


### PR DESCRIPTION
## Description

Fix hardcoded execution role arn assumptions during configure and disallows codebuild code path during deploy. 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Testing

- [ x ] Unit tests pass locally
- [ x ] Manual testing completed

## Checklist

- [ x ] My code follows the project's style guidelines (ruff/pre-commit)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have been merged and published

## Security Checklist

- [ x ] No hardcoded secrets or credentials
- [ x ] No new security warnings from bandit
- [ x ] Dependencies are from trusted sources
- [ x ] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
