### PR TITLE
fix(cli): re-emit deprecation recommendation after high-output commands + add uninstall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@
 > npm install -g @aws/agentcore
 > ```
 >
+> **Already installed this toolkit?** Once you've migrated, uninstall it:
+> ```bash
+> pip uninstall bedrock-agentcore-starter-toolkit
+> ```
+>
 > **Migrating from this toolkit?** See the [Migration Guide](https://github.com/awslabs/amazon-bedrock-agentcore-samples/blob/main/MIGRATION.md) for step-by-step instructions, and the [AgentCore CLI documentation](https://github.com/aws/agentcore-cli/tree/main/docs) for:
 > - [Commands reference](https://github.com/aws/agentcore-cli/blob/main/docs/commands.md) — create, deploy, dev, invoke, add, remove, logs, traces, evals
 > - [Supported frameworks](https://github.com/aws/agentcore-cli/blob/main/docs/frameworks.md) — Strands, LangGraph, LangChain, Google ADK, OpenAI Agents, BYO, and import from existing projects

--- a/src/bedrock_agentcore_starter_toolkit/cli/cli.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/cli.py
@@ -1,7 +1,5 @@
 """BedrockAgentCore CLI main module."""
 
-import os
-
 import typer
 from rich.console import Console
 
@@ -15,9 +13,10 @@ from ..cli.memory.commands import memory_app
 from ..cli.observability.commands import observability_app
 from ..cli.policy.commands import policy_app
 from ..utils.logging_config import setup_toolkit_logging
-from .create.commands import create, create_app
+from .create.commands import create_app
 from .create.import_agent.commands import import_agent
 from .identity.commands import identity_app
+from .recommendation import print_recommendation
 from .runtime.commands import (
     configure_app,
     deploy,
@@ -39,20 +38,11 @@ _stderr_console = Console(stderr=True)
 @app.callback(invoke_without_command=True)
 def _deprecation_banner(ctx: typer.Context) -> None:
     """Show deprecation warning before every command."""
-    if os.environ.get("AGENTCORE_SUPPRESS_RECOMMENDATION", "").lower() in ("1", "true", "yes"):
-        return
     if ctx.invoked_subcommand is None and not ctx.protected_args:
         return
-    _stderr_console.print(
-        "\n[yellow bold]⚠️  The AgentCore CLI (@aws/agentcore) is now the recommended way to create, develop,"
-        " and deploy agents on Amazon Bedrock AgentCore.[/yellow bold]\n"
-        "[yellow]   We recommend migrating to the new CLI:[/yellow] [cyan]npm install -g @aws/agentcore[/cyan]\n"
-        "[yellow]   To import existing agents, run:[/yellow] [cyan]agentcore import[/cyan]\n"
-        "[dim]   Set AGENTCORE_SUPPRESS_RECOMMENDATION=1 to silence this warning.[/dim]\n"
-    )
+    print_recommendation(_stderr_console)
 
 
-app.command("create")(create)
 app.add_typer(create_app, name="create")
 create_app.command("import")(import_agent)
 app.command("dev")(dev)

--- a/src/bedrock_agentcore_starter_toolkit/cli/create/import_agent/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/create/import_agent/commands.py
@@ -16,6 +16,7 @@ from bedrock_agentcore_starter_toolkit.services.runtime import generate_session_
 from ....services.import_agent.scripts.bedrock_to_langchain import BedrockLangchainTranslation
 from ....services.import_agent.scripts.bedrock_to_strands import BedrockStrandsTranslation
 from ...common import console, requires_aws_creds
+from ...recommendation import print_recommendation
 from .agent_info import auth_and_get_info, get_agent_aliases, get_agents, get_clients
 
 
@@ -487,3 +488,8 @@ def import_agent(
                 border_style="green",
             )
         )
+
+    # Re-emit the migration recommendation last so it survives the import flow's
+    # output flood (region/agent/alias tables + generation logs + summary panel)
+    # the top-level banner scrolls past.
+    print_recommendation(console)

--- a/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
@@ -25,14 +25,14 @@ def is_recommendation_suppressed() -> bool:
 def recommendation_text() -> str:
     """Rich-markup recommendation block recommending the AgentCore CLI."""
     return (
-        "\n[yellow bold]⚠️  Recommendation: The Starter Toolkit CLI is no longer supported.[/yellow bold]\n"
+        "\n[yellow bold]⚠️ Recommendation: The Starter Toolkit CLI is no longer supported.[/yellow bold]\n"
         "[yellow bold]   Please use the AgentCore CLI (@aws/agentcore) to create, develop, and deploy agents on"
         " Amazon Bedrock AgentCore.[/yellow bold]\n"
         "[yellow bold]   New Bedrock AgentCore features are only accessible in the AgentCore CLI.[/yellow bold]\n"
         "\n"
+        f"[yellow]   To uninstall this starter toolkit, run:[/yellow] [cyan]{UNINSTALL_CMD}[/cyan]\n"
         f"[yellow]   To install the AgentCore CLI:[/yellow] [cyan]{INSTALL_CMD}[/cyan]\n"
         f"[yellow]   To import existing agents, run:[/yellow] [cyan]{IMPORT_CMD}[/cyan]\n"
-        f"[yellow]   To uninstall this starter toolkit, run:[/yellow] [cyan]{UNINSTALL_CMD}[/cyan]\n"
         f"[dim]   Set {SUPPRESS_ENV_VAR}=1 to silence this warning.[/dim]\n"
     )
 

--- a/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
@@ -1,0 +1,42 @@
+"""Shared AgentCore CLI migration recommendation.
+
+The starter toolkit is no longer the recommended entry point; the AgentCore CLI
+(``@aws/agentcore``) is. This module is the single source of truth for that
+message so every surface (the per-command banner and the ``create`` success
+screen) and the install/uninstall commands stay in sync.
+"""
+
+import os
+
+from rich.console import Console
+
+AGENTCORE_CLI_PACKAGE = "@aws/agentcore"
+INSTALL_CMD = "npm install -g @aws/agentcore"
+UNINSTALL_CMD = "pip uninstall bedrock-agentcore-starter-toolkit"
+IMPORT_CMD = "agentcore import"
+
+SUPPRESS_ENV_VAR = "AGENTCORE_SUPPRESS_RECOMMENDATION"
+
+
+def is_recommendation_suppressed() -> bool:
+    """Return True when the user has opted out of the recommendation."""
+    return os.environ.get(SUPPRESS_ENV_VAR, "").lower() in ("1", "true", "yes")
+
+
+def recommendation_text() -> str:
+    """Rich-markup recommendation block recommending the AgentCore CLI."""
+    return (
+        f"\n[yellow bold]⚠️  The AgentCore CLI ({AGENTCORE_CLI_PACKAGE}) is now the recommended way to create,"
+        " develop, and deploy agents on Amazon Bedrock AgentCore.[/yellow bold]\n"
+        f"[yellow]   We recommend migrating to the new CLI:[/yellow] [cyan]{INSTALL_CMD}[/cyan]\n"
+        f"[yellow]   To import existing agents, run:[/yellow] [cyan]{IMPORT_CMD}[/cyan]\n"
+        f"[yellow]   To uninstall this starter toolkit, run:[/yellow] [cyan]{UNINSTALL_CMD}[/cyan]\n"
+        f"[dim]   Set {SUPPRESS_ENV_VAR}=1 to silence this warning.[/dim]\n"
+    )
+
+
+def print_recommendation(console: Console) -> None:
+    """Print the recommendation to ``console`` unless the user suppressed it."""
+    if is_recommendation_suppressed():
+        return
+    console.print(recommendation_text())

--- a/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
@@ -25,10 +25,12 @@ def is_recommendation_suppressed() -> bool:
 def recommendation_text() -> str:
     """Rich-markup recommendation block recommending the AgentCore CLI."""
     return (
-        "\n[yellow bold]⚠️  Recommendation: The Starter Toolkit CLI is no longer supported."
-        " Please use the AgentCore CLI (@aws/agentcore) to create, develop, and deploy agents on"
+        "\n[yellow bold]⚠️  Recommendation: The Starter Toolkit CLI is no longer supported.[/yellow bold]\n"
+        "[yellow bold]   Please use the AgentCore CLI (@aws/agentcore) to create, develop, and deploy agents on"
         " Amazon Bedrock AgentCore.[/yellow bold]\n"
-        f"[yellow]   We recommend migrating to the new CLI:[/yellow] [cyan]{INSTALL_CMD}[/cyan]\n"
+        "[yellow]   New Bedrock AgentCore features are only accessible in the AgentCore CLI.[/yellow]\n"
+        "\n"
+        f"[yellow]   To install the AgentCore CLI:[/yellow] [cyan]{INSTALL_CMD}[/cyan]\n"
         f"[yellow]   To import existing agents, run:[/yellow] [cyan]{IMPORT_CMD}[/cyan]\n"
         f"[yellow]   To uninstall this starter toolkit, run:[/yellow] [cyan]{UNINSTALL_CMD}[/cyan]\n"
         f"[dim]   Set {SUPPRESS_ENV_VAR}=1 to silence this warning.[/dim]\n"

--- a/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
@@ -10,7 +10,6 @@ import os
 
 from rich.console import Console
 
-AGENTCORE_CLI_PACKAGE = "@aws/agentcore"
 INSTALL_CMD = "npm install -g @aws/agentcore"
 UNINSTALL_CMD = "pip uninstall bedrock-agentcore-starter-toolkit"
 IMPORT_CMD = "agentcore import"
@@ -26,8 +25,9 @@ def is_recommendation_suppressed() -> bool:
 def recommendation_text() -> str:
     """Rich-markup recommendation block recommending the AgentCore CLI."""
     return (
-        f"\n[yellow bold]⚠️  The AgentCore CLI ({AGENTCORE_CLI_PACKAGE}) is now the recommended way to create,"
-        " develop, and deploy agents on Amazon Bedrock AgentCore.[/yellow bold]\n"
+        "\n[yellow bold]⚠️  Recommendation: The Starter Toolkit CLI is no longer supported."
+        " Please use the AgentCore CLI (@aws/agentcore) to create, develop, and deploy agents on"
+        " Amazon Bedrock AgentCore.[/yellow bold]\n"
         f"[yellow]   We recommend migrating to the new CLI:[/yellow] [cyan]{INSTALL_CMD}[/cyan]\n"
         f"[yellow]   To import existing agents, run:[/yellow] [cyan]{IMPORT_CMD}[/cyan]\n"
         f"[yellow]   To uninstall this starter toolkit, run:[/yellow] [cyan]{UNINSTALL_CMD}[/cyan]\n"

--- a/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/recommendation.py
@@ -28,7 +28,7 @@ def recommendation_text() -> str:
         "\n[yellow bold]⚠️  Recommendation: The Starter Toolkit CLI is no longer supported.[/yellow bold]\n"
         "[yellow bold]   Please use the AgentCore CLI (@aws/agentcore) to create, develop, and deploy agents on"
         " Amazon Bedrock AgentCore.[/yellow bold]\n"
-        "[yellow]   New Bedrock AgentCore features are only accessible in the AgentCore CLI.[/yellow]\n"
+        "[yellow bold]   New Bedrock AgentCore features are only accessible in the AgentCore CLI.[/yellow bold]\n"
         "\n"
         f"[yellow]   To install the AgentCore CLI:[/yellow] [cyan]{INSTALL_CMD}[/cyan]\n"
         f"[yellow]   To import existing agents, run:[/yellow] [cyan]{IMPORT_CMD}[/cyan]\n"

--- a/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
+++ b/src/bedrock_agentcore_starter_toolkit/cli/runtime/commands.py
@@ -29,6 +29,7 @@ from ...utils.runtime.config import load_config
 from ...utils.runtime.logs import get_agent_log_paths, get_aws_tail_commands, get_genai_observability_url
 from ...utils.server_addresses import build_server_urls
 from ..common import _handle_error, _print_success, console, requires_aws_creds
+from ..recommendation import print_recommendation
 from ._configure_impl import configure_impl
 
 # Create a module-specific logger
@@ -213,6 +214,11 @@ def configure(
         runtime=runtime,
         language=language,
     )
+
+    # Re-emit the migration recommendation last so it survives the configure
+    # output flood (interactive prompts + configuration summary panel) the
+    # top-level banner scrolls past.
+    print_recommendation(console)
 
 
 @requires_aws_creds
@@ -603,6 +609,11 @@ def deploy(
                     border_style="bright_blue",
                 )
             )
+
+        # Re-emit the migration recommendation last so it survives the deploy
+        # output flood (build/CodeBuild logs + success panel) the top-level
+        # banner scrolls past.
+        print_recommendation(console)
 
     except FileNotFoundError:
         _handle_error(".bedrock_agentcore.yaml not found. Run 'agentcore configure --entrypoint <file>' first")

--- a/src/bedrock_agentcore_starter_toolkit/create/util/console_print.py
+++ b/src/bedrock_agentcore_starter_toolkit/create/util/console_print.py
@@ -2,6 +2,7 @@
 
 from ...cli.cli_ui import _pause_and_new_line_on_finish, sandwich_text_ui
 from ...cli.common import console
+from ...cli.recommendation import print_recommendation
 from ..constants import IACProvider
 from ..types import ProjectContext
 
@@ -11,7 +12,15 @@ def emit_create_completed_message(ctx: ProjectContext):
     # end of progress sandwhich
     console.print("✓ Agent initialized.")
     _pause_and_new_line_on_finish(sleep_override=0.3)
+    _emit_next_steps(ctx)
+    # Repeat the migration recommendation last so it survives the create output
+    # flood (welcome box + prompts + generation logs) the top-level banner
+    # scrolls past — this is the final thing a `create` user sees.
+    print_recommendation(console)
 
+
+def _emit_next_steps(ctx: ProjectContext):
+    """Emit the green next-steps panel for the freshly created project."""
     # Common "Next Steps" styling to match the screenshot
     next_steps_header = "[bold]Next Steps[/bold]"
     deployment_header = "[bold]Deployment[/bold]"

--- a/tests/cli/test_recommendation.py
+++ b/tests/cli/test_recommendation.py
@@ -171,6 +171,7 @@ agents:
         with (
             patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.launch_bedrock_agentcore") as mock_launch,
             patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.print_recommendation") as mock_reco,
+            patch("bedrock_agentcore_starter_toolkit.cli.common.ensure_valid_aws_creds", return_value=(True, None)),
         ):
             mock_result = MagicMock()
             mock_result.mode = "cloud"
@@ -191,6 +192,7 @@ agents:
         with (
             patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.launch_bedrock_agentcore") as mock_launch,
             patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.print_recommendation") as mock_reco,
+            patch("bedrock_agentcore_starter_toolkit.cli.common.ensure_valid_aws_creds", return_value=(True, None)),
         ):
             mock_launch.side_effect = ValueError("boom")
             monkeypatch.chdir(tmp_path)

--- a/tests/cli/test_recommendation.py
+++ b/tests/cli/test_recommendation.py
@@ -44,6 +44,11 @@ class TestRecommendationModule:
         assert recommendation.IMPORT_CMD in text
         assert recommendation.SUPPRESS_ENV_VAR in text
 
+    def test_text_leads_with_no_longer_supported_headline(self):
+        text = recommendation.recommendation_text()
+        assert "The Starter Toolkit CLI is no longer supported. Please use the AgentCore CLI" in text
+        assert "(@aws/agentcore)" in text
+
     def test_uninstall_command_targets_the_starter_toolkit(self):
         assert recommendation.UNINSTALL_CMD == "pip uninstall bedrock-agentcore-starter-toolkit"
 
@@ -82,6 +87,11 @@ def _flat(text: str) -> str:
     return " ".join(text.split())
 
 
+# Stable phrase from the banner headline; used as the presence sentinel so
+# wording tweaks elsewhere in the message don't break these tests.
+BANNER_SENTINEL = "no longer supported"
+
+
 class TestBannerAcrossCommands:
     """The banner is a top-level callback; it must fire for every command path."""
 
@@ -91,28 +101,28 @@ class TestBannerAcrossCommands:
         return _flat(result.stderr)
 
     def test_banner_shown_for_top_level_command_help(self):
-        assert "now the recommended way" in self._stderr("dev", "--help")
+        assert BANNER_SENTINEL in self._stderr("dev", "--help")
 
     def test_banner_shown_for_create_help(self):
-        assert "now the recommended way" in self._stderr("create", "--help")
+        assert BANNER_SENTINEL in self._stderr("create", "--help")
 
     def test_banner_shown_for_subgroup_help(self):
         for group in ("memory", "gateway", "identity", "obs", "policy", "eval"):
-            assert "now the recommended way" in self._stderr(group, "--help"), group
+            assert BANNER_SENTINEL in self._stderr(group, "--help"), group
 
     def test_banner_shown_for_nested_subcommand_help(self):
-        assert "now the recommended way" in self._stderr("create", "import", "--help")
+        assert BANNER_SENTINEL in self._stderr("create", "import", "--help")
 
     def test_banner_includes_uninstall_command(self):
         assert "pip uninstall bedrock-agentcore-starter-toolkit" in self._stderr("dev", "--help")
 
     def test_banner_suppressed_by_env_var(self):
         stderr = self._stderr("dev", "--help", env={"AGENTCORE_SUPPRESS_RECOMMENDATION": "1"})
-        assert "now the recommended way" not in stderr
+        assert BANNER_SENTINEL not in stderr
 
     def test_banner_not_shown_for_bare_invocation(self):
         # Bare `agentcore` with no subcommand shows help only; no banner clutter.
-        assert "now the recommended way" not in self._stderr()
+        assert BANNER_SENTINEL not in self._stderr()
 
     def test_banner_fires_on_every_command_path(self):
         """Hermetic coverage: the top banner must fire for EVERY command path.
@@ -123,7 +133,7 @@ class TestBannerAcrossCommands:
         missing = []
         for path in _all_command_paths():
             stderr = self._stderr(*path, "--help")
-            if "now the recommended way" not in stderr:
+            if BANNER_SENTINEL not in stderr:
                 missing.append(" ".join(path))
         assert not missing, f"Banner missing for command paths: {missing}"
 

--- a/tests/cli/test_recommendation.py
+++ b/tests/cli/test_recommendation.py
@@ -1,0 +1,87 @@
+"""Tests for the AgentCore CLI migration recommendation and the CLI banner."""
+
+from typer.testing import CliRunner
+
+from bedrock_agentcore_starter_toolkit.cli import recommendation
+from bedrock_agentcore_starter_toolkit.cli.cli import app
+
+runner = CliRunner()
+
+
+class TestRecommendationModule:
+    def test_text_contains_install_uninstall_and_import(self):
+        text = recommendation.recommendation_text()
+        assert recommendation.INSTALL_CMD in text
+        assert recommendation.UNINSTALL_CMD in text
+        assert recommendation.IMPORT_CMD in text
+        assert recommendation.SUPPRESS_ENV_VAR in text
+
+    def test_uninstall_command_targets_the_starter_toolkit(self):
+        assert recommendation.UNINSTALL_CMD == "pip uninstall bedrock-agentcore-starter-toolkit"
+
+    def test_not_suppressed_by_default(self, monkeypatch):
+        monkeypatch.delenv(recommendation.SUPPRESS_ENV_VAR, raising=False)
+        assert recommendation.is_recommendation_suppressed() is False
+
+    def test_suppressed_for_truthy_values(self, monkeypatch):
+        for value in ("1", "true", "TRUE", "yes", "Yes"):
+            monkeypatch.setenv(recommendation.SUPPRESS_ENV_VAR, value)
+            assert recommendation.is_recommendation_suppressed() is True
+
+    def test_not_suppressed_for_other_values(self, monkeypatch):
+        for value in ("0", "false", "no", ""):
+            monkeypatch.setenv(recommendation.SUPPRESS_ENV_VAR, value)
+            assert recommendation.is_recommendation_suppressed() is False
+
+    def test_print_recommendation_respects_suppression(self, monkeypatch):
+        printed = []
+
+        class FakeConsole:
+            def print(self, *args, **kwargs):
+                printed.append(args)
+
+        monkeypatch.setenv(recommendation.SUPPRESS_ENV_VAR, "1")
+        recommendation.print_recommendation(FakeConsole())
+        assert printed == []
+
+        monkeypatch.setenv(recommendation.SUPPRESS_ENV_VAR, "0")
+        recommendation.print_recommendation(FakeConsole())
+        assert printed != []
+
+
+def _flat(text: str) -> str:
+    """Collapse all whitespace so width-based line wrapping doesn't break asserts."""
+    return " ".join(text.split())
+
+
+class TestBannerAcrossCommands:
+    """The banner is a top-level callback; it must fire for every command path."""
+
+    def _stderr(self, *args, env=None):
+        # Click 8.3+ captures stderr separately by default; banner goes to stderr.
+        result = runner.invoke(app, list(args), env=env or {})
+        return _flat(result.stderr)
+
+    def test_banner_shown_for_top_level_command_help(self):
+        assert "now the recommended way" in self._stderr("dev", "--help")
+
+    def test_banner_shown_for_create_help(self):
+        assert "now the recommended way" in self._stderr("create", "--help")
+
+    def test_banner_shown_for_subgroup_help(self):
+        for group in ("memory", "gateway", "identity", "obs", "policy", "eval"):
+            assert "now the recommended way" in self._stderr(group, "--help"), group
+
+    def test_banner_shown_for_nested_subcommand_help(self):
+        assert "now the recommended way" in self._stderr("create", "import", "--help")
+
+    def test_banner_includes_uninstall_command(self):
+        assert "pip uninstall bedrock-agentcore-starter-toolkit" in self._stderr("dev", "--help")
+
+    def test_banner_suppressed_by_env_var(self):
+        stderr = self._stderr("dev", "--help", env={"AGENTCORE_SUPPRESS_RECOMMENDATION": "1"})
+        assert "now the recommended way" not in stderr
+
+    def test_banner_not_shown_for_bare_invocation(self):
+        # Bare `agentcore` with no subcommand shows help only; no banner clutter.
+        assert "now the recommended way" not in self._stderr()

--- a/tests/cli/test_recommendation.py
+++ b/tests/cli/test_recommendation.py
@@ -46,8 +46,9 @@ class TestRecommendationModule:
 
     def test_text_leads_with_no_longer_supported_headline(self):
         text = recommendation.recommendation_text()
-        assert "The Starter Toolkit CLI is no longer supported. Please use the AgentCore CLI" in text
-        assert "(@aws/agentcore)" in text
+        assert "The Starter Toolkit CLI is no longer supported." in text
+        assert "Please use the AgentCore CLI (@aws/agentcore)" in text
+        assert "New Bedrock AgentCore features are only accessible in the AgentCore CLI." in text
 
     def test_uninstall_command_targets_the_starter_toolkit(self):
         assert recommendation.UNINSTALL_CMD == "pip uninstall bedrock-agentcore-starter-toolkit"

--- a/tests/cli/test_recommendation.py
+++ b/tests/cli/test_recommendation.py
@@ -1,11 +1,39 @@
 """Tests for the AgentCore CLI migration recommendation and the CLI banner."""
 
+from unittest.mock import MagicMock, patch
+
+import click
+from typer.main import get_command
 from typer.testing import CliRunner
 
 from bedrock_agentcore_starter_toolkit.cli import recommendation
 from bedrock_agentcore_starter_toolkit.cli.cli import app
 
 runner = CliRunner()
+
+
+def _all_command_paths():
+    """Walk the full Click command tree and return every invocable path.
+
+    Discovering paths from the tree (rather than hardcoding) means a newly
+    added command is automatically covered — banner coverage can't silently
+    regress.
+    """
+    root = get_command(app)
+    paths = []
+
+    def walk(cmd, prefix):
+        if isinstance(cmd, click.Group):
+            ctx = click.Context(cmd, info_name=prefix[-1] if prefix else None)
+            for name in cmd.list_commands(ctx):
+                walk(cmd.get_command(ctx, name), prefix + [name])
+            if prefix:  # the group itself is invocable (e.g. `agentcore memory`)
+                paths.append(list(prefix))
+        else:
+            paths.append(list(prefix))
+
+    walk(root, [])
+    return sorted(paths)
 
 
 class TestRecommendationModule:
@@ -85,3 +113,156 @@ class TestBannerAcrossCommands:
     def test_banner_not_shown_for_bare_invocation(self):
         # Bare `agentcore` with no subcommand shows help only; no banner clutter.
         assert "now the recommended way" not in self._stderr()
+
+    def test_banner_fires_on_every_command_path(self):
+        """Hermetic coverage: the top banner must fire for EVERY command path.
+
+        Uses --help so each command's body never runs (no AWS, no side effects);
+        the banner is a parent-group callback that fires before --help short-circuits.
+        """
+        missing = []
+        for path in _all_command_paths():
+            stderr = self._stderr(*path, "--help")
+            if "now the recommended way" not in stderr:
+                missing.append(" ".join(path))
+        assert not missing, f"Banner missing for command paths: {missing}"
+
+    def test_discovers_full_command_tree(self):
+        # Guards the discovery helper itself — if this drops near zero, the
+        # coverage test above would pass vacuously.
+        paths = _all_command_paths()
+        assert len(paths) >= 70, f"Expected the full tree (~78 paths), found {len(paths)}"
+
+
+class TestReEmitOnFloodCommands:
+    """High-output commands re-emit the recommendation at the END so it survives
+    the output flood that scrolls the top banner away.
+
+    We patch print_recommendation where each command imports it and assert it
+    fires on the success path — independent of terminal width or output volume.
+    """
+
+    def _config_file(self, tmp_path):
+        config_file = tmp_path / ".bedrock_agentcore.yaml"
+        config_file.write_text("""default_agent: test-agent
+agents:
+  test-agent:
+    name: test-agent
+    entrypoint: test.py
+    platform: linux/arm64
+    container_runtime: docker
+    aws:
+      region: us-west-2
+      account: "123456789012"
+      execution_role: arn:aws:iam::123456789012:role/TestRole
+      ecr_repository: null
+      ecr_auto_create: true
+      network_configuration:
+        network_mode: PUBLIC
+      observability:
+        enabled: true
+    bedrock_agentcore:
+      agent_id: null
+      agent_arn: null
+      endpoint_arn: null""")
+
+    def test_deploy_reemits_recommendation_on_success(self, tmp_path, monkeypatch):
+        self._config_file(tmp_path)
+        with (
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.launch_bedrock_agentcore") as mock_launch,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.print_recommendation") as mock_reco,
+        ):
+            mock_result = MagicMock()
+            mock_result.mode = "cloud"
+            mock_result.tag = "bedrock_agentcore-test-agent"
+            mock_result.agent_arn = "arn:aws:bedrock_agentcore:us-west-2:123456789012:agent-runtime/test-id"
+            mock_result.ecr_uri = "123456789012.dkr.ecr.us-west-2.amazonaws.com/test"
+            mock_result.agent_id = None
+            mock_launch.return_value = mock_result
+
+            monkeypatch.chdir(tmp_path)
+            result = runner.invoke(app, ["deploy"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        mock_reco.assert_called_once()
+
+    def test_deploy_does_not_reemit_on_error(self, tmp_path, monkeypatch):
+        self._config_file(tmp_path)
+        with (
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.launch_bedrock_agentcore") as mock_launch,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.print_recommendation") as mock_reco,
+        ):
+            mock_launch.side_effect = ValueError("boom")
+            monkeypatch.chdir(tmp_path)
+            runner.invoke(app, ["deploy"])
+
+        # Error path raises before the end-of-command re-emit; the top banner
+        # is still visible because error output is short.
+        mock_reco.assert_not_called()
+
+    def test_import_agent_reemits_recommendation_on_completion(self, tmp_path, monkeypatch):
+        # Drive import-agent fully non-interactively to the "Don't run now"
+        # completion branch, mocking only the AWS/translation boundary.
+        ia = "bedrock_agentcore_starter_toolkit.cli.create.import_agent.commands"
+        agents = [{"id": "AGENT123", "name": "MyAgent", "description": "d"}]
+        aliases = [{"id": "ALIAS123", "name": "prod", "description": "d"}]
+
+        translator = MagicMock()
+        translator.translate_bedrock_to_strands.return_value = {}
+
+        with (
+            patch(f"{ia}.print_recommendation") as mock_reco,
+            patch(f"{ia}.requires_aws_creds", lambda f: f),
+            patch("bedrock_agentcore_starter_toolkit.cli.common.ensure_valid_aws_creds", return_value=(True, None)),
+            patch("boto3.Session"),
+            patch(f"{ia}.get_clients", return_value=(MagicMock(), MagicMock())),
+            patch(f"{ia}.get_agents", return_value=agents),
+            patch(f"{ia}.get_agent_aliases", return_value=aliases),
+            patch(f"{ia}.auth_and_get_info", return_value=MagicMock()),
+            patch(f"{ia}.BedrockStrandsTranslation", return_value=translator),
+        ):
+            monkeypatch.chdir(tmp_path)
+            result = runner.invoke(
+                app,
+                [
+                    "create",
+                    "import",
+                    "--agent-id",
+                    "AGENT123",
+                    "--agent-alias-id",
+                    "ALIAS123",
+                    "--target-platform",
+                    "strands",
+                    "--region",
+                    "us-west-2",
+                    "--run-option",
+                    "none",
+                    "--output-dir",
+                    str(tmp_path / "out"),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_reco.assert_called_once()
+
+    def test_configure_reemits_recommendation_on_success(self, tmp_path, monkeypatch):
+        agent_file = tmp_path / "test_agent.py"
+        agent_file.write_text("from bedrock_agentcore.runtime import BedrockAgentCoreApp\napp = BedrockAgentCoreApp()")
+        with (
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.configure_impl") as mock_impl,
+            patch("bedrock_agentcore_starter_toolkit.cli.runtime.commands.print_recommendation") as mock_reco,
+            patch(
+                "bedrock_agentcore_starter_toolkit.cli.common.ensure_valid_aws_creds",
+                return_value=(True, None),
+            ),
+        ):
+            monkeypatch.chdir(tmp_path)
+            result = runner.invoke(
+                app,
+                ["configure", "--entrypoint", str(agent_file), "--execution-role", "TestRole", "--non-interactive"],
+            )
+
+        assert mock_impl.called
+        assert result.exit_code == 0
+        mock_reco.assert_called_once()

--- a/tests/create/test_console_print.py
+++ b/tests/create/test_console_print.py
@@ -1,0 +1,62 @@
+"""Tests for the create completion message and its trailing recommendation."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from bedrock_agentcore_starter_toolkit.create.types import ProjectContext
+from bedrock_agentcore_starter_toolkit.create.util import console_print
+
+
+def _flat(text: str) -> str:
+    """Collapse all whitespace so width-based line wrapping doesn't break asserts."""
+    return " ".join(text.split())
+
+
+def _ctx(**overrides) -> ProjectContext:
+    base = dict(
+        name="myAgent",
+        output_dir=Path("myAgent"),
+        src_dir=Path("myAgent/src"),
+        entrypoint_path=Path("myAgent/src/main.py"),
+        sdk_provider="Strands",
+        iac_provider=None,
+        model_provider="Bedrock",
+        template_dir_selection="runtime_only",
+        runtime_protocol="HTTP",
+        deployment_type="direct_code_deploy",
+        python_dependencies=[],
+    )
+    base.update(overrides)
+    return ProjectContext(**base)
+
+
+class TestEmitCreateCompletedMessage:
+    @patch("bedrock_agentcore_starter_toolkit.create.util.console_print.print_recommendation")
+    @patch("bedrock_agentcore_starter_toolkit.create.util.console_print._emit_next_steps")
+    def test_recommendation_printed_after_next_steps(self, mock_next_steps, mock_reco):
+        """Recommendation must be the LAST thing printed, after the next-steps panel."""
+        call_order = []
+        mock_next_steps.side_effect = lambda ctx: call_order.append("next_steps")
+        mock_reco.side_effect = lambda console: call_order.append("recommendation")
+
+        console_print.emit_create_completed_message(_ctx())
+
+        assert call_order == ["next_steps", "recommendation"]
+
+    @patch("bedrock_agentcore_starter_toolkit.create.util.console_print.print_recommendation")
+    def test_basic_runtime_panel_then_recommendation(self, mock_reco, capsys):
+        console_print.emit_create_completed_message(_ctx(iac_provider=None))
+        out = _flat(capsys.readouterr().out)
+        assert "You're ready to go!" in out
+        assert "agentcore deploy" in out
+        mock_reco.assert_called_once()
+
+    @patch("bedrock_agentcore_starter_toolkit.create.util.console_print.print_recommendation")
+    def test_production_panel_then_recommendation(self, mock_reco, capsys):
+        console_print.emit_create_completed_message(
+            _ctx(iac_provider="CDK", deployment_type="container", agent_name="myAgent")
+        )
+        out = _flat(capsys.readouterr().out)
+        assert "You're ready to go!" in out
+        assert "Deploy your project" in out
+        mock_reco.assert_called_once()


### PR DESCRIPTION
## Description

The AgentCore CLI deprecation recommendation is emitted by a top-level Typer callback (`_deprecation_banner`), so it fires before **every** command. The reported problem ("shows up for `dev` but not `create`") is a **visibility** issue, not a missing callback: the banner prints *first*, and high-output commands then flood the screen, scrolling the warning off the top before the command finishes.

This PR keeps the top banner everywhere, adds the requested **uninstall** command, and **re-emits the recommendation at the end** of the high-output "setup/build" commands so it survives the scroll.

### Coverage — verified across the whole CLI
Auto-discovered the full Click command tree (**78 command paths**) and confirmed the top banner fires on **78/78**. A hermetic tree-discovery test now guards this so coverage can't silently regress when commands are added.

### Visibility — fixed where it floods
"Buried" is a function of output height: the banner is ~7 lines printed first, so it scrolls away only when a command prints more than a screenful after it. The fix re-emits the recommendation as the **last** thing on screen for the commands that flood:

| Command | Behavior |
|---|---|
| `create` | re-emit after the success panel |
| `deploy` / `launch` | re-emit after the deployment panel (all modes: cloud, codebuild, direct_code_deploy, local-build) |
| `create import` (import-agent) | re-emit after the migration-complete summary |
| `configure` | re-emit after the configuration summary panel |
| everything else (`status`, `invoke`, `list`/`get` verbs, `destroy`, …) | top banner only — output is short, so it stays visible; a second copy would be noise |

Error paths re-raise before the re-emit (and their output is short), so they correctly keep only the top banner.

### Changes
- **New `cli/recommendation.py`** — single source of truth for the message, the install/uninstall/import commands, and the `AGENTCORE_SUPPRESS_RECOMMENDATION` env var. Banner and all end-of-command re-emits render from the same function so they can't drift.
- **Added the uninstall command** — `pip uninstall bedrock-agentcore-starter-toolkit` — to the banner, the end-of-command re-emits, and the README migration section.
- **End-of-command re-emit** on create, deploy/launch, import, configure (placed so it fires on success/flood, not on short error/cancel paths).
- **Cleanup**: removed the redundant `app.command("create")(create)` registration (the Typer group already owns the callback) plus now-unused imports.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

**Automated** (previously **zero** tests covered the banner):
- `tests/cli/test_recommendation.py` — recommendation module behavior; banner fires on **all 78** command paths (hermetic tree-discovery); uninstall present; suppress env var; no banner on bare `agentcore`; re-emit on deploy (and *not* on deploy error), import completion, and configure success.
- `tests/create/test_console_print.py` — recommendation printed after the next-steps panel for basic and production templates.
- Full `tests/cli/`, `tests/create/`, `tests/operations/runtime/`: **1050 passed, 64 skipped, 0 failed**.

**Manual** (via `python -m bedrock_agentcore_starter_toolkit.cli.cli` to avoid the new global `@aws/agentcore` CLI):
- Interactive `create` over a PTY + terminal-emulator render: recommendation (with uninstall) sits at the bottom, after the success panel.
- Real `configure` (success): recommendation lands after the configuration summary panel. Real `configure` (error, missing requirements): correctly does **not** re-emit.
- `dev`: top banner with uninstall on stderr. `AGENTCORE_SUPPRESS_RECOMMENDATION=1` silences all surfaces.

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit (scanned changed files — no issues identified)
- [x] Dependencies are from trusted sources (no new dependencies)
- [x] No sensitive data logged

## Breaking Changes

N/A

## Additional Notes

The recommendation text now reads:

```
⚠️ Recommendation: The Starter Toolkit CLI is no longer supported.
   Please use the AgentCore CLI (@aws/agentcore) to create, develop, and deploy agents on Amazon Bedrock AgentCore.
   New Bedrock AgentCore features are only accessible in the AgentCore CLI.

   To uninstall this starter toolkit, run: pip uninstall bedrock-agentcore-starter-toolkit
   To install the AgentCore CLI: npm install -g @aws/agentcore
   To import existing agents, run: agentcore import
   Set AGENTCORE_SUPPRESS_RECOMMENDATION=1 to silence this warning.
```



