### PR TITLE
fix: correct npm package name in install instructions (@aws/agentcore-cli → @aws/agentcore)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@
 
 > **⚠️ Recommendation: Use the AgentCore CLI for new projects**
 >
-> The **[AgentCore CLI (`@aws/agentcore-cli`)](https://github.com/aws/agentcore-cli)** is now the recommended way to create, develop, and deploy AI agents on Amazon Bedrock AgentCore. It supports a broader set of frameworks (Strands, LangGraph, LangChain, Google ADK, OpenAI Agents, and BYO), provides local development with hot reload, built-in evaluations, gateway management, and more.
+> The **[AgentCore CLI (`@aws/agentcore`)](https://github.com/aws/agentcore-cli)** is now the recommended way to create, develop, and deploy AI agents on Amazon Bedrock AgentCore. It supports a broader set of frameworks (Strands, LangGraph, LangChain, Google ADK, OpenAI Agents, and BYO), provides local development with hot reload, built-in evaluations, gateway management, and more.
 >
 > **For new projects**, install the AgentCore CLI:
 > ```bash
-> npm i @aws/agentcore-cli
+> npm install -g @aws/agentcore
 > ```
 >
 > **Migrating from this toolkit?** See the [Migration Guide](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/MIGRATION.md) for step-by-step instructions, and the [AgentCore CLI documentation](https://github.com/aws/agentcore-cli/tree/main/docs) for:
@@ -51,7 +51,7 @@ Amazon Bedrock AgentCore includes the following modular Services that you can us
 
 ## 🚀 Jump Into AgentCore
 
-> **New projects should use the [AgentCore CLI](https://github.com/aws/agentcore-cli):** `npm i @aws/agentcore-cli`
+> **New projects should use the [AgentCore CLI](https://github.com/aws/agentcore-cli):** `npm install -g @aws/agentcore`
 
 If you prefer a Python-based workflow, you can still get started with this toolkit using `agentcore create`.
 
@@ -116,7 +116,7 @@ AgentCore Import-Agent enables seamless migration of existing Amazon Bedrock Age
 ### Recommended: AgentCore CLI
 
 ```bash
-npm i @aws/agentcore-cli
+npm install -g @aws/agentcore
 ```
 
 See the [AgentCore CLI README](https://github.com/aws/agentcore-cli) and [docs](https://github.com/aws/agentcore-cli/tree/main/docs) for full usage.

--- a/documentation/overrides/main.html
+++ b/documentation/overrides/main.html
@@ -4,11 +4,11 @@
 <div class="agentcore-cli-banner">
   <strong>Recommendation: Use the AgentCore CLI for new projects</strong>
   <p>
-    The <a href="https://github.com/aws/agentcore-cli"><strong>AgentCore CLI (<code>@aws/agentcore-cli</code>)</strong></a>
+    The <a href="https://github.com/aws/agentcore-cli"><strong>AgentCore CLI (<code>@aws/agentcore</code>)</strong></a>
     is now the recommended way to create, develop, and deploy AI agents on Amazon Bedrock AgentCore.
     It offers broader framework support, local development with hot reload, built-in evaluations, gateway management, and more.
   </p>
-  <p><strong>Get started:</strong> <code>npm i @aws/agentcore-cli</code></p>
+  <p><strong>Get started:</strong> <code>npm install -g @aws/agentcore</code></p>
   <p>
     See the <a href="https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/MIGRATION.md"><strong>Migration Guide</strong></a>
     for step-by-step instructions to migrate existing projects.


### PR DESCRIPTION
## Description

The README and documentation banner reference `@aws/agentcore-cli` as the npm package to install, but this package does not exist on npm (returns 404). The correct package name is `@aws/agentcore`, per the [agentcore-cli repo README](https://github.com/aws/agentcore-cli#installation).

Fixed 6 references across 2 files:
- `README.md` (4 occurrences)
- `documentation/overrides/main.html` (2 occurrences)

Also updated `npm i` → `npm install -g` to match the upstream install instructions (global install).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [x] Manual testing completed

Verified `npm install -g @aws/agentcore` resolves on npmjs.org. Confirmed `npm i @aws/agentcore-cli` returns 404.

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

N/A

## Additional Notes

Documentation-only change. No code logic affected.