### PR TITLE
Quality: Type mismatch: api_key_env_var_name declared Optional[str] but defaults to False (bool)

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/create/types.py
+++ b/src/bedrock_agentcore_starter_toolkit/create/types.py
@@ -63,7 +63,7 @@ class ProjectContext:
     # observability (use opentelemetry-instrument at Docker entry CMD)
     observability_enabled: bool = True
     # api key authentication
-    api_key_env_var_name: Optional[str] = False
+    api_key_env_var_name: Optional[str] = None
 
     def dict(self):
         """Return dataclass as dictionary."""


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The field `api_key_env_var_name` is annotated as `Optional[str]` but its default value is `False`, which is a `bool`. This is a silent type violation. Any downstream code that performs string operations on this field (e.g., `os.environ[api_key_env_var_name]` or string formatting) will fail at runtime when the default is used. With mypy configured in strict mode (`disallow_untyped_defs`, `warn_return_any`), this will also be flagged as a type error. The intended default is almost certainly `None` (meaning "not set").


**Severity**: `medium`
**File**: `src/bedrock_agentcore_starter_toolkit/create/types.py`

### Solution
Change line:
  api_key_env_var_name: Optional[str] = False
to:
  api_key_env_var_name: Optional[str] = None


### Changes
- `src/bedrock_agentcore_starter_toolkit/create/types.py` (modified)

## Description

Brief description of changes

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [ ] Manual testing completed

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [ ] No hardcoded secrets or credentials
- [ ] No new security warnings from bandit
- [ ] Dependencies are from trusted sources
- [ ] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #523