### PR TITLE
ci: use dedicated release runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     outputs:
       version: ${{ steps.bump.outputs.version }}
       pr_created: ${{ steps.create-pr.outputs.pull-request-number }}
@@ -226,7 +226,7 @@ jobs:
   test:
     name: Test
     needs: prepare-release
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     if: needs.prepare-release.result == 'success'
     outputs:
       version: ${{ needs.prepare-release.outputs.version }}
@@ -266,7 +266,7 @@ jobs:
   build:
     name: Build Distribution
     needs: prepare-release
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     if: needs.prepare-release.result == 'success'
 
     steps:
@@ -329,7 +329,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: [test, build]
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     environment:
       name: pypi
       url: https://pypi.org/project/bedrock-agentcore-starter-toolkit/
@@ -401,7 +401,7 @@ jobs:
   summary:
     name: Release Summary
     needs: publish-pypi
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     if: always()
 
     steps:

--- a/.github/workflows/test-pypi-release.yml
+++ b/.github/workflows/test-pypi-release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build-and-publish:
     name: Build and Publish to Test PyPI
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     environment:
       name: testpypi
       url: https://test.pypi.org/p/bedrock-agentcore-starter-toolkit

--- a/.github/workflows/test-pypi-release.yml
+++ b/.github/workflows/test-pypi-release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build-and-publish:
     name: Build and Publish to Test PyPI
-    runs-on: aws-release-4-core
+    runs-on: ubuntu-latest
     environment:
       name: testpypi
       url: https://test.pypi.org/p/bedrock-agentcore-starter-toolkit


### PR DESCRIPTION
## Description

Moves the production release workflow to the dedicated `aws-release-4-core` GitHub-hosted runner group. This prevents releases from waiting behind the enterprise-wide `ubuntu-latest` pool while keeping release execution and provenance on GitHub Actions.

The workflow remains manually triggered with `workflow_dispatch`; no pull-request-triggered workflow can target the release runner. The TestPyPI workflow remains on `ubuntu-latest`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [ ] Test coverage remains above 80%
- [x] Manual workflow validation completed

Parsed the modified workflow as YAML, verified every production release job uses `aws-release-4-core`, and verified the workflow has no `pull_request` trigger. Source tests were not run because this change only updates workflow runner labels.

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [x] I have performed a self-review of my own code
- [x] No comments are needed for this configuration-only change
- [x] No documentation changes are needed
- [x] My changes generate no new warnings
- [x] No source tests are needed for this workflow-only change
- [x] No dependent changes are required

## Security Checklist

- [x] No hardcoded secrets or credentials
- [ ] No new security warnings from bandit
- [x] Dependencies are unchanged
- [x] No sensitive data logged

## Breaking Changes

N/A

## Additional Notes

The runner group is reserved for release workflows and has a concurrency limit of 10.
