### PR TITLE
fix: update execution role policies for runtime, gateway, and evaluation

### DIFF
--- a/src/bedrock_agentcore_starter_toolkit/operations/evaluation/create_role.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/evaluation/create_role.py
@@ -148,7 +148,10 @@ def get_or_create_evaluation_execution_role(
                         "Sid": "BedrockInvokeStatement",
                         "Effect": "Allow",
                         "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
-                        "Resource": "*",
+                        "Resource": [
+                            "arn:aws:bedrock:*::foundation-model/*",
+                            f"arn:aws:bedrock:{region}:{account_id}:*",
+                        ],
                     },
                 ],
             }

--- a/src/bedrock_agentcore_starter_toolkit/operations/gateway/client.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/gateway/client.py
@@ -18,7 +18,11 @@ from .constants import (
     LAMBDA_CONFIG,
 )
 from .create_lambda import create_test_lambda
-from .create_role import create_gateway_execution_role
+from .create_role import (
+    append_credential_provider_permissions,
+    append_lambda_target_permission,
+    create_gateway_execution_role,
+)
 from .exceptions import GatewaySetupException
 
 
@@ -90,7 +94,9 @@ class GatewayClient:
             name = f"TestGateway{GatewayClient.generate_random_id()}"
         if not role_arn:
             self.logger.info("Role not provided, creating an execution role to use")
-            role_arn = create_gateway_execution_role(self.session, self.logger, region=self.region)
+            role_arn = create_gateway_execution_role(
+                self.session, self.logger, region=self.region, gateway_name=name.lower()
+            )
             self.logger.info("✓ Successfully created execution role for Gateway")
         if not authorizer_config:
             self.logger.info("Authorizer config not provided, creating an authorizer to use")
@@ -182,7 +188,7 @@ class GatewayClient:
         # handle open api schema
         if target_type == "openApiSchema":
             create_request |= self.__handle_openapi_target_credential_provider_creation(
-                name=name, credentials=credentials
+                name=name, credentials=credentials, role_arn=gateway.get("roleArn")
             )
         # create the target
         self.logger.info("Creating Target")
@@ -703,30 +709,49 @@ class GatewayClient:
         """
         lambda_arn = create_test_lambda(self.session, logger=self.logger, gateway_role_arn=role_arn)
 
+        append_lambda_target_permission(
+            session=self.session,
+            logger=self.logger,
+            role_arn=role_arn,
+            function_arn=lambda_arn,
+            region=self.region,
+        )
+
         return {
             "targetConfiguration": {"mcp": {"lambda": {"lambdaArn": lambda_arn, "toolSchema": LAMBDA_CONFIG}}},
         }
 
     def __handle_openapi_target_credential_provider_creation(
-        self, name: str, credentials: Dict[str, Any]
+        self, name: str, credentials: Dict[str, Any], role_arn: Optional[str] = None
     ) -> Dict[str, Any]:
         """Generate the credential provider config for open api target.
 
         :param name: the name of the target.
         :param credentials: credentials to use in setting up this target.
+        :param role_arn: the gateway execution role ARN, to scope credential access to this provider.
         :return: the credential provider config.
         """
         acps = self.session.client(service_name="bedrock-agentcore-control")
         if "api_key" in credentials:
             self.logger.info("Creating credential provider")
+            provider_name = f"{name}-ApiKey-{self.generate_random_id()}"
             credential_provider = acps.create_api_key_credential_provider(
-                name=f"{name}-ApiKey-{self.generate_random_id()}",
+                name=provider_name,
                 apiKey=credentials["api_key"],
             )
             self.logger.info(
                 "✓ Added credential provider successfully (ARN: %s)",
                 credential_provider["credentialProviderArn"],
             )
+            if role_arn:
+                append_credential_provider_permissions(
+                    session=self.session,
+                    logger=self.logger,
+                    role_arn=role_arn,
+                    provider_name=provider_name,
+                    provider_kind="apikey",
+                    region=self.region,
+                )
             target_cred_provider_config = {
                 "credentialProviderType": "API_KEY",
                 "credentialProvider": {
@@ -739,8 +764,9 @@ class GatewayClient:
             }
         elif "oauth2_provider_config" in credentials:
             self.logger.info("Creating credential provider")
+            provider_name = f"{name}-OAuth-Credentials-{self.generate_random_id()}"
             credential_provider = acps.create_oauth2_credential_provider(
-                name=f"{name}-OAuth-Credentials-{self.generate_random_id()}",
+                name=provider_name,
                 credentialProviderVendor="CustomOauth2",
                 oauth2ProviderConfigInput=credentials["oauth2_provider_config"],
             )
@@ -748,6 +774,15 @@ class GatewayClient:
                 "✓ Added credential provider successfully (ARN: %s)",
                 credential_provider["credentialProviderArn"],
             )
+            if role_arn:
+                append_credential_provider_permissions(
+                    session=self.session,
+                    logger=self.logger,
+                    role_arn=role_arn,
+                    provider_name=provider_name,
+                    provider_kind="oauth2",
+                    region=self.region,
+                )
             target_cred_provider_config = {
                 "credentialProviderType": "OAUTH",
                 "credentialProvider": {

--- a/src/bedrock_agentcore_starter_toolkit/operations/gateway/constants.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/gateway/constants.py
@@ -44,51 +44,121 @@ CREATE_OPENAPI_TARGET_INVALID_CREDENTIALS_SHAPE_EXCEPTION_MESSAGE = """
             }
 """
 
-AGENTCORE_FULL_ACCESS = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "BedrockAgentCoreFullAccess",
-            "Effect": "Allow",
-            "Action": ["bedrock-agentcore:*"],
-            "Resource": "arn:aws:bedrock-agentcore:*:*:*",
-        },
-        {
-            "Sid": "GetSecretValue",
-            "Effect": "Allow",
-            "Action": ["secretsmanager:GetSecretValue"],
-            "Resource": "*",
-        },
-        {
-            "Sid": "LambdaInvokeAccess",
-            "Effect": "Allow",
-            "Action": ["lambda:InvokeFunction"],
-            "Resource": "arn:aws:lambda:*:*:function:*",
-        },
-    ],
-}
+GATEWAY_EXECUTION_POLICY_NAME = "BedrockAgentCoreGatewayExecutionPolicy"
 
-KMS_FULL_ACCESS = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "KmsFullAccess",
-            "Effect": "Allow",
-            "Action": ["kms:*"],
-            "Resource": "arn:aws:kms:*:*:*",
-        }
-    ],
-}
 
-POLICIES_TO_CREATE = [
-    ("BedrockAgentCoreGatewayStarterFullAccess", AGENTCORE_FULL_ACCESS),
-    ("KmsStarterFullAccess", KMS_FULL_ACCESS),
-]
+def build_gateway_access_policy(region: str, account_id: str, gateway_name: str, partition: str = "aws") -> dict:
+    """Build the base gateway execution policy.
 
-POLICIES = {
-    "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
-    "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
-}
+    Credential-provider and Lambda-target permissions are attached separately, scoped to each
+    resource, by append_credential_provider_permissions and append_lambda_target_permission.
+
+    :param region: AWS region for resource ARNs.
+    :param account_id: AWS account ID for resource ARNs.
+    :param gateway_name: gateway name prefix used to scope the gateway ARN.
+    :param partition: AWS partition (``aws``, ``aws-cn``, ``aws-us-gov``).
+    :return: an IAM policy document.
+    """
+    prefix = f"arn:{partition}:bedrock-agentcore:{region}:{account_id}"
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "GetGateway",
+                "Effect": "Allow",
+                "Action": ["bedrock-agentcore:GetGateway"],
+                "Resource": [f"{prefix}:gateway/{gateway_name}-*"],
+            },
+            {
+                "Sid": "GetConfigurationBundleVersion",
+                "Effect": "Allow",
+                "Action": ["bedrock-agentcore:GetConfigurationBundleVersion"],
+                "Resource": [f"{prefix}:configuration-bundle/*"],
+                "Condition": {
+                    "StringEquals": {
+                        "aws:ResourceAccount": "${aws:PrincipalAccount}",
+                        "aws:RequestedRegion": region,
+                    }
+                },
+            },
+        ],
+    }
+
+
+def build_gateway_credential_provider_policy(
+    region: str,
+    account_id: str,
+    provider_name: str,
+    provider_kind: str,
+    partition: str = "aws",
+) -> dict:
+    """Build a policy granting credential and secret access for a single OpenAPI provider.
+
+    :param region: AWS region.
+    :param account_id: AWS account ID.
+    :param provider_name: the credential provider name (used to scope the secret ARN prefix).
+    :param provider_kind: ``oauth2`` or ``apikey``.
+    :param partition: AWS partition.
+    :return: an IAM policy document.
+    """
+    bac = f"arn:{partition}:bedrock-agentcore:{region}:{account_id}"
+    sm = f"arn:{partition}:secretsmanager:{region}:{account_id}"
+    if provider_kind == "oauth2":
+        token_action = "bedrock-agentcore:GetResourceOauth2Token"  # nosec B105 - IAM action name, not a secret
+        provider_resource = f"{bac}:token-vault/default/oauth2credentialprovider/{provider_name}*"
+        secret_resource = f"{sm}:secret:bedrock-agentcore-identity!default/oauth2/{provider_name}-*"
+    elif provider_kind == "apikey":
+        token_action = "bedrock-agentcore:GetResourceApiKey"  # nosec B105 - IAM action name, not a secret
+        provider_resource = f"{bac}:token-vault/default/apikeycredentialprovider/{provider_name}*"
+        secret_resource = f"{sm}:secret:bedrock-agentcore-identity!default/apikey/{provider_name}-*"
+    else:
+        raise ValueError(f"Unknown provider_kind: {provider_kind!r} (expected 'oauth2' or 'apikey')")
+
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "GatewayCredentialProviderToken",
+                "Effect": "Allow",
+                "Action": [token_action],
+                "Resource": [f"{bac}:token-vault/default", provider_resource],
+            },
+            {
+                "Sid": "GatewayCredentialProviderSecret",
+                "Effect": "Allow",
+                "Action": ["secretsmanager:GetSecretValue"],
+                "Resource": [secret_resource],
+            },
+        ],
+    }
+
+
+def build_gateway_lambda_invoke_policy(region: str, account_id: str, function_arn: str, partition: str = "aws") -> dict:
+    """Build a policy granting invoke on a single Lambda function.
+
+    :param region: AWS region (unused in ARN, kept for signature symmetry).
+    :param account_id: AWS account ID for the ResourceAccount condition.
+    :param function_arn: the exact Lambda function ARN the gateway target invokes.
+    :param partition: AWS partition.
+    :return: an IAM policy document.
+    """
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "GatewayLambdaTargetInvoke",
+                "Effect": "Allow",
+                "Action": ["lambda:InvokeFunction"],
+                "Resource": [function_arn],
+                "Condition": {"StringEquals": {"aws:ResourceAccount": account_id}},
+            }
+        ],
+    }
+
+
+POLICIES: set = set()
+
+POLICIES_TO_CREATE: list = []
 
 LAMBDA_FUNCTION_CODE = """
 import json

--- a/src/bedrock_agentcore_starter_toolkit/operations/gateway/create_role.py
+++ b/src/bedrock_agentcore_starter_toolkit/operations/gateway/create_role.py
@@ -9,9 +9,14 @@ from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 
 from ...operations.gateway.constants import (
+    GATEWAY_EXECUTION_POLICY_NAME,
     POLICIES,
     POLICIES_TO_CREATE,
+    build_gateway_access_policy,
+    build_gateway_credential_provider_policy,
+    build_gateway_lambda_invoke_policy,
 )
+from ...utils.aws import get_partition
 from ...utils.runtime.policy_template import render_trust_policy_template
 
 
@@ -20,6 +25,7 @@ def create_gateway_execution_role(
     logger: logging.Logger,
     role_name: str = "AgentCoreGatewayExecutionRole",
     region: Optional[str] = None,
+    gateway_name: str = "*",
 ) -> str:
     """Create the Gateway execution role.
 
@@ -27,12 +33,14 @@ def create_gateway_execution_role(
     :param logger: the logger to use.
     :param role_name: the name of the role to create.
     :param region: the AWS region for the SourceArn condition. Defaults to the session region.
+    :param gateway_name: the gateway name used to scope the gateway ARN in the base policy.
     :return: the role ARN.
     """
     iam = session.client("iam")
     sts = session.client("sts")
     account_id = sts.get_caller_identity()["Account"]
     region = region or session.region_name
+    partition = get_partition(region)
     trust_policy = render_trust_policy_template(region=region, account_id=account_id)
     # Create the role
     try:
@@ -41,6 +49,17 @@ def create_gateway_execution_role(
             AssumeRolePolicyDocument=trust_policy,
             Description="Execution role for AgentCore Gateway",
         )
+
+        base_policy = build_gateway_access_policy(
+            region=region, account_id=account_id, gateway_name=gateway_name, partition=partition
+        )
+        _attach_policy(
+            iam_client=iam,
+            role_name=role_name,
+            policy_name=GATEWAY_EXECUTION_POLICY_NAME,
+            policy_document=json.dumps(base_policy),
+        )
+
         for policy_name, policy in POLICIES_TO_CREATE:
             _attach_policy(
                 iam_client=iam,
@@ -65,6 +84,102 @@ def create_gateway_execution_role(
         else:
             logger.error("Error creating role: %s", e)
             raise
+
+
+def _role_name_from_arn(role_arn: str) -> str:
+    """Extract the role name from a role ARN (``.../role/<name>`` -> ``<name>``)."""
+    return role_arn.split("/")[-1]
+
+
+def append_credential_provider_permissions(
+    session: Session,
+    logger: logging.Logger,
+    role_arn: str,
+    provider_name: str,
+    provider_kind: str,
+    region: Optional[str] = None,
+) -> None:
+    """Attach token and secret access for a single credential provider to the gateway role.
+
+    Failures are logged and do not raise, so target creation proceeds.
+
+    :param session: the boto3 session to use.
+    :param logger: the logger to use.
+    :param role_arn: the gateway execution role ARN.
+    :param provider_name: the credential provider name (scopes the secret/token-vault ARNs).
+    :param provider_kind: ``oauth2`` or ``apikey``.
+    :param region: AWS region; defaults to the session region.
+    """
+    region = region or session.region_name
+    account_id = session.client("sts").get_caller_identity()["Account"]
+    partition = get_partition(region)
+    role_name = _role_name_from_arn(role_arn)
+    policy = build_gateway_credential_provider_policy(
+        region=region,
+        account_id=account_id,
+        provider_name=provider_name,
+        provider_kind=provider_kind,
+        partition=partition,
+    )
+    policy_name = f"GatewayCredentialProvider-{provider_kind}-{provider_name}"[:128]
+    try:
+        session.client("iam").put_role_policy(
+            RoleName=role_name,
+            PolicyName=policy_name,
+            PolicyDocument=json.dumps(policy),
+        )
+        logger.info("✓ Scoped credential-provider permissions added to %s for provider %s", role_name, provider_name)
+    except ClientError as e:
+        logger.warning(
+            "⚠️ Could not add scoped credential-provider permissions to %s for provider %s: %s. "
+            "The gateway may lack access to this provider's secret; continuing (best effort).",
+            role_name,
+            provider_name,
+            e,
+        )
+
+
+def append_lambda_target_permission(
+    session: Session,
+    logger: logging.Logger,
+    role_arn: str,
+    function_arn: str,
+    region: Optional[str] = None,
+) -> None:
+    """Attach ``lambda:InvokeFunction`` for a single function ARN to the gateway role.
+
+    Failures are logged and do not raise, so target creation proceeds.
+
+    :param session: the boto3 session to use.
+    :param logger: the logger to use.
+    :param role_arn: the gateway execution role ARN.
+    :param function_arn: the exact Lambda function ARN the target invokes.
+    :param region: AWS region; defaults to the session region.
+    """
+    region = region or session.region_name
+    account_id = session.client("sts").get_caller_identity()["Account"]
+    partition = get_partition(region)
+    role_name = _role_name_from_arn(role_arn)
+    policy = build_gateway_lambda_invoke_policy(
+        region=region, account_id=account_id, function_arn=function_arn, partition=partition
+    )
+    function_name = function_arn.split(":function:")[-1].split(":")[0]
+    policy_name = f"GatewayLambdaTarget-{function_name}"[:128]
+    try:
+        session.client("iam").put_role_policy(
+            RoleName=role_name,
+            PolicyName=policy_name,
+            PolicyDocument=json.dumps(policy),
+        )
+        logger.info("✓ Scoped Lambda invoke permission added to %s for %s", role_name, function_arn)
+    except ClientError as e:
+        logger.warning(
+            "⚠️ Could not add scoped Lambda invoke permission to %s for %s: %s. "
+            "The gateway may lack invoke access to this target; continuing (best effort).",
+            role_name,
+            function_arn,
+            e,
+        )
 
 
 def _attach_policy(

--- a/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
+++ b/src/bedrock_agentcore_starter_toolkit/utils/runtime/templates/execution_role_policy.json.j2
@@ -78,17 +78,14 @@
       }
     },
     {
-        "Effect": "Allow",
-        "Action": [
-            "logs:CreateLogGroup",
-            "logs:PutDeliverySource",
-            "logs:PutDeliveryDestination",
-            "logs:CreateDelivery",
-            "logs:GetDeliverySource",
-            "logs:DeleteDeliverySource",
-            "logs:DeleteDeliveryDestination"
-        ],
-        "Resource": "*"
+      "Sid": "CloudWatchLogsPutResourcePolicy",
+      "Effect": "Allow",
+      "Action": [
+        "logs:PutResourcePolicy"
+      ],
+      "Resource": [
+        "arn:{{ partition }}:logs:{{ region }}:{{ account_id }}:log-group:/aws/bedrock-agentcore/runtimes/{{ agent_name }}-*"
+      ]
     },
     {% if is_a2a_protocol %}
     {
@@ -99,21 +96,11 @@
         "bedrock-agentcore:InvokeAgentRuntimeForUser"
       ],
       "Resource": [
-        "arn:{{ partition }}:bedrock-agentcore:{{ region }}:{{ account_id }}:runtime/*"
+        "arn:{{ partition }}:bedrock-agentcore:{{ region }}:{{ account_id }}:runtime/{{ agent_name }}-*"
       ]
     },
     {% endif %}
     {% if memory_enabled %}
-    {% if not has_memory_id %}
-    {
-      "Sid": "BedrockAgentCoreMemoryCreateMemory",
-      "Effect": "Allow",
-      "Action": [
-        "bedrock-agentcore:CreateMemory"
-      ],
-      "Resource": "*"
-    },
-    {% endif %}
     {
       "Sid": "BedrockAgentCoreMemory",
       "Effect": "Allow",
@@ -134,7 +121,7 @@
         {% if has_memory_id %}
         "arn:{{ partition }}:bedrock-agentcore:{{ region }}:{{ account_id }}:memory/{{ memory_id }}"
         {% else %}
-        "arn:{{ partition }}:bedrock-agentcore:{{ region }}:{{ account_id }}:memory/*"
+        "arn:{{ partition }}:bedrock-agentcore:{{ region }}:{{ account_id }}:memory/{{ agent_name }}_mem-*"
         {% endif %}
       ]
     },
@@ -186,7 +173,6 @@
       ],
       "Resource": [
         "arn:{{ partition }}:bedrock:*::foundation-model/*",
-        "arn:{{ partition }}:bedrock:*:*:inference-profile/*",
         "arn:{{ partition }}:bedrock:{{ region }}:{{ account_id }}:*"
       ]
     },
@@ -223,12 +209,11 @@
       "Sid": "BedrockAgentCoreIdentity",
       "Effect": "Allow",
       "Action": [
-        "bedrock-agentcore:CreateWorkloadIdentity",
         "bedrock-agentcore:GetWorkloadAccessTokenForUserId"
       ],
       "Resource": [
         "arn:{{ partition }}:bedrock-agentcore:{{ region }}:{{ account_id }}:workload-identity-directory/default",
-        "arn:{{ partition }}:bedrock-agentcore:{{ region }}:{{ account_id }}:workload-identity-directory/default/workload-identity/*"
+        "arn:{{ partition }}:bedrock-agentcore:{{ region }}:{{ account_id }}:workload-identity-directory/default/workload-identity/{{ agent_name }}-*"
       ]
     },
     {

--- a/tests/operations/evaluation/test_create_role.py
+++ b/tests/operations/evaluation/test_create_role.py
@@ -193,6 +193,13 @@ class TestGetOrCreateEvaluationExecutionRole:
         assert "logs:StartQuery" in actions
         assert "bedrock:InvokeModel" in actions
 
+        bedrock_stmt = next(s for s in policy["Statement"] if s.get("Sid") == "BedrockInvokeStatement")
+        assert bedrock_stmt["Resource"] == [
+            "arn:aws:bedrock:*::foundation-model/*",
+            "arn:aws:bedrock:us-east-1:123456789012:*",
+        ]
+        assert "*" not in bedrock_stmt["Resource"]
+
     @patch("time.sleep")
     def test_handles_entity_already_exists_race_condition(self, mock_sleep):
         """Test handles race condition when role is created between checks."""

--- a/tests/operations/gateway/test_gateway_client.py
+++ b/tests/operations/gateway/test_gateway_client.py
@@ -89,6 +89,7 @@ class TestGatewayClient:
             session_client.exceptions.ResourceConflictException = ValueError
             session_client.create_role.return_value = {"Role": {"Arn": "arn"}}
             session_client.create_function.return_value = {"FunctionArn": "arn"}
+            session_client.get_caller_identity.return_value = {"Account": "123456789012"}
             # Test Lambda target
             gateway = gateway_client.create_mcp_gateway(
                 name="test-lambda",
@@ -150,6 +151,7 @@ class TestGatewayClient:
             acps_client = Mock()
             mock_acps.return_value = acps_client
             acps_client.create_api_key_credential_provider.return_value = {"credentialProviderArn": "arn"}
+            acps_client.get_caller_identity.return_value = {"Account": "123456789012"}
             # Test OpenAPI from S3
             gateway = gateway_client.create_mcp_gateway(
                 name="test-lambda",

--- a/tests/operations/gateway/test_gateway_client_init.py
+++ b/tests/operations/gateway/test_gateway_client_init.py
@@ -209,7 +209,10 @@ class TestCreateMCPGateway:
 
                         # Verify role creation was called
                         mock_create_role.assert_called_once_with(
-                            self.client.session, self.client.logger, region=self.client.region
+                            self.client.session,
+                            self.client.logger,
+                            region=self.client.region,
+                            gateway_name="testgateway12345678",
                         )
 
                         # Verify authorizer creation was called
@@ -432,8 +435,9 @@ class TestCreateMCPGatewayTarget:
                     credentials=credentials,
                 )
 
-                # Verify OpenAPI handler was called
-                mock_handle_openapi.assert_called_once_with(name="OpenAPITarget", credentials=credentials)
+                mock_handle_openapi.assert_called_once_with(
+                    name="OpenAPITarget", credentials=credentials, role_arn=self.gateway["roleArn"]
+                )
 
                 # Verify create_gateway_target was called
                 call_args = self.client.client.create_gateway_target.call_args[1]
@@ -506,9 +510,14 @@ class TestHandleLambdaTargetCreation:
         role_arn = "arn:aws:iam::123456789012:role/TestRole"
         lambda_arn = "arn:aws:lambda:us-west-2:123456789012:function:TestFunction"
 
-        with patch(
-            "bedrock_agentcore_starter_toolkit.operations.gateway.client.create_test_lambda"
-        ) as mock_create_lambda:
+        with (
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.gateway.client.create_test_lambda"
+            ) as mock_create_lambda,
+            patch(
+                "bedrock_agentcore_starter_toolkit.operations.gateway.client.append_lambda_target_permission"
+            ) as mock_append,
+        ):
             mock_create_lambda.return_value = lambda_arn
 
             result = self.client._GatewayClient__handle_lambda_target_creation(role_arn)
@@ -516,6 +525,14 @@ class TestHandleLambdaTargetCreation:
             # Verify create_test_lambda was called with correct parameters
             mock_create_lambda.assert_called_once_with(
                 self.client.session, logger=self.client.logger, gateway_role_arn=role_arn
+            )
+
+            mock_append.assert_called_once_with(
+                session=self.client.session,
+                logger=self.client.logger,
+                role_arn=role_arn,
+                function_arn=lambda_arn,
+                region=self.client.region,
             )
 
             # Verify return value structure

--- a/tests/operations/gateway/test_gateway_create_role.py
+++ b/tests/operations/gateway/test_gateway_create_role.py
@@ -8,15 +8,22 @@ import pytest
 from botocore.exceptions import ClientError
 
 from bedrock_agentcore_starter_toolkit.operations.gateway.constants import (
-    AGENTCORE_FULL_ACCESS,
     POLICIES,
     POLICIES_TO_CREATE,
+    build_gateway_access_policy,
 )
 from bedrock_agentcore_starter_toolkit.operations.gateway.create_role import (
     _attach_policy,
+    append_credential_provider_permissions,
+    append_lambda_target_permission,
     create_gateway_execution_role,
 )
 from bedrock_agentcore_starter_toolkit.utils.runtime.policy_template import render_trust_policy_template
+
+# The base gateway policy is built dynamically; use a concrete instance where tests need a document.
+AGENTCORE_FULL_ACCESS = build_gateway_access_policy(
+    region="us-east-1", account_id="123456789012", gateway_name="testgateway"
+)
 
 
 class TestCreateGatewayExecutionRole:
@@ -59,8 +66,7 @@ class TestCreateGatewayExecutionRole:
             Description="Execution role for AgentCore Gateway",
         )
 
-        # Verify policies were attached
-        expected_calls = len(POLICIES_TO_CREATE) + len(POLICIES)
+        expected_calls = 1 + len(POLICIES_TO_CREATE) + len(POLICIES)
         assert mock_attach.call_count == expected_calls
 
         # Verify return value
@@ -154,13 +160,27 @@ class TestCreateGatewayExecutionRole:
         with patch("bedrock_agentcore_starter_toolkit.operations.gateway.create_role._attach_policy") as mock_attach:
             create_gateway_execution_role(self.mock_session, self.logger, self.role_name)
 
-            # Verify policy creation calls (POLICIES_TO_CREATE)
             policy_creation_calls = [
                 call for call in mock_attach.call_args_list if call.kwargs.get("policy_document") is not None
             ]
-            assert len(policy_creation_calls) == len(POLICIES_TO_CREATE)
+            assert len(policy_creation_calls) == 1 + len(POLICIES_TO_CREATE)
 
-            # Verify policy ARN attachment calls (POLICIES)
+            base_call = policy_creation_calls[0]
+            doc = json.loads(base_call.kwargs["policy_document"])
+            base_actions = []
+            for stmt in doc["Statement"]:
+                res = stmt["Resource"] if isinstance(stmt["Resource"], list) else [stmt["Resource"]]
+                assert "*" not in res, f"base gateway policy has Resource:* in {stmt.get('Sid')}"
+                acts = stmt["Action"] if isinstance(stmt["Action"], list) else [stmt["Action"]]
+                base_actions.extend(acts)
+                assert "bedrock-agentcore:*" not in acts
+                assert "secretsmanager:GetSecretValue" not in acts
+                assert "lambda:InvokeFunction" not in acts
+            assert base_actions == [
+                "bedrock-agentcore:GetGateway",
+                "bedrock-agentcore:GetConfigurationBundleVersion",
+            ]
+
             policy_arn_calls = [
                 call for call in mock_attach.call_args_list if call.kwargs.get("policy_arn") is not None
             ]
@@ -181,9 +201,8 @@ class TestCreateGatewayExecutionRole:
         # Verify role was created successfully
         assert result == self.role_arn
 
-        # Verify policies were created and attached
-        assert self.mock_iam_client.create_policy.call_count == len(POLICIES_TO_CREATE)
-        assert self.mock_iam_client.attach_role_policy.call_count == len(POLICIES_TO_CREATE) + len(POLICIES)
+        assert self.mock_iam_client.create_policy.call_count == 1 + len(POLICIES_TO_CREATE)
+        assert self.mock_iam_client.attach_role_policy.call_count == 1 + len(POLICIES_TO_CREATE) + len(POLICIES)
 
 
 class TestAttachPolicy:
@@ -468,3 +487,108 @@ class TestAttachPolicy:
 
             # Verify create_policy was not called for managed policies
             self.mock_iam_client.create_policy.assert_not_called()
+
+
+class TestDeferredAppendHelpers:
+    """Test append_lambda_target_permission and append_credential_provider_permissions."""
+
+    def setup_method(self):
+        """Setup test fixtures."""
+        self.mock_session = Mock()
+        self.mock_iam_client = Mock()
+        self.mock_sts_client = Mock()
+        self.mock_sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
+        self.mock_session.client.side_effect = lambda svc, **kw: (
+            self.mock_sts_client if svc == "sts" else self.mock_iam_client
+        )
+        self.mock_session.region_name = "us-east-1"
+        self.logger = logging.getLogger(__name__)
+        self.role_arn = "arn:aws:iam::123456789012:role/AgentCoreGatewayExecutionRole"
+
+    def test_append_lambda_target_permission_scoped_to_function(self):
+        """Lambda invoke is scoped to the exact function ARN with a ResourceAccount condition."""
+        function_arn = "arn:aws:lambda:us-east-1:123456789012:function:AgentCoreLambdaTestFunction"
+
+        append_lambda_target_permission(
+            session=self.mock_session,
+            logger=self.logger,
+            role_arn=self.role_arn,
+            function_arn=function_arn,
+        )
+
+        self.mock_iam_client.put_role_policy.assert_called_once()
+        kwargs = self.mock_iam_client.put_role_policy.call_args.kwargs
+        assert kwargs["RoleName"] == "AgentCoreGatewayExecutionRole"
+        doc = json.loads(kwargs["PolicyDocument"])
+        stmt = doc["Statement"][0]
+        assert stmt["Action"] == ["lambda:InvokeFunction"]
+        assert stmt["Resource"] == [function_arn]
+        assert stmt["Condition"] == {"StringEquals": {"aws:ResourceAccount": "123456789012"}}
+        assert "*" not in stmt["Resource"]
+
+    def test_append_credential_provider_permissions_oauth2_scoped(self):
+        """OAuth2 provider access is scoped to that provider's token-vault and secret ARNs."""
+        append_credential_provider_permissions(
+            session=self.mock_session,
+            logger=self.logger,
+            role_arn=self.role_arn,
+            provider_name="MyProvider",
+            provider_kind="oauth2",
+        )
+
+        self.mock_iam_client.put_role_policy.assert_called_once()
+        doc = json.loads(self.mock_iam_client.put_role_policy.call_args.kwargs["PolicyDocument"])
+        actions = [a for s in doc["Statement"] for a in s["Action"]]
+        assert "bedrock-agentcore:GetResourceOauth2Token" in actions
+        assert "secretsmanager:GetSecretValue" in actions
+        all_res = [
+            r for s in doc["Statement"] for r in (s["Resource"] if isinstance(s["Resource"], list) else [s["Resource"]])
+        ]
+        assert "*" not in all_res
+        expected_provider_arn = (
+            "arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default/oauth2credentialprovider/MyProvider*"
+        )
+        expected_secret_arn = (
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:"
+            "bedrock-agentcore-identity!default/oauth2/MyProvider-*"
+        )
+        assert expected_provider_arn in all_res
+        assert expected_secret_arn in all_res
+        non_provider = [r for r in all_res if "MyProvider" not in r]
+        assert non_provider == ["arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default"]
+
+    def test_append_credential_provider_permissions_apikey_scoped(self):
+        """API-key provider access is scoped to that provider's token-vault and secret ARNs."""
+        append_credential_provider_permissions(
+            session=self.mock_session,
+            logger=self.logger,
+            role_arn=self.role_arn,
+            provider_name="MyApiKey",
+            provider_kind="apikey",
+        )
+        doc = json.loads(self.mock_iam_client.put_role_policy.call_args.kwargs["PolicyDocument"])
+        actions = [a for s in doc["Statement"] for a in s["Action"]]
+        assert "bedrock-agentcore:GetResourceApiKey" in actions
+        secret_res = [
+            r
+            for s in doc["Statement"]
+            for r in (s["Resource"] if isinstance(s["Resource"], list) else [s["Resource"]])
+            if "secretsmanager" in r
+        ]
+        assert secret_res == [
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:bedrock-agentcore-identity!default/apikey/MyApiKey-*"
+        ]
+
+    def test_append_is_best_effort_on_failure(self):
+        """A put_role_policy failure is swallowed (logged) so target creation is not blocked."""
+        self.mock_iam_client.put_role_policy.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDenied", "Message": "denied"}},
+            operation_name="PutRolePolicy",
+        )
+        # Should not raise
+        append_lambda_target_permission(
+            session=self.mock_session,
+            logger=self.logger,
+            role_arn=self.role_arn,
+            function_arn="arn:aws:lambda:us-east-1:123456789012:function:F",
+        )

--- a/tests/utils/runtime/test_policy_template.py
+++ b/tests/utils/runtime/test_policy_template.py
@@ -207,6 +207,10 @@ class TestPolicyTemplate:
         sids_a2a = [s.get("Sid") for s in policy_a2a["Statement"]]
         assert "BedrockAgentCoreRuntime" in sids_a2a
 
+        a2a_stmt = next(s for s in policy_a2a["Statement"] if s.get("Sid") == "BedrockAgentCoreRuntime")
+        assert a2a_stmt["Resource"] == ["arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test-agent-*"]
+        assert "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/*" not in a2a_stmt["Resource"]
+
         # With HTTP protocol
         policy_http = json.loads(
             render_execution_policy_template(
@@ -278,6 +282,77 @@ class TestPolicyTemplate:
         # CreateMemory permission should NOT be included when memory_id is provided
         sids = [s.get("Sid") for s in policy["Statement"]]
         assert "BedrockAgentCoreMemoryCreateMemory" not in sids
+
+    def test_memory_scoped_to_name_prefix_when_id_unknown(self):
+        """Memory access is scoped to the agent's memory ARN and never grants CreateMemory."""
+        policy = json.loads(
+            render_execution_policy_template(
+                region="us-east-1",
+                account_id="123456789012",
+                agent_name="test-agent",
+                memory_id="test-memory-id",
+            )
+        )
+        # (memory_id known path already covered above; here assert the CreateMemory action is gone entirely)
+        all_actions = []
+        for s in policy["Statement"]:
+            acts = s["Action"]
+            all_actions.extend([acts] if isinstance(acts, str) else acts)
+        assert "bedrock-agentcore:CreateMemory" not in all_actions
+
+    def test_no_create_workload_identity_and_scoped_identity(self):
+        """Identity access omits CreateWorkloadIdentity and scopes tokens to the agent's prefix."""
+        policy = json.loads(
+            render_execution_policy_template(region="us-east-1", account_id="123456789012", agent_name="test-agent")
+        )
+        all_actions = []
+        for s in policy["Statement"]:
+            acts = s["Action"]
+            all_actions.extend([acts] if isinstance(acts, str) else acts)
+        assert "bedrock-agentcore:CreateWorkloadIdentity" not in all_actions
+
+        identity_stmt = next(s for s in policy["Statement"] if s.get("Sid") == "BedrockAgentCoreIdentity")
+        assert identity_stmt["Resource"] == [
+            "arn:aws:bedrock-agentcore:us-east-1:123456789012:workload-identity-directory/default",
+            "arn:aws:bedrock-agentcore:us-east-1:123456789012:workload-identity-directory/default/"
+            "workload-identity/test-agent-*",
+        ]
+
+    def test_no_broad_log_delivery_and_scoped_put_resource_policy(self):
+        """Log config grants only logs:PutResourcePolicy scoped to the agent's runtime log group."""
+        policy = json.loads(
+            render_execution_policy_template(region="us-east-1", account_id="123456789012", agent_name="test-agent")
+        )
+        all_actions = []
+        for s in policy["Statement"]:
+            acts = s["Action"]
+            all_actions.extend([acts] if isinstance(acts, str) else acts)
+        for gone in (
+            "logs:PutDeliverySource",
+            "logs:PutDeliveryDestination",
+            "logs:CreateDelivery",
+            "logs:DeleteDeliverySource",
+            "logs:DeleteDeliveryDestination",
+        ):
+            assert gone not in all_actions
+
+        prp = next(s for s in policy["Statement"] if s.get("Sid") == "CloudWatchLogsPutResourcePolicy")
+        assert prp["Action"] == ["logs:PutResourcePolicy"]
+        assert prp["Resource"] == [
+            "arn:aws:logs:us-east-1:123456789012:log-group:/aws/bedrock-agentcore/runtimes/test-agent-*"
+        ]
+
+    def test_bedrock_invocation_two_arn_form(self):
+        """BedrockModelInvocation grants foundation-model and same-account Bedrock resources only."""
+        policy = json.loads(
+            render_execution_policy_template(region="us-east-1", account_id="123456789012", agent_name="test-agent")
+        )
+        bedrock_stmt = next(s for s in policy["Statement"] if s.get("Sid") == "BedrockModelInvocation")
+        assert bedrock_stmt["Resource"] == [
+            "arn:aws:bedrock:*::foundation-model/*",
+            "arn:aws:bedrock:us-east-1:123456789012:*",
+        ]
+        assert "arn:aws:bedrock:*:*:inference-profile/*" not in bedrock_stmt["Resource"]
 
     def test_code_interpreter_always_included(self):
         """Test that CodeInterpreter permissions are always included and scoped to AWS managed."""


### PR DESCRIPTION
## Description
Updates the IAM execution role policies generated by the toolkit so that resource
ARNs are specified explicitly for the runtime, gateway, and evaluation execution roles.

### Runtime execution role (`execution_role_policy.json.j2`)
- Grant `logs:PutResourcePolicy` on the agent's runtime log group
- Set Bedrock model invocation resources to foundation-model and the account's Bedrock resources
- Set A2A `InvokeAgentRuntime` resource to the agent's runtime family
- Set memory resources to the agent's memory ARN
- Set workload-identity resources to the agent's workload-identity prefix

### Gateway execution role (`operations/gateway`)
- Build the base execution policy per account/region/partition
- Attach credential-provider access per OpenAPI credential provider
- Attach `lambda:InvokeFunction` per Lambda target

### Evaluation execution role (`operations/evaluation`)
- Set Bedrock model invocation resources to foundation-model and the account's Bedrock resources

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [x] Test coverage remains above 80%
- [x] Manual testing completed

Full suite: 2847 passed, 64 skipped. Coverage on the changed modules is 85%.
Manual testing: verified end-to-end against a test account via `agentcore configure`
/ `deploy` / `invoke` / `destroy` (runtime), and the gateway create / add-target /
invoke flow. (`tests_integ/` suite not run — requires live AWS setup.)

## Checklist

- [x] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] No new security warnings from bandit
- [x] Dependencies are from trusted sources
- [x] No sensitive data logged

## Breaking Changes

N/A

## Additional Notes

No new dependencies introduced. Changes are limited to the generated IAM policy
documents and their unit tests. The user-facing permissions documentation shows a
curated subset of the execution-role policy and does not enumerate the specific
statements changed here; the documented Bedrock invocation example already matches
the updated form.
