### PR TITLE
feat: add deprecation banner recommending AgentCore CLI

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -1,6 +1,9 @@
 """BedrockAgentCore CLI main module."""
 
+import os
+
 import typer
+from rich.console import Console
 
 from ..cli.evaluation.commands import evaluation_app
 from ..cli.gateway.commands import (
@@ -29,6 +32,25 @@ app = typer.Typer(name="agentcore", help="BedrockAgentCore CLI", add_completion=
 
 # Setup centralized logging for CLI
 setup_toolkit_logging(mode="cli")
+
+MIGRATION_GUIDE_URL = "https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/MIGRATION.md"
+
+_stderr_console = Console(stderr=True)
+
+
+@app.callback(invoke_without_command=True)
+def _deprecation_banner(ctx: typer.Context) -> None:
+    """Show deprecation warning before every command."""
+    if os.environ.get("AGENTCORE_SUPPRESS_DEPRECATION"):
+        return
+    if ctx.invoked_subcommand is None and not ctx.protected_args:
+        return
+    _stderr_console.print(
+        "\n[yellow bold]⚠️  This toolkit is no longer actively developed.[/yellow bold]\n"
+        "[yellow]   Use the AgentCore CLI instead:[/yellow] [cyan]npm install -g @aws/agentcore[/cyan]\n"
+        f"[yellow]   Migration guide:[/yellow] [underline]{MIGRATION_GUIDE_URL}[/underline]\n"
+        "[dim]   Set AGENTCORE_SUPPRESS_DEPRECATION=1 to silence this warning.[/dim]\n"
+    )
 
 app.command("create")(create)
 app.add_typer(create_app, name="create")


### PR DESCRIPTION
## Summary

- Adds a deprecation warning banner that prints on **every command invocation**, directing users to the AgentCore CLI (`@aws/agentcore`) as the actively developed replacement
- Banner prints to **stderr** so it doesn't interfere with piped/redirected stdout
- Users can silence the warning by setting `AGENTCORE_SUPPRESS_DEPRECATION=1`
- Skips the banner when running bare `agentcore` (help output)

### What it looks like

```
⚠️  This toolkit is no longer actively developed.
   Use the AgentCore CLI instead: npm install -g @aws/agentcore
   Migration guide: https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/MIGRATION.md
   Set AGENTCORE_SUPPRESS_DEPRECATION=1 to silence this warning.
```

## Test plan

- [x] Verified banner shows on command invocation (`status`, `deploy`, etc.)
- [x] Verified `AGENTCORE_SUPPRESS_DEPRECATION=1` suppresses the banner
- [x] Verified bare `agentcore` (no subcommand) does not show the banner
- [x] Verified banner prints to stderr, not stdout
- [x] Ran existing test suite — 699 passed, 0 new failures