### PR TITLE
fix: handle PENDING trace destination status + add missing traces delivery in direct-code-deploy (#457)

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/runtime/launch.py
@@ -1475,6 +1475,12 @@ def _launch_with_direct_code_deploy(
         if agent_config.aws.observability.enabled:
             log.info("Enabling observability...")
             enable_transaction_search_if_needed(region, account_id)
+            enable_traces_delivery_for_runtime(
+                agent_id=agent_info["id"],
+                agent_arn=agent_info["arn"],
+                region=region,
+                logger=log,
+            )
             console_url = get_genai_observability_url(region)
             log.info("🔍 GenAI Observability Dashboard: %s", console_url)
 

--- a/src/bedrock_agentcore_starter_toolkit/services/xray.py
+++ b/src/bedrock_agentcore_starter_toolkit/services/xray.py
@@ -77,6 +77,8 @@ def enable_transaction_search_if_needed(region: str, account_id: str) -> bool:
             steps_run.append("trace_destination")
         else:
             logger.info("X-Ray trace destination already configured")
+            # Destination may be set but still PENDING from a previous run
+            _log_trace_destination_status(xray_client)
 
         # Step 3: Indexing rule (only if needed)
         if _need_indexing_rule(xray_client):
@@ -187,7 +189,11 @@ def _create_cloudwatch_logs_resource_policy(logs_client, account_id: str, region
 
 
 def _configure_trace_segment_destination(xray_client) -> None:
-    """Configure X-Ray trace segment destination to CloudWatch Logs (idempotent)."""
+    """Configure X-Ray trace segment destination to CloudWatch Logs (idempotent).
+
+    Logs a warning if the destination is still PENDING after configuration,
+    since OTEL trace exports will fail until it becomes ACTIVE (~10-15 minutes).
+    """
     try:
         # Configure trace segments to be sent to CloudWatch Logs
         # This enables Transaction Search functionality
@@ -199,6 +205,26 @@ def _configure_trace_segment_destination(xray_client) -> None:
             logger.info("X-Ray trace segment destination already configured")
         else:
             raise
+
+    # Check status — warn if still PENDING
+    _log_trace_destination_status(xray_client)
+
+
+def _log_trace_destination_status(xray_client):
+    """Check and log the trace segment destination status."""
+    try:
+        resp = xray_client.get_trace_segment_destination()
+        status = resp.get("Status")
+        if status == "ACTIVE":
+            logger.info("X-Ray trace segment destination is ACTIVE")
+        else:
+            logger.info(
+                "⏳ X-Ray trace segment destination is %s — "
+                "OTEL trace exports may fail until it becomes ACTIVE (typically 10-15 minutes)",
+                status,
+            )
+    except Exception as e:
+        logger.warning("Could not check trace destination status: %s", e)
 
 
 def _configure_indexing_rule(xray_client) -> None:

--- a/tests/operations/runtime/test_launch.py
+++ b/tests/operations/runtime/test_launch.py
@@ -3751,6 +3751,9 @@ class TestCodeZipDeployment:
             patch(
                 "bedrock_agentcore_starter_toolkit.operations.runtime.launch.enable_transaction_search_if_needed"
             ) as mock_enable_xray,
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.runtime.launch.enable_traces_delivery_for_runtime"
+            ) as mock_enable_traces,
             patch("shutil.which") as mock_which,
         ):
             mock_which.side_effect = lambda cmd: f"/usr/bin/{cmd}" if cmd in ["uv", "zip"] else None
@@ -3779,6 +3782,13 @@ class TestCodeZipDeployment:
 
             # Verify observability was enabled
             mock_enable_xray.assert_called_once_with("us-west-2", "123456789012")
+
+            # Verify traces delivery was enabled for the runtime
+            mock_enable_traces.assert_called_once()
+            call_kwargs = mock_enable_traces.call_args.kwargs
+            assert "agent_id" in call_kwargs
+            assert "agent_arn" in call_kwargs
+            assert call_kwargs["region"] == "us-west-2"
 
     def test_launch_with_direct_code_deploy_session_id_reset(self, mock_boto3_clients, tmp_path):
         """Test direct_code_deploy deployment resets existing session_id with warning."""

--- a/tests/services/test_xray.py
+++ b/tests/services/test_xray.py
@@ -478,3 +478,30 @@ class TestEdgeCasesAndErrorHandling:
         result = enable_transaction_search_if_needed("us-east-1", "123456789012")
 
         assert result is False
+
+
+class TestConfigureTraceSegmentDestinationChecksStatus:
+    """Test that _configure_trace_segment_destination checks status after update."""
+
+    @patch("bedrock_agentcore_starter_toolkit.services.xray._log_trace_destination_status")
+    def test_checks_status_after_update(self, mock_log_status):
+        """Test that _configure_trace_segment_destination checks status after update."""
+        mock_xray_client = Mock()
+
+        _configure_trace_segment_destination(mock_xray_client)
+
+        mock_xray_client.update_trace_segment_destination.assert_called_once_with(Destination="CloudWatchLogs")
+        mock_log_status.assert_called_once_with(mock_xray_client)
+
+    @patch("bedrock_agentcore_starter_toolkit.services.xray._log_trace_destination_status")
+    def test_checks_status_even_when_already_configured(self, mock_log_status):
+        """Test status check runs even when destination was already configured."""
+        mock_xray_client = Mock()
+        error_response = {"Error": {"Code": "InvalidRequestException", "Message": "Already configured"}}
+        mock_xray_client.update_trace_segment_destination.side_effect = ClientError(
+            error_response, "UpdateTraceSegmentDestination"
+        )
+
+        _configure_trace_segment_destination(mock_xray_client)
+
+        mock_log_status.assert_called_once_with(mock_xray_client)


### PR DESCRIPTION
## Description

Two fixes for observability setup during `agentcore deploy`:

1. **`_configure_trace_segment_destination` silently continued while destination was PENDING** — after calling `update_trace_segment_destination(Destination="CloudWatchLogs")`, the function returned without checking status. The destination takes ~10-15 minutes to become ACTIVE, during which OTEL trace exports fail with `400 Bad Request`. Now logs the status so users know exports may be delayed.

2. **Direct-code-deploy path missing `enable_traces_delivery_for_runtime()`** — the container deploy path calls both `enable_transaction_search_if_needed()` and `enable_traces_delivery_for_runtime()`, but the direct-code-deploy path only called the first. Runtime traces delivery was never configured for direct-code-deploy deployments.

Fixes #457

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally (35 xray tests, launch test updated)
- [x] Manual e2e: deployed with fix in clean account, verified traces delivery created and status logged
- [x] Verified launch test fails without the launch.py fix (enable_traces_delivery_for_runtime not called)

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

N/A

## Additional Notes

Non-blocking fix — deploy does not wait for ACTIVE. The agent is fully usable while the destination transitions; only OTEL trace exports are affected during the ~10-15 minute PENDING window.