### PR TITLE
chore: replace all github.token/GITHUB_TOKEN with GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,18 @@ jobs:
           echo "::error::Minor and major releases are blocked. Only patch and pre releases are allowed."
           exit 1
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -155,7 +162,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH_NAME="release/v${{ steps.bump.outputs.version }}"
 


### PR DESCRIPTION
## Summary
Replace `github.token` and `secrets.GITHUB_TOKEN` in release workflow with short-lived GitHub App token.

## Test plan
- [ ] Add APP_ID variable and APP_PRIVATE_KEY secret to this repo
- [ ] Merge and confirm release workflow runs successfully