### PR TITLE
fix: soften deprecation banner and fix env var check

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -33,8 +33,6 @@ app = typer.Typer(name="agentcore", help="BedrockAgentCore CLI", add_completion=
 # Setup centralized logging for CLI
 setup_toolkit_logging(mode="cli")
 
-MIGRATION_GUIDE_URL = "https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/MIGRATION.md"
-
 _stderr_console = Console(stderr=True)
 
 
@@ -49,8 +47,6 @@ def _deprecation_banner(ctx: typer.Context) -> None:
         "\n[yellow bold]⚠️  The AgentCore CLI (@aws/agentcore) is now the recommended way to create, develop,"
         " and deploy agents on Amazon Bedrock AgentCore.[/yellow bold]\n"
         "[yellow]   We recommend migrating to the new CLI:[/yellow] [cyan]npm install -g @aws/agentcore[/cyan]\n"
-        "[yellow]   To import existing agents, run:[/yellow] [cyan]agentcore create import[/cyan]\n"
-        f"[yellow]   Migration guide:[/yellow] [underline]{MIGRATION_GUIDE_URL}[/underline]\n"
         "[dim]   Set AGENTCORE_SUPPRESS_DEPRECATION=1 to silence this warning.[/dim]\n"
     )
 

--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -51,6 +51,7 @@ def _deprecation_banner(ctx: typer.Context) -> None:
         "[dim]   Set AGENTCORE_SUPPRESS_RECOMMENDATION=1 to silence this warning.[/dim]\n"
     )
 
+
 app.command("create")(create)
 app.add_typer(create_app, name="create")
 create_app.command("import")(import_agent)

--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -47,6 +47,7 @@ def _deprecation_banner(ctx: typer.Context) -> None:
         "\n[yellow bold]⚠️  The AgentCore CLI (@aws/agentcore) is now the recommended way to create, develop,"
         " and deploy agents on Amazon Bedrock AgentCore.[/yellow bold]\n"
         "[yellow]   We recommend migrating to the new CLI:[/yellow] [cyan]npm install -g @aws/agentcore[/cyan]\n"
+        "[yellow]   To import existing agents, run:[/yellow] [cyan]agentcore create import[/cyan]\n"
         "[dim]   Set AGENTCORE_SUPPRESS_DEPRECATION=1 to silence this warning.[/dim]\n"
     )
 

--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -39,7 +39,7 @@ _stderr_console = Console(stderr=True)
 @app.callback(invoke_without_command=True)
 def _deprecation_banner(ctx: typer.Context) -> None:
     """Show deprecation warning before every command."""
-    if os.environ.get("AGENTCORE_SUPPRESS_DEPRECATION", "").lower() in ("1", "true", "yes"):
+    if os.environ.get("AGENTCORE_SUPPRESS_RECOMMENDATION", "").lower() in ("1", "true", "yes"):
         return
     if ctx.invoked_subcommand is None and not ctx.protected_args:
         return
@@ -48,7 +48,7 @@ def _deprecation_banner(ctx: typer.Context) -> None:
         " and deploy agents on Amazon Bedrock AgentCore.[/yellow bold]\n"
         "[yellow]   We recommend migrating to the new CLI:[/yellow] [cyan]npm install -g @aws/agentcore[/cyan]\n"
         "[yellow]   To import existing agents, run:[/yellow] [cyan]agentcore create import[/cyan]\n"
-        "[dim]   Set AGENTCORE_SUPPRESS_DEPRECATION=1 to silence this warning.[/dim]\n"
+        "[dim]   Set AGENTCORE_SUPPRESS_RECOMMENDATION=1 to silence this warning.[/dim]\n"
     )
 
 app.command("create")(create)

--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -41,13 +41,15 @@ _stderr_console = Console(stderr=True)
 @app.callback(invoke_without_command=True)
 def _deprecation_banner(ctx: typer.Context) -> None:
     """Show deprecation warning before every command."""
-    if os.environ.get("AGENTCORE_SUPPRESS_DEPRECATION"):
+    if os.environ.get("AGENTCORE_SUPPRESS_DEPRECATION", "").lower() in ("1", "true", "yes"):
         return
     if ctx.invoked_subcommand is None and not ctx.protected_args:
         return
     _stderr_console.print(
-        "\n[yellow bold]⚠️  This toolkit is no longer actively developed.[/yellow bold]\n"
-        "[yellow]   Use the AgentCore CLI instead:[/yellow] [cyan]npm install -g @aws/agentcore[/cyan]\n"
+        "\n[yellow bold]⚠️  The AgentCore CLI (@aws/agentcore) is now the recommended way to create, develop,"
+        " and deploy agents on Amazon Bedrock AgentCore.[/yellow bold]\n"
+        "[yellow]   We recommend migrating to the new CLI:[/yellow] [cyan]npm install -g @aws/agentcore[/cyan]\n"
+        "[yellow]   To import existing agents, run:[/yellow] [cyan]agentcore create import[/cyan]\n"
         f"[yellow]   Migration guide:[/yellow] [underline]{MIGRATION_GUIDE_URL}[/underline]\n"
         "[dim]   Set AGENTCORE_SUPPRESS_DEPRECATION=1 to silence this warning.[/dim]\n"
     )


### PR DESCRIPTION
## Summary

- Softens the deprecation banner language from "no longer actively developed" to a recommendation to use the AgentCore CLI
- Adds a hint about `agentcore create import` for migrating existing agents
- Fixes the suppression env var to require an explicit truthy value (`1`, `true`, `yes`) so that `=0` doesn't accidentally suppress the banner

### Banner text

```
⚠️  The AgentCore CLI (@aws/agentcore) is now the recommended way to create, develop,
    and deploy agents on Amazon Bedrock AgentCore.
   We recommend migrating to the new CLI: npm install -g @aws/agentcore
   To import existing agents, run: agentcore create import
   Set AGENTCORE_SUPPRESS_RECOMMENDATION=1 to silence this warning.
```

<img width="1222" height="149" alt="Screenshot 2026-04-29 at 5 02 42 PM" src="https://github.com/user-attachments/assets/c67e6fcf-7019-45e0-b3b2-0a6823edeb89" />


## Test plan

- [x] `AGENTCORE_SUPPRESS_RECOMMENDATION=0` → banner shows
- [x] `AGENTCORE_SUPPRESS_RECOMMENDATION=1` → banner suppressed
- [x] Unset env var → banner shows
- [x] Verified `true`/`yes` also suppress the banner